### PR TITLE
Copy downloaded DLDT IR to converter.py output directory

### DIFF
--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -19,6 +19,7 @@ import os
 import re
 import string
 import sys
+from shutil import copytree
 
 from pathlib import Path
 
@@ -111,6 +112,9 @@ def main():
         if model.mo_args is None:
             reporter.print_section_heading('Skipping {} (no conversions defined)', model.name)
             reporter.print()
+            if model.framework == "dldt":
+                # Copy DLDT IR as is to output directory
+                copytree(args.download_dir / model.subdirectory, output_dir / model.subdirectory)
             return True
 
         model_precisions = requested_precisions & model.precisions


### PR DESCRIPTION
As user of converter.py, if I specify --output_dir, I'm waiting to find all DLDT IRs in it. But already downloaded IRs aren't copied to output_dir