### PR TITLE
Updated ie headers

### DIFF
--- a/demos/classification_demo/main.cpp
+++ b/demos/classification_demo/main.cpp
@@ -15,8 +15,6 @@
 
 #include <inference_engine.hpp>
 
-#include <ie_iextension.h>
-
 #include <samples/common.hpp>
 #include <samples/slog.hpp>
 #include <samples/args_helper.hpp>

--- a/demos/common/include/samples/common.hpp
+++ b/demos/common/include/samples/common.hpp
@@ -21,10 +21,7 @@
 #include <algorithm>
 #include <random>
 
-#include <ie_core.hpp>
-#include <ie_plugin_config.hpp>
-#include <cpp/ie_infer_request.hpp>
-#include <ie_blob.h>
+#include <inference_engine.hpp>
 
 #ifndef UNUSED
   #ifdef WIN32

--- a/demos/gaze_estimation_demo/include/ie_wrapper.hpp
+++ b/demos/gaze_estimation_demo/include/ie_wrapper.hpp
@@ -10,14 +10,9 @@
 #include <map>
 #include <vector>
 
-#include <inference_engine.hpp>
-
-
-#include <ie_iextension.h>
-
+#include <samples/common.hpp>
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>
-#include <samples/common.hpp>
 
 namespace gaze_estimation {
 class IEWrapper {

--- a/demos/gaze_estimation_demo/include/utils.hpp
+++ b/demos/gaze_estimation_demo/include/utils.hpp
@@ -13,8 +13,6 @@
 
 #include <inference_engine.hpp>
 
-#include <ie_iextension.h>
-
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>
 

--- a/demos/gaze_estimation_demo/main.cpp
+++ b/demos/gaze_estimation_demo/main.cpp
@@ -49,8 +49,6 @@
 
 #include "utils.hpp"
 
-#include <ie_iextension.h>
-
 using namespace InferenceEngine;
 using namespace gaze_estimation;
 

--- a/demos/interactive_face_detection_demo/detectors.cpp
+++ b/demos/interactive_face_detection_demo/detectors.cpp
@@ -22,8 +22,6 @@
 #include <samples/ocv_common.hpp>
 #include <samples/slog.hpp>
 
-#include <ie_iextension.h>
-
 #include "detectors.hpp"
 
 using namespace InferenceEngine;

--- a/demos/interactive_face_detection_demo/detectors.hpp
+++ b/demos/interactive_face_detection_demo/detectors.hpp
@@ -23,8 +23,6 @@
 #include <samples/common.hpp>
 #include <samples/slog.hpp>
 
-#include <ie_iextension.h>
-
 #include <opencv2/opencv.hpp>
 
 // -------------------------Generic routines for detection networks-------------------------------------------------

--- a/demos/interactive_face_detection_demo/main.cpp
+++ b/demos/interactive_face_detection_demo/main.cpp
@@ -33,8 +33,6 @@
 #include "face.hpp"
 #include "visualizer.hpp"
 
-#include <ie_iextension.h>
-
 using namespace InferenceEngine;
 
 

--- a/demos/multi_channel/common/graph.hpp
+++ b/demos/multi_channel/common/graph.hpp
@@ -16,10 +16,6 @@
 #include <memory>
 
 #include <inference_engine.hpp>
-#include <ie_common.h>
-#include <ie_icnn_network.hpp>
-#include <ie_iextension.h>
-#include <ie_plugin_config.hpp>
 
 #include <samples/common.hpp>
 #include <samples/slog.hpp>

--- a/demos/pedestrian_tracker_demo/src/utils.cpp
+++ b/demos/pedestrian_tracker_demo/src/utils.cpp
@@ -6,8 +6,6 @@
 
 #include <opencv2/imgproc.hpp>
 
-#include <ie_plugin_config.hpp>
-
 #include <algorithm>
 #include <vector>
 #include <map>

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -17,7 +17,6 @@
 #include <set>
 #include <algorithm>
 #include <utility>
-#include <ie_iextension.h>
 
 #include "actions.hpp"
 #include "action_detector.hpp"


### PR DESCRIPTION
Recommendation from IE core team is to use `inference_engine.hpp` which contains all other common IE headers (not including plugin specific headers with their configuration options). This approach is more future proof in terms if we shuffle headers / remove deprecated classes and headers as well.