### PR TITLE
AC: fix kinetics conversion for flow

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/action_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/action_recognition.py
@@ -137,7 +137,8 @@ class ActionRecognitionConverter(BaseFormatConverter):
 
     @staticmethod
     def get_clips(video, clips_per_video, clip_duration, temporal_stride=1, file_ext='jpg'):
-        num_frames = video['n_frames']
+        shift = int(file_ext == 'npy')
+        num_frames = video['n_frames'] - shift
         clip_duration *= temporal_stride
 
         if clips_per_video == 0:


### PR DESCRIPTION
optical flow is aggregation of 2 frames (current and previous), so per frame converted dataset contains on 2 frame less then original video.