### PR TITLE
AC: allow to process result without resize meta

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/action_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/action_recognition.py
@@ -137,7 +137,7 @@ class ActionDetection(Adapter):
                 self.head_sizes = [add_conf_out_count]
                 self.glob_layer_id_map = [list(range(add_conf_out_count))]
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)
         if not self.outputs_verified:

--- a/tools/accuracy_checker/accuracy_checker/adapters/adapter.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/adapter.py
@@ -48,7 +48,7 @@ class Adapter(ClassProvider):
             ),
         }
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raise NotImplementedError
 
     def configure(self):

--- a/tools/accuracy_checker/accuracy_checker/adapters/attribute_classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/attribute_classification.py
@@ -46,7 +46,7 @@ class AttributeClassificationAdapter(Adapter):
     def validate_config(self):
         super().validate_config(on_extra_argument=ConfigValidator.ERROR_ON_EXTRA_ARGUMENT)
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/accuracy_checker/adapters/attributes_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/attributes_recognition.py
@@ -57,7 +57,7 @@ class HeadPoseEstimatorAdapter(Adapter):
         self.angle_pitch = self.get_value_from_config('angle_pitch')
         self.angle_roll = self.get_value_from_config('angle_roll')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/accuracy_checker/adapters/centernet.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/centernet.py
@@ -122,7 +122,7 @@ class CTDETAdapter(Adapter):
             dets[:, 2:4], center, scale, (width, heigth))
         return dets
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         predictions_batch = self._extract_predictions(raw, frame_meta)
         hm_batch = predictions_batch[self.center_heatmap_out]

--- a/tools/accuracy_checker/accuracy_checker/adapters/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/classification.py
@@ -46,7 +46,7 @@ class ClassificationAdapter(Adapter):
         self.argmax_output = self.get_value_from_config('argmax_output')
         self.classification_out = self.get_value_from_config('classification_output')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/accuracy_checker/adapters/detection_person_vehicle.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detection_person_vehicle.py
@@ -39,7 +39,7 @@ class PersonVehicleDetectionAdapter(Adapter):
     def configure(self):
         self.iou_threshold = self.get_value_from_config('iou_threshold')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         if isinstance(raw, dict):
             bbox_pred = raw['bbox_pred']

--- a/tools/accuracy_checker/accuracy_checker/adapters/hit_ratio.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/hit_ratio.py
@@ -28,7 +28,7 @@ class HitRatioAdapter(Adapter):
     __provider__ = 'hit_ratio_adapter'
     prediction_types = (HitRatioPrediction, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             raw: output of model.

--- a/tools/accuracy_checker/accuracy_checker/adapters/image_inpainting.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/image_inpainting.py
@@ -24,7 +24,7 @@ class ImageInpaintingAdapter(Adapter):
     __provider__ = 'inpainting'
     prediction_types = (ImageInpaintingPrediction, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)[self.output_blob]
         for identifier, img in zip(identifiers, raw_outputs):

--- a/tools/accuracy_checker/accuracy_checker/adapters/image_processing.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/image_processing.py
@@ -72,7 +72,7 @@ class ImageProcessingAdapter(Adapter):
         self.target_out = self.get_value_from_config('target_out')
         self.cast_to_uint8 = self.get_value_from_config('cast_to_uint8')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)
         if not self.target_out:

--- a/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn.py
@@ -189,7 +189,12 @@ class MaskRCNNAdapter(Adapter):
                 im_scale_y = image_meta['scale_y']
             else:
                 image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
-                processed_image_size = image_input[0][1:]
+                assert image_input, "image input not found"
+                image_input = image_input[0]
+                if image_input[1] == 3:
+                    processed_image_size = image_input[2:]
+                else:
+                    processed_image_size = image_input[1:3]
                 im_scale_y = processed_image_size[0] / original_image_size[0]
                 im_scale_x = processed_image_size[1] / original_image_size[1]
             boxes[:, 0::2] /= im_scale_x

--- a/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn.py
@@ -108,7 +108,7 @@ class MaskRCNNAdapter(Adapter):
 
             self.realisation = self._process_pytorch_outputs
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         return self.realisation(raw_outputs, identifiers, frame_meta)
 
@@ -190,6 +190,7 @@ class MaskRCNNAdapter(Adapter):
             else:
                 image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
                 assert image_input, "image input not found"
+                assert len(image_input) == 1, 'several input images detected'
                 image_input = image_input[0]
                 if image_input[1] == 3:
                     processed_image_size = image_input[2:]

--- a/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn_with_text.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn_with_text.py
@@ -91,7 +91,7 @@ class MaskRCNNWithTextAdapter(MaskRCNNAdapter):
                 im_scale_x = image_meta['scale_x']
                 im_scale_y = image_meta['scale_y']
             else:
-                processed_image_size = next(image_meta['input_shape'])[1:]
+                processed_image_size = next(image_meta['input_shape'])[2:]
                 im_scale_y = processed_image_size[0] / original_image_size[0]
                 im_scale_x = processed_image_size[1] / original_image_size[1]
             boxes[:, 0::2] /= im_scale_x

--- a/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn_with_text.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mask_rcnn_with_text.py
@@ -66,7 +66,7 @@ class MaskRCNNWithTextAdapter(MaskRCNNAdapter):
         self.texts_out = self.get_value_from_config('texts_out')
         self.confidence_threshold = self.get_value_from_config('confidence_threshold')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
 
         classes = raw_outputs[self.classes_out]
@@ -91,7 +91,10 @@ class MaskRCNNWithTextAdapter(MaskRCNNAdapter):
                 im_scale_x = image_meta['scale_x']
                 im_scale_y = image_meta['scale_y']
             else:
-                processed_image_size = next(image_meta['input_shape'])[2:]
+                image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
+                assert image_input, "image input not found"
+                assert len(image_input) == 1, 'several input images detected'
+                processed_image_size = image_input[0][2:]
                 im_scale_y = processed_image_size[0] / original_image_size[0]
                 im_scale_x = processed_image_size[1] / original_image_size[1]
             boxes[:, 0::2] /= im_scale_x

--- a/tools/accuracy_checker/accuracy_checker/adapters/mixed_adapter.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mixed_adapter.py
@@ -67,7 +67,7 @@ class MixedAdapter(Adapter):
                     return False
         return True
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = {}
 
         for layer, (_, adapter) in self.adapters.items():

--- a/tools/accuracy_checker/accuracy_checker/adapters/mono_depth.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/mono_depth.py
@@ -18,11 +18,10 @@ from ..representation import DepthEstimationPrediction
 class MonoDepthAdapter(Adapter):
     __provider__ = 'mono_depth'
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         batch_prediction = self._extract_predictions(raw, frame_meta)[self.output_blob]
         result = []
         for identifier, prediction in zip(identifiers, batch_prediction):
             result.append(DepthEstimationPrediction(identifier, prediction))
 
         return result
-        

--- a/tools/accuracy_checker/accuracy_checker/adapters/nlp.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/nlp.py
@@ -49,7 +49,7 @@ class MachineTranslationAdapter(Adapter):
         self.eos_index = self.get_value_from_config('eos_index')
         self.subword_option = vocab_file.name.split('.')[1] if len(vocab_file.name.split('.')) > 1 else None
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         translation = raw_outputs[self.output_blob]
         translation = np.transpose(translation, (1, 2, 0))
@@ -91,7 +91,7 @@ class QuestionAnsweringAdapter(Adapter):
         self.start_token_logit_out = self.get_value_from_config('start_token_logits_output')
         self.end_token_logit_out = self.get_value_from_config('end_token_logits_output')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_output = self._extract_predictions(raw, frame_meta)
         result = []
         for identifier, start_token_logits, end_token_logits in zip(

--- a/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation.py
@@ -71,7 +71,7 @@ class HumanPoseAdapter(Adapter):
             self._keypoints_heatmap_bias = self.keypoints_heatmap + '/add_'
             self._part_affinity_fileds_bias = self.part_affinity_fields + '/add_'
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)
         if not self.concat_out:

--- a/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation_3d.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/pose_estimation_3d.py
@@ -70,7 +70,7 @@ class HumanPose3dAdapter(Adapter):
         self.part_affinity_fields = self.get_value_from_config('part_affinity_fields_out')
         self.keypoints_heatmap = self.get_value_from_config('keypoints_heatmap_out')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)
         raw_output = zip(

--- a/tools/accuracy_checker/accuracy_checker/adapters/regression.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/regression.py
@@ -27,7 +27,7 @@ class RegressionAdapter(Adapter):
     __provider__ = 'regression'
     prediction_types = (RegressionPrediction, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/accuracy_checker/adapters/reidentification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/reidentification.py
@@ -33,7 +33,7 @@ class ReidAdapter(Adapter):
         """
         self.grn_workaround = self.launcher_config.get("grn_workaround", True)
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
@@ -47,7 +47,7 @@ class RetinaFaceAdapter(Adapter):
         else:
             self.landmark_std = 1.0
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_predictions = self._extract_predictions(raw, frame_meta)
         results = []
         for batch_id, (identifier, meta) in enumerate(zip(identifiers, frame_meta)):
@@ -244,6 +244,7 @@ class RetinaFaceAdapter(Adapter):
         original_image_size = meta['image_size'][:2]
         image_input = [shape for shape in meta['input_shape'].values() if len(shape) == 4]
         assert image_input, "image input not found"
+        assert len(image_input) == 1, 'model should have only one image input'
         image_input = image_input[0]
         if image_input[1] == 3:
             processed_image_size = image_input[2:]

--- a/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
@@ -55,7 +55,6 @@ class RetinaFaceAdapter(Adapter):
             scores_list = []
             landmarks_list = []
             mask_scores_list = []
-            x_scale, y_scale = meta['scale_x'], meta['scale_y']
             for _idx, s in enumerate(self._features_stride_fpn):
                 anchor_num = self._num_anchors[s]
                 scores = self._get_scores(raw_predictions[self.scores_output[_idx]][batch_id], anchor_num)
@@ -80,14 +79,11 @@ class RetinaFaceAdapter(Adapter):
             mask_scores = np.reshape(mask_scores_list, -1)
             labels = np.full_like(scores, 1, dtype=int)
             x_mins, y_mins, x_maxs, y_maxs = np.array(proposals_list).T # pylint: disable=E0633
+            x_scale, y_scale = self.get_scale(meta)
             detection_representation = DetectionPrediction(
                 identifier, labels, scores, x_mins / x_scale, y_mins / y_scale, x_maxs / x_scale, y_maxs / y_scale
             )
-            if not self.landmarks_output and not self.type_scores_output:
-                results.append(detection_representation)
-                continue
-            representations = {}
-            representations['face_detection'] = detection_representation
+            representations = {'face_detection': detection_representation}
             if self.type_scores_output:
                 representations['mask_detection'] = AttributeDetectionPrediction(
                     identifier, labels, scores, mask_scores, x_mins / x_scale,
@@ -98,7 +94,9 @@ class RetinaFaceAdapter(Adapter):
                 landmarks_y_coords = np.array(landmarks_list)[:, :, 1::2].reshape(len(landmarks_list), -1) / y_scale
                 representations['landmarks_regression'] = FacialLandmarksPrediction(identifier, landmarks_x_coords,
                                                                                     landmarks_y_coords)
-            results.append(ContainerPrediction(representations))
+            results.append(
+                ContainerPrediction(representations) if len(representations) > 1 else detection_representation
+            )
         return results
 
     def _get_proposals(self, bbox_deltas, anchor_num, anchors):
@@ -238,3 +236,20 @@ class RetinaFaceAdapter(Adapter):
             pred[:, i, 1] = landmark_deltas[:, i, 1] * heights + ctr_y
 
         return pred
+
+    @staticmethod
+    def get_scale(meta):
+        if 'scale_x' in meta:
+            return meta['scale_x'], meta['scale_y']
+        original_image_size = meta['image_size'][:2]
+        image_input = [shape for shape in meta['input_shape'].values() if len(shape) == 4]
+        assert image_input, "image input not found"
+        image_input = image_input[0]
+        if image_input[1] == 3:
+            processed_image_size = image_input[2:]
+        else:
+            processed_image_size = image_input[1:3]
+        y_scale = processed_image_size[0] / original_image_size[0]
+        x_scale = processed_image_size[1] / original_image_size[1]
+
+        return x_scale, y_scale

--- a/tools/accuracy_checker/accuracy_checker/adapters/segmentation.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/segmentation.py
@@ -40,7 +40,7 @@ class SegmentationAdapter(Adapter):
     def configure(self):
         self.make_argmax = self.launcher_config.get('make_argmax', False)
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         frame_meta = frame_meta or [] * len(identifiers)
         raw_outputs = self._extract_predictions(raw, frame_meta)

--- a/tools/accuracy_checker/accuracy_checker/adapters/ssd.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/ssd.py
@@ -35,7 +35,7 @@ class SSDAdapter(Adapter):
     prediction_types = (DetectionPrediction, )
     topology_types = (SSD, FasterRCNN, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers
@@ -143,7 +143,7 @@ class PyTorchSSDDecoder(Adapter):
 
         return default_boxes
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers
@@ -256,9 +256,9 @@ class FacePersonAdapter(Adapter):
         self.face_adapter = SSDAdapter(self.launcher_config, self.label_map, self.face_detection_out)
         self.person_adapter = SSDAdapter(self.launcher_config, self.label_map, self.person_detection_out)
 
-    def process(self, raw, identifiers=None, frame_meta=None):
-        face_batch_result = self.face_adapter.process(raw, identifiers)
-        person_batch_result = self.person_adapter.process(raw, identifiers)
+    def process(self, raw, identifiers, frame_meta):
+        face_batch_result = self.face_adapter.process(raw, identifiers, frame_meta)
+        person_batch_result = self.person_adapter.process(raw, identifiers, frame_meta)
         result = [ContainerPrediction({self.face_detection_out: face_result, self.person_detection_out: person_result})
                   for face_result, person_result in zip(face_batch_result, person_batch_result)]
 
@@ -271,7 +271,7 @@ class SSDAdapterMxNet(Adapter):
     """
     __provider__ = 'ssd_mxnet'
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers
@@ -312,7 +312,7 @@ class SSDONNXAdapter(Adapter):
         self.bboxes_out = self.get_value_from_config('bboxes_out')
         self.outputs_verified = False
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         results = []
         if not self.outputs_verified:

--- a/tools/accuracy_checker/accuracy_checker/adapters/style_transfer.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/style_transfer.py
@@ -23,7 +23,7 @@ class StyleTransferAdapter(Adapter):
     __provider__ = 'style_transfer'
     prediction_types = (StyleTransferPrediction, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         result = []
         raw_outputs = self._extract_predictions(raw, frame_meta)[self.output_blob]
         for identifier, img in zip(identifiers, raw_outputs):

--- a/tools/accuracy_checker/accuracy_checker/adapters/text_detection.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/text_detection.py
@@ -74,7 +74,7 @@ class TextDetectionAdapter(Adapter):
         self.min_area = self.get_value_from_config('min_area')
         self.min_height = self.get_value_from_config('min_height')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         results = []
         predictions = self._extract_predictions(raw, frame_meta)
 
@@ -309,7 +309,7 @@ class TextProposalsDetectionAdapter(Adapter):
             raise ValueError("east_text_detection adapter requires shapely, please install it")
         self.text_proposal_connector = TextProposalConnector()
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         result = []
         data = zip(raw_outputs[self.bbox_pred_out], raw_outputs[self.cls_prob_out], frame_meta, identifiers)
@@ -691,7 +691,7 @@ class EASTTextDetectionAdapter(Adapter):
         if Polygon is None:
             raise ValueError("east_text_detection adapter requires shapely, please install it")
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         raw_outputs = self._extract_predictions(raw, frame_meta)
         score_maps = raw_outputs[self.score_map_out]
         geometry_maps = raw_outputs[self.geometry_map_out]

--- a/tools/accuracy_checker/accuracy_checker/adapters/text_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/text_recognition.py
@@ -49,7 +49,7 @@ class BeamSearchDecoder(Adapter):
         self.blank_label = self.launcher_config.get('blank_label')
         self.softmaxed_probabilities = self.get_value_from_config('softmaxed_probabilities')
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         if not self.label_map:
             raise ConfigError('Beam Search Decoder requires dataset label map for correct decoding.')
         if self.blank_label is None:

--- a/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
@@ -45,7 +45,7 @@ class TinyYOLOv1Adapter(Adapter):
     prediction_types = (DetectionPrediction, )
     topology_types = (YoloV1Tiny, )
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers
@@ -203,7 +203,7 @@ class YoloV2Adapter(Adapter):
             self.processor = YoloOutputProcessor(coord_normalizer=(self.cells, self.cells),
                                                  size_normalizer=(self.cells, self.cells))
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers
@@ -348,7 +348,7 @@ class YoloV3Adapter(Adapter):
         else:
             self.processor = YoloOutputProcessor()
 
-    def process(self, raw, identifiers=None, frame_meta=None):
+    def process(self, raw, identifiers, frame_meta):
         """
         Args:
             identifiers: list of input data identifiers

--- a/tools/accuracy_checker/tests/test_adapters.py
+++ b/tools/accuracy_checker/tests/test_adapters.py
@@ -41,7 +41,7 @@ def test_detection_adapter_partially_filling_output_blob():
     }
     expected = make_representation('0.2 3 0 0 1 1;0.5 2 4 4 7 7;0.7 5 3 3 9 8')
 
-    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0'])
+    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0'], {})
 
     assert np.array_equal(actual, expected)
 
@@ -58,7 +58,7 @@ def test_detection_adapter_partially_filling_output_blob_with_zeros_at_the_end()
     }
     expected = make_representation('0.2 3 0 0 1 1;0.5 2 4 4 7 7;0.7 5 3 3 9 8')
 
-    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0'])
+    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0'], {})
 
     assert np.array_equal(actual, expected)
 
@@ -69,7 +69,7 @@ def test_detection_adapter_batch_2():
     }
     expected = make_representation(['0.2 3 0 0 1 1;0.5 2 4 4 7 7', '0.7 5 3 3 9 8'])
 
-    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0', '1'])
+    actual = SSDAdapter({}, output_blob='detection_out').process([raw], ['0', '1'], {})
 
     assert np.array_equal(actual, expected)
 


### PR DESCRIPTION
with enabling preprocessing throw ie, some preprocessing metadata missed.
adapters which use such info are updated to work without it (by default scaling coefficients calculated like for case with single resize to input resolution - ie resize behaviour. if coeffs provided, then we use them (they can be different from default, for example, if we use aspect ratio preserving resize + padding to input size)