### PR TITLE
Revert "resnet-50-tf: fix broken link on model repo (#1406)"

### DIFF
--- a/models/public/resnet-50-tf/model.yml
+++ b/models/public/resnet-50-tf/model.yml
@@ -15,7 +15,7 @@
 description: >-
   resnet-50-tf is a TensorFlow\* implementation of ResNet-50 - an image classification model
   pretrained on the ImageNet dataset. For details see paper <https://arxiv.org/abs/1512.03385>,
-  repository <https://github.com/tensorflow/models/tree/v2.2.0/official/resnet>.
+  repository <https://github.com/tensorflow/models/tree/v2.2.0/official/r1/resnet>.
 task_type: classification
 files:
   - name: resnet_v1-50.pb

--- a/models/public/resnet-50-tf/resnet-50-tf.md
+++ b/models/public/resnet-50-tf/resnet-50-tf.md
@@ -6,7 +6,7 @@
 pretrained on the ImageNet dataset. Originally redistributed in Saved model format,
 converted to frozen graph using `tf.graph_util` module.
 For details see [paper](https://arxiv.org/abs/1512.03385),
-[repository](https://github.com/tensorflow/models/tree/v2.2.0/official/resnet).
+[repository](https://github.com/tensorflow/models/tree/v2.2.0/official/r1/resnet).
 
 ### Steps to Reproduce Conversion to Frozen Graph
 


### PR DESCRIPTION
I don't know what's going on in there, but the new link is now broken and the old one is fine.

This reverts commit 57b7ac1664f6d359717b228f956c9dfd4523b48c.