### PR TITLE
 AC: fix per object polygons for instance segment

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -275,7 +275,7 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
         return areas
 
     def to_polygon(self):
-        if not self.raw_mask:
+        if self.raw_mask is None or np.size(self.raw_mask) == 0:
             warnings.warn("Polygon can be found only for non-empty mask")
             return {}
 
@@ -286,12 +286,14 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
         polygons = defaultdict(list)
         for elem, label in zip(self.raw_mask, self.labels):
             elem = np.uint8(maskUtils.decode(elem))
+            obj_contours = []
             contours, _ = cv.findContours(elem, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE)
             for contour in contours:
                 if contour.size < 6:
                     continue
                 contour = np.squeeze(contour, axis=1)
-                polygons[label].append(contour)
+                obj_contours.append(contour)
+            polygons[label].append(obj_contours)
 
         return polygons
 

--- a/tools/accuracy_checker/tests/test_segmentation_representation.py
+++ b/tools/accuracy_checker/tests/test_segmentation_representation.py
@@ -37,8 +37,8 @@ def encode_mask(mask):
         raw_mask.append(maskUtils.encode(np.asfortranarray(np.uint8(elem))))
     return raw_mask
 
-class TestSegmentationRepresentation:
 
+class TestSegmentationRepresentation:
     def test_to_polygon_annotation(self):
         annotation = make_segmentation_representation(np.array([[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]), True)[0]
         expected = {
@@ -199,7 +199,6 @@ class TestSegmentationRepresentation:
 
 @pytest.mark.skipif(no_available_pycocotools(), reason='no installed pycocotools in the system')
 class TestCoCoInstanceSegmentationRepresentation:
-
     def test_to_polygon_annotation(self):
         mask = [np.array([[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]),
                 np.array([[0, 1, 1, 1], [0, 0, 1, 1], [0, 0, 0, 1]])]
@@ -207,15 +206,17 @@ class TestCoCoInstanceSegmentationRepresentation:
         labels = [0, 1]
         annotation = make_instance_segmentation_representation(raw_mask, labels, True)[0]
         expected = {
-            0: [np.array([[1, 0], [3, 0], [3, 2]])],
-            1: [np.array([[0, 0], [0, 2], [2, 2]])]}
+            1: [np.array([[[1, 0], [3, 0], [3, 2]]])],
+            0: [np.array([[[0, 0], [0, 2], [2, 2]]])]}
 
         actual = annotation.to_polygon()
 
         for key in expected.keys():
             assert actual[key]
             for actual_arr, expected_arr in zip(actual[key], expected[key]):
-                assert np.array_equal(actual_arr.sort(axis=0), expected_arr.sort(axis=0))
+                actual_arr = np.sort(actual_arr, axis=1)
+                expected_arr = np.sort(expected_arr, axis=1)
+                assert np.array_equal(actual_arr, expected_arr)
 
     def test_to_polygon_prediction(self):
         mask = [np.array([[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]),
@@ -224,15 +225,17 @@ class TestCoCoInstanceSegmentationRepresentation:
         labels = [0, 1]
         prediction = make_instance_segmentation_representation(raw_mask, labels, False)[0]
         expected = {
-            0: [np.array([[1, 0], [3, 0], [3, 2]])],
-            1: [np.array([[0, 0], [0, 2], [2, 2]])]}
+            1: [np.array([[[1, 0], [3, 0], [3, 2]]])],
+            0: [np.array([[[0, 0], [0, 2], [2, 2]]])]}
 
         actual = prediction.to_polygon()
 
         for key in expected.keys():
             assert actual[key]
             for actual_arr, expected_arr in zip(actual[key], expected[key]):
-                assert np.array_equal(actual_arr.sort(axis=0), expected_arr.sort(axis=0))
+                actual_arr = np.sort(actual_arr, axis=1)
+                expected_arr = np.sort(expected_arr, axis=1)
+                assert np.array_equal(actual_arr, expected_arr)
 
     def test_to_polygon_with_None_mask(self):
         labels = [0, 1]


### PR DESCRIPTION
previous implementation store all poligons parts together. it is impossible to get polygons belong to specific object