### PR TITLE
downloader: don't delete the whole output directory if the download fails

### DIFF
--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -224,7 +224,11 @@ def download_model(reporter, args, cache, session_factory, requested_precisions,
 
         if not try_retrieve(model_file_reporter, destination, model_file, cache, args.num_attempts,
                 functools.partial(model_file.source.start_download, session, CHUNK_SIZE)):
-            shutil.rmtree(str(output))
+            try:
+                destination.unlink()
+            except FileNotFoundError:
+                pass
+
             model_file_reporter.emit_event('model_file_download_end', successful=False)
             reporter.emit_event('model_download_end', model=model.name, successful=False)
             return False


### PR DESCRIPTION
The purpose of deleting it is to make sure the user doesn't end up with an incomplete or unverified file. However, deleting the whole directory is overkill, and can lead to nasty surprises if the user sets an existing directory as the output directory.

Instead, just delete the file we were trying to download. This means we can leave the user with an incomplete _set_ of files, but that doesn't seem like a significant issue.