### PR TITLE
Use the same heading style in all Markdown files

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,5 +1,4 @@
-Open Model Zoo Demos
-====================
+# Open Model Zoo Demos
 
 The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
 

--- a/demos/python_demos/action_recognition/README.md
+++ b/demos/python_demos/action_recognition/README.md
@@ -1,5 +1,4 @@
-Action Recognition Python* Demo
-===============================
+# Action Recognition Python* Demo
 
 This is the demo application for Action Recognition algorithm, which classifies actions that are being performed on input video.
 The following pre-trained models are delivered with the product:
@@ -8,8 +7,8 @@ The following pre-trained models are delivered with the product:
 
 For more information about the pre-trained models, refer to the [model documentation](../../../models/intel/index.md).
 
-How It Works
-------------
+## How It Works
+
 The demo pipeline consists of several frames, namely `Data`, `Encoder`, `Decoder` and `Render`.
 Every step implements `PipelineStep` interface by creating a class derived from `PipelineStep` base class. See `steps.py` for implementation details.
 
@@ -29,8 +28,8 @@ You can change the value of `num_requests` in `action_recognition.py` to find an
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_prepare_model_convert_model_Converting_Model_General.html).
 
-Running
--------
+## Running
+
 Running the application with the `-h` option yields the following usage message:
 
 ```
@@ -89,8 +88,8 @@ python3 action_recognition.py -m_en models/driver_action_recognition_tsd_0002_en
     -lb driver_actions.txt
 ```
 
-Demo Output
-------------
+## Demo Output
+
 The application uses OpenCV to display the real-time results and current inference performance (in FPS).
 
 ## See Also

--- a/tools/accuracy_checker/sample/README.md
+++ b/tools/accuracy_checker/sample/README.md
@@ -1,5 +1,4 @@
-Sample
-===========
+# Sample
 
 In this sample we will go through typical steps required to evaluate DL topologies. 
 

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -1,5 +1,4 @@
-Model Downloader and other automation tools
-===========================================
+# Model Downloader and other automation tools
 
 This directory contains scripts that automate certain model-related tasks
 based on configuration files in the models' directories.
@@ -21,8 +20,7 @@ Please use these tools instead of attempting to parse the configuration files
 directly. Their format is undocumented and may change in incompatible ways in
 future releases.
 
-Prerequisites
--------------
+## Prerequisites
 
 1. Install Python (version 3.5.2 or higher)
 2. Install the tools' dependencies with the following command:
@@ -61,8 +59,7 @@ python3 -mpip install --user 'requests[security]'
 
 Alternatively, upgrade to Python 3.6 or a later version.
 
-Model downloader usage
-----------------------
+## Model downloader usage
 
 The basic usage is to run the script like this:
 
@@ -220,8 +217,7 @@ In particular:
   is set to a value greater than 1, event sequences for different files or models
   may get interleaved.
 
-Model converter usage
----------------------
+## Model converter usage
 
 The basic usage is to run the script like this:
 
@@ -307,8 +303,7 @@ To do this, use the `--dry_run` option:
 See the "Shared options" section for information on other options accepted by
 the script.
 
-Model Quantizer Usage
----------------------
+## Model Quantizer Usage
 
 Before you run the model quantizer, you must prepare a directory with
 the datasets required for the quantization process. This directory will be
@@ -389,8 +384,7 @@ Toolkit will still be created, so that you can inspect it.
 See the "Shared options" section for information on other options accepted by
 the script.
 
-Model information dumper usage
-------------------------------
+## Model information dumper usage
 
 The basic usage is to run the script like this:
 
@@ -457,8 +451,7 @@ describing a single model. Each such object has the following keys:
 
   Additional possible values might be added in the future.
 
-Shared options
---------------
+## Shared options
 
 The are certain options that all tools accept.
 


### PR DESCRIPTION
The hash style is both more commonly used than the underline style, and is more convenient for maintenance (since you don't need to edit the underline when you rename a section). Reformat the few files where the underline style is used to use the hash style instead.