### PR TITLE
AC: fix warnings

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
@@ -70,6 +70,7 @@ class Launcher(ClassProvider):
         self.default_layout = 'NCHW'
         self.const_inputs = self.config.get('_list_const_inputs', [])
         self.image_info_inputs = self.config.get('_list_image_infos', [])
+        self._lstm_inputs = self.config.get('_list_lstm_inputs', [])
 
     @classmethod
     def parameters(cls):
@@ -89,6 +90,9 @@ class Launcher(ClassProvider):
             ),
             '_list_image_infos': ListField(
                 allow_empty=True, optional=True, default=[], description="List of image information inputs."
+            ),
+            '_list_lstm_inputs': ListField(
+                allow_empty=True, optional=True, default=[], description="List of lstm inputs."
             )
         }
 

--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -8,7 +8,7 @@ scikit-image
 scikit-learn
 
 # cpu extension usage
-py-cpuinfo<=4.0
+py-cpuinfo<=4.0,>=7.0
 
 # text detection
 shapely

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -20,10 +20,10 @@ import sys
 import warnings
 import platform
 import subprocess
-from distutils.version import LooseVersion
 from setuptools import find_packages, setup
 from setuptools.command.test import test as test_command
 from setuptools.command.install import install as install_command
+from distutils.version import LooseVersion
 from pathlib import Path
 
 

--- a/tools/accuracy_checker/tests/test_dlsdk_launcher.py
+++ b/tools/accuracy_checker/tests/test_dlsdk_launcher.py
@@ -525,7 +525,6 @@ class TestDLSDKLauncher:
             'framework': 'dlsdk',
             'tf_meta': '/path/to/source_models/custom_model',
             'device': 'cpu',
-            '_models_prefix': '/path/to/source_models',
             'adapter': 'classification',
             'should_log_cmd': False
         }
@@ -542,7 +541,6 @@ class TestDLSDKLauncher:
             'framework': 'dlsdk',
             'tf_model': '/path/to/source_models/custom_model',
             'device': 'cpu',
-            '_models_prefix': '/path/to',
             'adapter': 'classification',
             'mo_params': {'tensorflow_use_custom_operations_config': 'ssd_v2_support.json'},
             '_tf_custom_op_config_dir': 'config/dir'
@@ -570,7 +568,6 @@ class TestDLSDKLauncher:
             'framework': 'dlsdk',
             'tf_model': '/path/to/source_models/custom_model',
             'device': 'cpu',
-            '_models_prefix': '/path/to',
             'adapter': 'classification',
             'mo_params': {'tensorflow_use_custom_operations_config': 'config.json'}
         }
@@ -596,7 +593,6 @@ class TestDLSDKLauncher:
             'framework': 'dlsdk',
             'tf_model': '/path/to/source_models/custom_model',
             'device': 'cpu',
-            '_models_prefix': '/path/to',
             'adapter': 'classification',
             'mo_params': {'tensorflow_object_detection_api_pipeline_config': 'operations.config'},
             '_tf_obj_detection_api_pipeline_config_path': None
@@ -1186,8 +1182,7 @@ class TestDLSDKLauncherConfig:
 
     def test_dlsdk_launcher(self):
         launcher = {
-            'framework': 'dlsdk', 'model': 'custom', 'weights': 'custom', 'adapter': 'ssd', 'device': 'cpu',
-            '_models_prefix': 'models'
+            'framework': 'dlsdk', 'model': 'custom', 'weights': 'custom', 'adapter': 'ssd', 'device': 'cpu'
         }
         create_launcher(launcher)
 


### PR DESCRIPTION
- [x] * UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
- [x] * UserWarning: DLSDK_Launcher specifies unknown options: ['_list_lstm_inputs']

- [x]  *UserWarning: DLSDK_Launcher specifies unknown options: ['_models_prefix']