### PR TITLE
Add missed `operator<<` to fix IEVersion print in demos

### DIFF
--- a/demos/common/include/samples/common.hpp
+++ b/demos/common/include/samples/common.hpp
@@ -50,6 +50,22 @@ static UNUSED std::string fileNameNoExt(const std::string &filepath) {
     return filepath.substr(0, pos);
 }
 
+static UNUSED std::ostream &operator<<(std::ostream &os, const InferenceEngine::Version *version) {
+    os << "\n\tAPI version ............ ";
+    if (nullptr == version) {
+        os << "UNKNOWN";
+    } else {
+        os << version->apiVersion.major << "." << version->apiVersion.minor;
+        if (nullptr != version->buildNumber) {
+            os << "\n\t" << "Build .................. " << version->buildNumber;
+        }
+        if (nullptr != version->description) {
+            os << "\n\t" << "Description ....... " << version->description;
+        }
+    }
+    return os;
+}
+
 inline std::ostream &operator<<(std::ostream &os, const InferenceEngine::Version &version) {
     os << "\t" << version.description << " version ......... ";
     os << version.apiVersion.major << "." << version.apiVersion.minor;


### PR DESCRIPTION
Hello!

I found that OMZ demos doesn't print IE version information correctly (it print object address instead of human-readable message, example: https://github.com/openvinotoolkit/openvino/issues/1330#issuecomment-661587879). The rootcause is in missed `operator<<` which weren't copied from https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/samples/common/samples/common.hpp#L88

This PR should fix the issue