### PR TITLE
Fix WER metric, rename greedy_wer to wer, add CER metric for speech recognition

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/README.md
+++ b/tools/accuracy_checker/accuracy_checker/metrics/README.md
@@ -196,7 +196,7 @@ More detailed information about calculation segmentation metrics you can find [h
   * `attributes`: names of attributes.
   * `calculate_average` - allows calculation of average precision (default value: `True`).
 * `wer` - Word error rate ([WER](https://en.wikipedia.org/wiki/Word_error_rate)). Supported representations: `CharacterRecognitionAnnotation`, `CharacterRecognitionPrediction`.
-* `greedy_wer` - approach to calculate WER as length normalized [edit distance](https://en.wikipedia.org/wiki/Edit_distance). Supported representations: `CharacterRecognitionAnnotation`, `CharacterRecognitionPrediction`.
+* `cer` - Character error rate, character-level counterpart of [WER](https://en.wikipedia.org/wiki/Word_error_rate). Supported representations: `CharacterRecognitionAnnotation`, `CharacterRecognitionPrediction`.
 * `score_class_comparison` - allows calculate an accuracy of quality score class(low/normal/good). It sorts all quality scores from annotations and predictions and set the k1 highest scores as high class and the k2 lowest scores as low class where k1 is `num_high_quality` and k2 is `num_low_quality`. Supported representations: `QualityAssessmentAnnotation`, `QualityAssessmentPrediction`.
   * `num_high_quality` - the number of high class in total (default value: `1`).
   * `num_low_quality` - the number of low class in total (default value: `1`).

--- a/tools/accuracy_checker/accuracy_checker/metrics/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/__init__.py
@@ -90,7 +90,7 @@ from .attribute_classification import (
     AttributeClassificationAccuracy
 )
 
-from .speech_recognition import SpeechRecognitionWER, GreedyWER
+from .speech_recognition import SpeechRecognitionWER, SpeechRecognitionCER
 from .score_class_comparison import ScoreClassComparisonMetric
 __all__ = [
     'Metric',
@@ -174,7 +174,7 @@ __all__ = [
     'AttributeClassificationAccuracy',
 
     'SpeechRecognitionWER',
-    'GreedyWER',
+    'SpeechRecognitionCER',
 
     'ScoreClassComparisonMetric',
 ]

--- a/tools/accuracy_checker/accuracy_checker/metrics/speech_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/speech_recognition.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import numpy as np
 try:
     import editdistance
 except ImportError:
@@ -30,48 +29,6 @@ from .metric import PerImageEvaluationMetric
 
 class SpeechRecognitionWER(PerImageEvaluationMetric):
     __provider__ = 'wer'
-    annotation_types = (CharacterRecognitionAnnotation,)
-    prediction_types = (CharacterRecognitionPrediction,)
-
-    def configure(self):
-        self.overall_metric = []
-
-    @staticmethod
-    def distance(prediction, annotation):
-        h = prediction.label
-        r = annotation.label
-        dist = np.zeros((len(r) + 1, len(h) + 1), dtype=np.uint8)
-        for i in range(len(r) + 1):
-            dist[i][0] = i
-        for j in range(len(h) + 1):
-            dist[0][j] = j
-        for i in range(1, len(r) + 1):
-            for j in range(1, len(h) + 1):
-                if r[i - 1] == h[j - 1]:
-                    dist[i][j] = dist[i - 1][j - 1]
-                else:
-                    substitute = dist[i - 1][j - 1] + 1
-                    insert = dist[i][j - 1] + 1
-                    delete = dist[i - 1][j] + 1
-                    dist[i][j] = min(substitute, insert, delete)
-
-        return float(dist[len(r)][len(h)]) / len(r)
-
-    def update(self, annotation, prediction):
-        result = self.distance(prediction, annotation)
-        self.overall_metric.append(result)
-
-        return result
-
-    def evaluate(self, annotations, predictions):
-        return np.mean(self.overall_metric)
-
-    def reset(self):
-        self.overall_metric = []
-
-
-class GreedyWER(PerImageEvaluationMetric):
-    __provider__ = 'greedy_wer'
     annotation_types = (CharacterRecognitionAnnotation,)
     prediction_types = (CharacterRecognitionPrediction,)
 
@@ -93,3 +50,28 @@ class GreedyWER(PerImageEvaluationMetric):
 
     def reset(self):
         self.words, self.score = 0, 0
+
+
+class SpeechRecognitionCER(PerImageEvaluationMetric):
+    __provider__ = 'cer'
+    annotation_types = (CharacterRecognitionAnnotation,)
+    prediction_types = (CharacterRecognitionPrediction,)
+
+    def configure(self):
+        if editdistance is None:
+            raise ConfigError('editdistance is not installed. Please install it before usage')
+        self.length = 0
+        self.score = 0
+
+    def update(self, annotation, prediction):
+        cur_score = editdistance.eval(annotation.label, prediction.label)
+        cur_length = len(annotation.label)
+        self.score += cur_score
+        self.length += cur_length
+        return cur_score / cur_length
+
+    def evaluate(self, annotations, predictions):
+        return self.score / self.length if self.length != 0 else 0
+
+    def reset(self):
+        self.length, self.score = 0, 0


### PR DESCRIPTION
The existing implementation of "wer" metric computed CER metric instead, and incorrectly averaged it over samples.  The existing greedy_wer metric was the correct WER metric, consistent with the other implementations (for example, Mozilla DeepSpeech).
