### PR TITLE
demos: don't write files into the demo directory

### DIFF
--- a/demos/python_demos/monodepth_demo/monodepth_demo.py
+++ b/demos/python_demos/monodepth_demo/monodepth_demo.py
@@ -100,13 +100,13 @@ def main():
         disp.fill(0.5)
 
     # pfm
-    out = os.path.join(os.path.dirname(__file__), 'disp.pfm')
+    out = 'disp.pfm'
     cv2.imwrite(out, disp)
 
     log.info("Disparity map was saved to {}".format(out))
 
     # png
-    out = os.path.join(os.path.dirname(__file__), 'disp.png')
+    out = 'disp.png'
     plt.imsave(out, disp, vmin=0, vmax=1, cmap='inferno')
 
     log.info("Color-coded disparity image was saved to {}".format(out))

--- a/demos/python_demos/segmentation_demo/segmentation_demo.py
+++ b/demos/python_demos/segmentation_demo/segmentation_demo.py
@@ -142,7 +142,7 @@ def main():
                 else:
                     pixel_class = np.argmax(data[:, i, j])
                 classes_map[i, j, :] = classes_color_map[min(pixel_class, 20)]
-        out_img = os.path.join(os.path.dirname(__file__), "out_{}.bmp".format(batch))
+        out_img = "out_{}.bmp".format(batch)
         cv2.imwrite(out_img, classes_map)
         log.info("Result image was saved to {}".format(out_img))
     log.info("This demo is an API example, for any performance measurements please use the dedicated benchmark_app tool "


### PR DESCRIPTION
The demo dir can be non-writable by the current user (in the common case where the demo is installed systemwide as part of OpenVINO toolkit). Use the current directory instead.