### PR TITLE
Clean up .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,7 @@
 root = true
 
 [*]
-end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-# 4 space indentation
-#[*.py]
-#indent_style = space
-#indent_size = 4
-
-#[{CMakeLists.txt,*.cmake}]
-#indent_style = space
-#indent_size = 4
-
-#[*.{c,cpp,h,hpp}]
-#indent_style = space
-#indent_size = 4


### PR DESCRIPTION
* Remove junk.
* Remove the end_of_line setting, which is useless, since Git transforms all line endings to the LF format upon commit anyway. (And since it transforms them to the native format upon checkout, all files end up inconsistent with `.editorconfig` on Windows if this setting is used.)