### PR TITLE
Fix small errors in model documentation page titles

### DIFF
--- a/models/intel/person-detection-retail-0002/description/person-detection-retail-0002.md
+++ b/models/intel/person-detection-retail-0002/description/person-detection-retail-0002.md
@@ -1,4 +1,4 @@
-# person-detection-retail-0002 {#person-detection-retail-0002}
+# person-detection-retail-0002
 
 ## Use Case and High-Level Description
 

--- a/models/public/brain-tumor-segmentation-0001/brain-tumor-segmentation-0001.md
+++ b/models/public/brain-tumor-segmentation-0001/brain-tumor-segmentation-0001.md
@@ -1,4 +1,4 @@
-# Brain-tumor-segmentation-0001
+# brain-tumor-segmentation-0001
 
 ## Use Case and High-Level Description
 

--- a/models/public/retinaface-resnet50/retinaface-resnet50.md
+++ b/models/public/retinaface-resnet50/retinaface-resnet50.md
@@ -1,4 +1,4 @@
-# RetinaFace-ResNet50
+# retinaface-resnet50
 
 ## Use Case and High-Level Description
 RetinaFace-R50 is a medium size model with ResNet50 backbone for Face Localization. It can output face bounding boxes and five facial landmarks in a single forward pass. More details provided in the [paper](https://arxiv.org/abs/1905.00641) and [repository](https://github.com/deepinsight/insightface/tree/master/RetinaFace)

--- a/models/public/ssd-resnet34-1200-onnx/ssd-resnet34-1200-onnx.md
+++ b/models/public/ssd-resnet34-1200-onnx/ssd-resnet34-1200-onnx.md
@@ -1,4 +1,4 @@
-# ssd-resnet-34-1200-onnx
+# ssd-resnet34-1200-onnx
 
 ## Use Case and High-Level Description
 

--- a/models/public/yolo-v2-tiny-tf/yolo-v2-tiny-tf.md
+++ b/models/public/yolo-v2-tiny-tf/yolo-v2-tiny-tf.md
@@ -1,4 +1,4 @@
-# yolo-v2-tiny
+# yolo-v2-tiny-tf
 
 ## Use Case and High-Level Description
 


### PR DESCRIPTION
The title should always be the same as the name of the model.