### PR TITLE
build_demos_msvc.bat: let CMake find MSBuild for us

### DIFF
--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -20,8 +20,8 @@ set "ROOT_DIR=%~dp0"
 
 set "SOLUTION_DIR64=%USERPROFILE%\Documents\Intel\OpenVINO\omz_demos_build"
 
-set MSBUILD_BIN=
-set VS_PATH=
+set SUPPORTED_VS_VERSIONS=VS2015 VS2017 VS2019
+
 set VS_VERSION=
 set EXTRA_CMAKE_OPTS=
 
@@ -41,14 +41,14 @@ if not "%1" == "" (
     )
 
     if "%1"=="VS2015" (
-        set "VS_VERSION=2015"
+        set "VS_VERSION=14 2015"
     ) else if "%1"=="VS2017" (
-        set "VS_VERSION=2017"
+        set "VS_VERSION=15 2017"
     ) else if "%1"=="VS2019" (
-        set "VS_VERSION=2019"
+        set "VS_VERSION=16 2019"
     ) else (
         echo Unrecognized Visual Studio version specified: "%1"
-        echo Supported versions: VS2015, VS2017, VS2019
+        echo Supported versions: %SUPPORTED_VS_VERSIONS%
         goto errorHandling
     )
 
@@ -75,84 +75,55 @@ if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
     set "PLATFORM=Win32"
 )
 
-set VSWHERE="false"
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-    set VSWHERE="true"
-    cd "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
-) else if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
-    set VSWHERE="true"
-    cd "%ProgramFiles%\Microsoft Visual Studio\Installer"
-) else (
-    echo "vswhere tool is not found"
-)
-
-if !VSWHERE! == "true" (
-    if "!VS_VERSION!"=="" (
-        echo Searching the latest Visual Studio...
-        for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-            set VS_PATH=%%i
-        )
+if "%VS_VERSION%" == "" (
+    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+        set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
+        set "VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
     ) else (
-        echo Searching Visual Studio !VS_VERSION!...
-        for /f "usebackq tokens=*" %%i in (`vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
-            set CUR_VS=%%i
-            if not "!CUR_VS:%VS_VERSION%=!"=="!CUR_VS!" (
-                set VS_PATH=!CUR_VS!
-            )
-        )
+        echo vswhere.exe was not found.
+        echo To use Visual Studio autodetection, make sure Visual Studio 2017 version 15.2
+        echo or a newer version of Visual Studio is installed. If you'd like to use Visual
+        echo Studio 2015, request it explicitly by running "%0 VS2015".
+        goto errorHandling
     )
-    if exist "!VS_PATH!\MSBuild\14.0\Bin\MSBuild.exe" (
-        set "MSBUILD_BIN=!VS_PATH!\MSBuild\14.0\Bin\MSBuild.exe"
-    )
-    if exist "!VS_PATH!\MSBuild\15.0\Bin\MSBuild.exe" (
-        set "MSBUILD_BIN=!VS_PATH!\MSBuild\15.0\Bin\MSBuild.exe"
-    )
-    if exist "!VS_PATH!\MSBuild\Current\Bin\MSBuild.exe" (
-        set "MSBUILD_BIN=!VS_PATH!\MSBuild\Current\Bin\MSBuild.exe"
-    )
-)
 
-if "!MSBUILD_BIN!" == "" (
-    if "!VS_VERSION!"=="2015" (
-        if exist "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" (
-            set "MSBUILD_BIN=C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
-            set "MSBUILD_VERSION=14 2015"
-        )
-    ) else if "!VS_VERSION!"=="2017" (
-        if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe" (
-            set "MSBUILD_BIN=C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe"
-            set "MSBUILD_VERSION=15 2017"
-        ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe" (
-            set "MSBUILD_BIN=C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
-            set "MSBUILD_VERSION=15 2017"
-        ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" (
-            set "MSBUILD_BIN=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
-            set "MSBUILD_VERSION=15 2017"
+    echo Searching for the latest Visual Studio...
+    for /f "usebackq tokens=*" %%i in (`"!VSWHERE!" -latest -products * -requires Microsoft.Component.MSBuild -property catalog_productLineVersion`) do (
+        if "%%i" == "2015" (
+            set VS_VERSION=14 2015
+        ) else if "%%i" == "2017" (
+            set VS_VERSION=15 2017
+        ) else if "%%i" == "2019" (
+            set VS_VERSION=16 2019
+        ) else (
+            echo The most recent version of Visual Studio installed on this computer ^(%%i^) is not
+            echo supported by this script.
+            echo If one of the supported versions is installed, try to pass an argument to this
+            echo script to indicate which version should be used.
+            echo Supported versions: %SUPPORTED_VS_VERSIONS%
+            goto errorHandling
         )
     )
-) else (
-    if not "!MSBUILD_BIN:2019=!"=="!MSBUILD_BIN!" set "MSBUILD_VERSION=16 2019"
-    if not "!MSBUILD_BIN:2017=!"=="!MSBUILD_BIN!" set "MSBUILD_VERSION=15 2017"
-    if not "!MSBUILD_BIN:2015=!"=="!MSBUILD_BIN!" set "MSBUILD_VERSION=14 2015"
-)
 
-if "!MSBUILD_BIN!" == "" (
-    echo Build tools for Microsoft Visual Studio !VS_VERSION! cannot be found. If you use Visual Studio 2017, please download and install build tools from https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017
-    goto errorHandling
+    if "!VS_VERSION!" == "" (
+        echo No installed versions of Visual Studio were detected.
+        goto errorHandling
+    )
 )
 
 if exist "%SOLUTION_DIR64%\CMakeCache.txt" del "%SOLUTION_DIR64%\CMakeCache.txt"
 
-echo Creating Visual Studio %MSBUILD_VERSION% %PLATFORM% files in %SOLUTION_DIR64%... && ^
+echo Creating Visual Studio %VS_VERSION% %PLATFORM% files in %SOLUTION_DIR64%...
 cd "%ROOT_DIR%" && cmake -E make_directory "%SOLUTION_DIR64%"
 
-cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !MSBUILD_VERSION!" -A %PLATFORM% %EXTRA_CMAKE_OPTS% "%ROOT_DIR%"
+cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !VS_VERSION!" -A %PLATFORM% %EXTRA_CMAKE_OPTS% "%ROOT_DIR%"
 
 echo.
-echo ###############^|^| Build Open Model Zoo Demos using MS Visual Studio (MSBuild.exe) ^|^|###############
+echo ###############^|^| Build Open Model Zoo Demos using MS Visual Studio ^|^|###############
 echo.
-echo "!MSBUILD_BIN!" Demos.sln /p:Configuration=Release
-"!MSBUILD_BIN!" Demos.sln /p:Configuration=Release
+echo cmake --build . --config Release
+cmake --build . --config Release
 if ERRORLEVEL 1 goto errorHandling
 
 echo Done.


### PR DESCRIPTION
This simplifies the script and makes it easier to add support for new versions of Visual Studio. I also trust CMake more with this than I do our home-grown logic; CMake is more actively maintained, so they're more likely to handle any obscure cases.

I also took the opportunity to improve some of the error messages.