### PR TITLE
downloader: remove prefix-less integer precisions

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -83,7 +83,7 @@ You may use `--precisions` flag to specify comma separated precisions of weights
 to be downloaded.
 
 ```sh
-./downloader.py --name face-detection-retail-0004 --precisions FP16,INT8
+./downloader.py --name face-detection-retail-0004 --precisions FP16,FP16-INT8
 ```
 
 By default, the script will attempt to download each file only once. You can use
@@ -420,8 +420,6 @@ describing a single model. Each such object has the following keys:
   * `FP32`
   * `FP32-INT1`
   * `FP32-INT8`
-  * `INT1`
-  * `INT8`
 
   Additional possible values might be added in the future.
 

--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -48,7 +48,6 @@ KNOWN_FRAMEWORKS = {
 KNOWN_PRECISIONS = {
     'FP16', 'FP16-INT1', 'FP16-INT8',
     'FP32', 'FP32-INT1', 'FP32-INT8',
-    'INT1', 'INT8',
 }
 KNOWN_TASK_TYPES = {
     'action_recognition',


### PR DESCRIPTION
We used to have models with precisions INT1 and INT8. But we don't anymore. Remove those precisions from the codebase to avoid confusion.