### PR TITLE
downloader: postprocess each model immediately after downloading it

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -171,9 +171,10 @@ class Reporter:
         self.enable_json_output = enable_json_output
         self.event_context = event_context
 
-    def print_group_heading(self, text):
+    def print_group_heading(self, format, *args):
         if not self.enable_human_output: return
-        self.job_context.printf('{} {} {}', self.GROUP_DECORATION, text, self.GROUP_DECORATION[::-1])
+        self.job_context.printf('{} {} {}',
+            self.GROUP_DECORATION, format.format(*args), self.GROUP_DECORATION[::-1])
         self.job_context.print('')
 
     def print_section_heading(self, format, *args):


### PR DESCRIPTION
This has a few advantages over what we're doing now (postprocessing all models at the end):

* Postprocessing is parallelized along with downloading (we could've parallelized the postprocessing loop explicitly, but this way is much simpler).

* If the downloader is interrupted, models that have already been processed will be fully ready to use.

* The code structure is simpler, with no parallel loops.