### PR TITLE
Stop calling the demos "Inference Engine demos"

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,5 +1,5 @@
-Inference Engine Demos
-========================
+Open Model Zoo Demos
+====================
 
 The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
 

--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -149,7 +149,7 @@ cd "%ROOT_DIR%" && cmake -E make_directory "%SOLUTION_DIR64%"
 cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !MSBUILD_VERSION!" -A %PLATFORM% %EXTRA_CMAKE_OPTS% "%ROOT_DIR%"
 
 echo.
-echo ###############^|^| Build Inference Engine Demos using MS Visual Studio (MSBuild.exe) ^|^|###############
+echo ###############^|^| Build Open Model Zoo Demos using MS Visual Studio (MSBuild.exe) ^|^|###############
 echo.
 echo "!MSBUILD_BIN!" Demos.sln /p:Configuration=Release
 "!MSBUILD_BIN!" Demos.sln /p:Configuration=Release


### PR DESCRIPTION
This seems to be a holdover from when the original demos were extracted
from the Inference Engine repository. They're not IE demos anymore, they're
OMZ demos.