### PR TITLE
Mzuevx ac criteo block

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -18,6 +18,9 @@ adapter:
 
 AccuracyChecker supports following set of adapters:
 * `classification` - converting output of classification model to `ClassificationPrediction` representation.
+  * `argmax_output` - identifier that model output is ArgMax layer.
+  * `block` - process whole batch as a single data block.
+  * `classification_output` - target output layer name.
 * `segmentation` - converting output of semantic segmentation model to `SeegmentationPrediction` representation.
   * `make_argmax` - allows to apply argmax operation to output values.
 * `segmentation_one_class` - converting output of semantic segmentation to `SeegmentationPrediction` representation. It is suitable for situation when model's output is probability of belong each pixel to foreground class.

--- a/tools/accuracy_checker/accuracy_checker/adapters/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/classification.py
@@ -40,7 +40,7 @@ class ClassificationAdapter(Adapter):
             'block': BoolField(
                 optional=True, default=False, description="process whole batch as a single data block"
             ),
-            'classification_output': StringField(optional=True, description='otarget output layer name')
+            'classification_output': StringField(optional=True, description='target output layer name')
         })
 
         return parameters

--- a/tools/accuracy_checker/accuracy_checker/adapters/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/classification.py
@@ -37,6 +37,9 @@ class ClassificationAdapter(Adapter):
             'argmax_output': BoolField(
                 optional=True, default=False, description="identifier that model output is ArgMax layer"
             ),
+            'block': BoolField(
+                optional=True, default=False, description="process whole batch as a single data block"
+            ),
             'classification_output': StringField(optional=True, description='otarget output layer name')
         })
 
@@ -44,6 +47,7 @@ class ClassificationAdapter(Adapter):
 
     def configure(self):
         self.argmax_output = self.get_value_from_config('argmax_output')
+        self.block = self.get_value_from_config('block')
         self.classification_out = self.get_value_from_config('classification_output')
 
     def process(self, raw, identifiers, frame_meta):
@@ -66,12 +70,21 @@ class ClassificationAdapter(Adapter):
         prediction = np.reshape(prediction, (prediction.shape[0], -1))
 
         result = []
-        for identifier, output in zip(identifiers, prediction):
+        if self.block:
             if self.argmax_output:
-                single_prediction = ArgMaxClassificationPrediction(identifier, output[0])
+                single_prediction = ArgMaxClassificationPrediction(identifiers[0], prediction)
             else:
-                single_prediction = ClassificationPrediction(identifier, output)
+                single_prediction = ClassificationPrediction(identifiers[0], prediction)
+
             result.append(single_prediction)
+
+        else:
+            for identifier, output in zip(identifiers, prediction):
+                if self.argmax_output:
+                    single_prediction = ArgMaxClassificationPrediction(identifier, output[0])
+                else:
+                    single_prediction = ClassificationPrediction(identifier, output)
+                result.append(single_prediction)
 
         return result
 

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
@@ -357,6 +357,17 @@ The main difference between this converter and `super_resolution` in data organi
   * `annotation_file` - path to file which describe the data which should be used in evaluation (`audio_filepath`, `text`, `duration`). Optional, used only for data filtering and sorting audio samples by duration.
   * `use_numpy` - allows to use preprocessed data stored in npy-files instead of audio (Optional, default False).
   * `top_n` - numeric value for getting only the n shortest samples **Note:** applicable only with `annotation_file` providing.
+* `criteo` - converts [Criteo](http://labs.criteo.com/2013/12/download-terabyte-click-logs/) datasets to `ClassificationAnnotation`.
+  * `testing_file` - Path to testing file, terabyte_preprocessed.npz (Criteo Terabyte) or day_6_processed.npz (Criteo Kaggle Dac)
+  * `batch` - Model batch.
+  * `subsample_size` - Subsample size in batches
+  * `validation` - Allows to use half of dataset for validation purposes
+  * `block` - Make batch-oriented annotations
+  * `separator` - Separator between input identifier and file identifier
+  * `preprocessed_dir` - Preprocessed dataset location
+  * `dense_features` - Name of model dense features input
+  * `sparse_features` - Name of model sparse features input. For multiple inputs use comma-separated list in form <name>:<index>
+  * `lso_features` - Name of lS_o-like features input
 
 ## <a name="customizing-dataset-meta"></a>Customizing Dataset Meta
 There are situations when we need customize some default dataset parameters (e.g. replace original dataset label map with own.)

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
@@ -38,18 +38,17 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
             "validation": BoolField(optional=True, default=True,
                                     description="Allows to use half of dataset for validation purposes"),
             "block": BoolField(optional=True, default=True,
-                                    description="Make batch-oriented annotations"),
+                               description="Make batch-oriented annotations"),
             "separator": StringField(optional=True, default='#',
                                      description="Separator between input identifier and file identifier"),
             "preprocessed_dir": PathField(optional=False, is_directory=True, check_exists=True,
                                           description="Preprocessed dataset location"),
             "dense_features": StringField(optional=True, default='input.1',
-                                     description="Name of model dense features input"),
+                                          description="Name of model dense features input"),
             "sparse_features": StringField(optional=True, default='lS_i',
-                                          description="Name of model sparse features input. " +
-                                                "For multiple inputs use comma-separated list in form <name>:<index>"),
-            "lso_features": StringField(optional=True, default='lS_o',
-                                           description="Name of lS_o-like features input. " ),
+                                           description="Name of model sparse features input. " +
+                                           "For multiple inputs use comma-separated list in form <name>:<index>"),
+            "lso_features": StringField(optional=True, default='lS_o', description="Name of lS_o-like features input."),
         })
 
         return parameters
@@ -149,7 +148,7 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
                         "{}_{}{}{}".format(self.lso_features, j, self.separator, c_file),
                     ]
                     for name in self.sparse_features.keys():
-                        identifiers,append("{}_{}{}{}".format(name, j, self.separator, c_file))
+                        identifiers.append("{}_{}{}{}".format(name, j, self.separator, c_file))
                     annotations.append(ClassificationAnnotation(identifiers, y[j, ...]))
 
         return ConverterReturn(annotations, None, None)

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
@@ -118,7 +118,7 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
             sample = {
                 self.dense_features: np.log1p(x_int[i:i+self.batch, ...]),
                 self.lso_features: np.dot(np.expand_dims(np.linspace(0, self.batch - 1, num=self.batch), -1),
-                               np.ones((1, cat_feat))).T
+                                          np.ones((1, cat_feat))).T
             }
 
             for name in self.sparse_features.keys():

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/criteo_kaggle_dac.py
@@ -18,13 +18,13 @@ from pathlib import Path
 import numpy as np
 
 from ..representation import ClassificationAnnotation
-from ..config import NumberField, StringField, PathField, BoolField
+from ..config import NumberField, StringField, PathField, BoolField, ConfigError
 from .format_converter import BaseFormatConverter
 from .format_converter import ConverterReturn
 
 class CriteoKaggleDACConverter(BaseFormatConverter):
 
-    __provider__ = 'criteo_kaggle_dac'
+    __provider__ = 'criteo'
     annotation_types = (ClassificationAnnotation, )
 
     @classmethod
@@ -42,7 +42,14 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
             "separator": StringField(optional=True, default='#',
                                      description="Separator between input identifier and file identifier"),
             "preprocessed_dir": PathField(optional=False, is_directory=True, check_exists=True,
-                                          description="Preprocessed dataset location")
+                                          description="Preprocessed dataset location"),
+            "dense_features": StringField(optional=True, default='input.1',
+                                     description="Name of model dense features input"),
+            "sparse_features": StringField(optional=True, default='lS_i',
+                                          description="Name of model sparse features input. " +
+                                                "For multiple inputs use comma-separated list in form <name>:<index>"),
+            "lso_features": StringField(optional=True, default='lS_o',
+                                           description="Name of lS_o-like features input. " ),
         })
 
         return parameters
@@ -55,6 +62,24 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
         self.block = self.get_value_from_config('block')
         self.separator = self.get_value_from_config('separator')
         self.preprocessed_dir = self.get_value_from_config('preprocessed_dir')
+        self.dense_features = self.get_value_from_config('dense_features')
+        self.sparse_features = self.get_value_from_config('sparse_features')
+        self.lso_features = self.get_value_from_config('lso_features')
+        self.parse_sparse_features()
+
+    def parse_sparse_features(self):
+        features = self.sparse_features.split(',')
+        if len(features) == 1:
+            self.sparse_features = {features[0]: range(26)}
+        else:
+            self.sparse_features = {}
+            for feat in features:
+                parts = feat.split(':')
+                if len(parts) == 2:
+                    self.sparse_features[parts[0]] = int(parts[1])
+                else:
+                    ConfigError('Invalid configuration option {}'.format(feat))
+
 
     def convert(self, check_content=False, **kwargs):
 
@@ -92,11 +117,13 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
             c_input = c_input / "{:06d}.npz".format(i)
 
             sample = {
-                "input.1": np.log1p(x_int[i:i+self.batch, ...]),
-                "lS_i": x_cat[i:i+self.batch, ...].T,
-                "lS_o": np.dot(np.expand_dims(np.linspace(0, self.batch - 1, num=self.batch), -1),
+                self.dense_features: np.log1p(x_int[i:i+self.batch, ...]),
+                self.lso_features: np.dot(np.expand_dims(np.linspace(0, self.batch - 1, num=self.batch), -1),
                                np.ones((1, cat_feat))).T
             }
+
+            for name in self.sparse_features.keys():
+                sample[name] = x_cat[i:i+self.batch, self.sparse_features[name]].T
 
             np.savez_compressed(str(c_input), **sample)
 
@@ -108,23 +135,21 @@ class CriteoKaggleDACConverter(BaseFormatConverter):
             c_file = str(c_input.relative_to(preprocessed_folder))
 
             if self.block:
-                annotations.append(ClassificationAnnotation(
-                    [
-                        "input.1_{}{}{}".format(i, self.separator, c_file),
-                        "lS_i_{}{}{}".format(i, self.separator, c_file),
-                        "lS_o_{}{}{}".format(i, self.separator, c_file),
-                    ],
-                    y[i:i+self.batch, ...]
-                ))
+                identifiers = [
+                    "{}_{}{}{}".format(self.dense_features, i, self.separator, c_file),
+                    "{}_{}{}{}".format(self.lso_features, i, self.separator, c_file),
+                ]
+                for name in self.sparse_features.keys():
+                    identifiers.append("{}_{}{}{}".format(name, i, self.separator, c_file))
+                annotations.append(ClassificationAnnotation(identifiers, y[i:i+self.batch, ...]))
             else:
                 for j in range(i, i + self.batch):
-                    annotations.append(ClassificationAnnotation(
-                        [
-                            "input.1_{}{}{}".format(j, self.separator, c_file),
-                            "lS_i_{}{}{}".format(j, self.separator, c_file),
-                            "lS_o_{}{}{}".format(j, self.separator, c_file),
-                        ],
-                        y[j, ...]
-                    ))
+                    identifiers = [
+                        "{}_{}{}{}".format(self.dense_features, j, self.separator, c_file),
+                        "{}_{}{}{}".format(self.lso_features, j, self.separator, c_file),
+                    ]
+                    for name in self.sparse_features.keys():
+                        identifiers,append("{}_{}{}{}".format(name, j, self.separator, c_file))
+                    annotations.append(ClassificationAnnotation(identifiers, y[j, ...]))
 
         return ConverterReturn(annotations, None, None)

--- a/tools/accuracy_checker/accuracy_checker/data_readers/README.md
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/README.md
@@ -28,10 +28,10 @@ reader:
 ```
 
 AccuracyChecker supports following list of data readers:
-* `opencv_imread` - read images using OpenCV library. Default color space is BGR. 
+* `opencv_imread` - read images using OpenCV library. Default color space is BGR.
    * `reading_flag` - (Optional) flag which specifies the way image should be read: `color` - default, loads color image, `gray` - loads image in grayscale mode, `unchanged` - loads image as such including alpha channel.
 * `pillow_imread` - read images using Pillow library. Default color space is RGB.
-* `scipy_imread` - read images using similar approach as in `scipy.misc.imread` 
+* `scipy_imread` - read images using similar approach as in `scipy.misc.imread`
 ```
 Note: since 1.3.0 version the image processing module is not a part of scipy library. This reader does not use scipy anymore.
 ```
@@ -42,6 +42,9 @@ Note: since 1.3.0 version the image processing module is not a part of scipy lib
 * `annotation_features_extractor` - read features from annotation.
   * `features` - list of features. All features should be fields of annotation representation.
 * `numpy_reader` - read numpy dumped files (npy or npz formats are supported for reading)
+  * `keys` - comma-separated list of model input names
+  * `separator` - separator symbol between input identifier and file identifier
+  * `block` - block mode (batch - oriented). In this mode reader returns whole variable.
 * `numpy_txt_reader`- read data stored in text format to numpy array.
 * `numpy_dict_reader` - read and unpack dictionaries saved in numpy files.
 * `nifti_reader` - read NifTI data format

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -397,13 +397,14 @@ class NumPyReader(BaseReader):
             key = [k for k, v in self.keyRegex.items() if v.match(field_id)]
             if len(key) > 0:
                 if self.block:
-                    return data[key[0]]
+                    res = data[key[0]]
                 else:
                     recno = field_id.split('_')[-1]
                     recno = int(recno)
                     start = Path(data_id).name.split('.')[0]
                     start = int(start)
-                    return data[key[0]][recno - start, :]
+                    res = data[key[0]][recno - start, :]
+                return res
 
         key = next(iter(data.keys()))
         return data[key]

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -38,7 +38,7 @@ except ImportError:
 
 from ..utils import get_path, read_json, read_pickle, contains_all
 from ..dependency import ClassProvider
-from ..config import BaseField, StringField, ConfigValidator, ConfigError, DictField, ListField, BoolField
+from ..config import BaseField, StringField, ConfigValidator, ConfigError, DictField, ListField, BoolField, NumberField
 
 REQUIRES_ANNOTATIONS = ['annotation_features_extractor', ]
 
@@ -353,6 +353,8 @@ class NumpyReaderConfig(ConfigValidator):
     type = StringField(optional=True)
     keys = StringField(optional=True, default="")
     separator = StringField(optional=True, default="@")
+    block = BoolField(optional=True, default=False)
+    batch = NumberField(optional=True, default=1)
 
 
 class NumPyReader(BaseReader):
@@ -369,6 +371,9 @@ class NumPyReader(BaseReader):
         self.keys = self.config.get('keys', "") if self.config else ""
         self.keys = [t.strip() for t in self.keys.split(',')] if len(self.keys) > 0 else []
         self.separator = self.config.get('separator')
+        self.block = self.config.get('block', False)
+        self.batch = int(self.config.get('batch', 1))
+
         if self.separator and self.is_text:
             raise ConfigError('text file reading with numpy does')
         self.multi_infer = self.config.get('multi_infer', False)
@@ -391,11 +396,14 @@ class NumPyReader(BaseReader):
         if field_id is not None:
             key = [k for k, v in self.keyRegex.items() if v.match(field_id)]
             if len(key) > 0:
-                recno = field_id.split('_')[-1]
-                recno = int(recno)
-                start, _ = Path(data_id).name.split('.')
-                start = int(start)
-                return data[key[0]][recno - start, :]
+                if self.block:
+                    return data[key[0]]
+                else:
+                    recno = field_id.split('_')[-1]
+                    recno = int(recno)
+                    start, _ = Path(data_id).name.split('.')
+                    start = int(start)
+                    return data[key[0]][recno - start, :]
 
         key = next(iter(data.keys()))
         return data[key]

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -401,7 +401,7 @@ class NumPyReader(BaseReader):
                 else:
                     recno = field_id.split('_')[-1]
                     recno = int(recno)
-                    start, _ = Path(data_id).name.split('.')
+                    start = Path(data_id).name.split('.')[0]
                     start = int(start)
                     return data[key[0]][recno - start, :]
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -837,6 +837,9 @@ class DLSDKLauncher(Launcher):
         if len(layer_shape) == 2:
             if len(data_shape) == 1:
                 return np.transpose([data])
+            if len(data_shape) > 2:
+                if len(np.squeeze(np.zeros(layer_shape))) == len(np.squeeze(np.zeros(data_shape))):
+                    return np.resize(data, layer_shape)
 
         if len(layer_shape) == 3 and len(data_shape) == 4:
             data = np.transpose(data, layout)

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -823,7 +823,7 @@ class DLSDKLauncher(Launcher):
         return self._align_data_shape(data, layer_name, layout)
 
     @staticmethod
-    def _data_to_blob(layer_shape, data, layout):
+    def _data_to_blob(layer_shape, data, layout): # pylint:disable=R0911
         data_shape = np.shape(data)
         if len(layer_shape) == 4:
             if len(data_shape) == 5:

--- a/tools/accuracy_checker/accuracy_checker/metrics/README.md
+++ b/tools/accuracy_checker/accuracy_checker/metrics/README.md
@@ -15,6 +15,7 @@ Accuracy Checker supports following set of metrics:
 * `accuracy` - classification accuracy metric, defined as the number of correct predictions divided by the total number of predictions.
 Supported representation: `ClassificationAnnotation`, `TextClassificationAnnotation`, `ClassificationPrediction`, `ArgMaxClassificationPrediction`.
   * `top_k` - the number of classes with the highest probability, which will be used to decide if prediction is correct.
+  * `match` - Batch-oriented binary classification metric. Metric value calculated for each record in batch. Parameter `top_k` ignored in this mode.
 * `accuracy_per_class` - classification accuracy metric which represents results for each class. Supported representation: `ClassificationAnnotation`, `ClassificationPrediction`.
   * `top_k` - the number of classes with the highest probability, which will be used to decide if prediction is correct.
   * `label_map` - the field in annotation metadata, which contains dataset label map (Optional, should be provided if different from default).

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -26,12 +26,16 @@ from ..representation import (
 from ..config import NumberField, StringField, ConfigError, BoolField
 from .metric import PerImageEvaluationMetric
 from .average_meter import AverageMeter
-from sklearn.metrics import accuracy_score
 
 try:
     from sklearn.metrics import roc_auc_score
 except ImportError:
     roc_auc_score = None
+
+try:
+    from sklearn.metrics import accuracy_score
+except ImportError:
+    accuracy_score = None
 
 class ClassificationAccuracy(PerImageEvaluationMetric):
     """

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -26,7 +26,6 @@ from ..representation import (
 from ..config import NumberField, StringField, ConfigError, BoolField
 from .metric import PerImageEvaluationMetric
 from .average_meter import AverageMeter
-from sklearn.metrics import accuracy_score
 
 try:
     from sklearn.metrics import roc_auc_score

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -23,9 +23,10 @@ from ..representation import (
     ArgMaxClassificationPrediction
 )
 
-from ..config import NumberField, StringField, ConfigError
+from ..config import NumberField, StringField, ConfigError, BoolField
 from .metric import PerImageEvaluationMetric
 from .average_meter import AverageMeter
+from sklearn.metrics import accuracy_score
 
 try:
     from sklearn.metrics import roc_auc_score
@@ -50,27 +51,43 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
                 value_type=int, min_value=1, optional=True, default=1,
                 description="The number of classes with the highest probability, which will be used to decide "
                             "if prediction is correct."
-            )
+            ),
+            'match': BoolField(optional=True, default=False)
         })
 
         return parameters
 
     def configure(self):
         self.top_k = self.get_value_from_config('top_k')
+        self.match = self.get_value_from_config('match')
 
         def loss(annotation_label, prediction_top_k_labels):
             return int(annotation_label in prediction_top_k_labels)
 
-        self.accuracy = AverageMeter(loss)
+        if not self.match:
+            self.accuracy = AverageMeter(loss)
+        else:
+            self.accuracy = []
 
     def update(self, annotation, prediction):
-        return self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
+        if not self.match:
+            return self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
+        else:
+            accuracy = accuracy_score(annotation.label, prediction.label)
+            self.accuracy.append(accuracy)
+
 
     def evaluate(self, annotations, predictions):
-        return self.accuracy.evaluate()
+        if not self.match:
+            return self.accuracy.evaluate()
+        else:
+            return np.mean(self.accuracy)
 
     def reset(self):
-        self.accuracy.reset()
+        if not self.match:
+            self.accuracy.reset()
+        else:
+            self.accuracy = []
 
 
 class ClassificationAccuracyClasses(PerImageEvaluationMetric):

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -71,6 +71,8 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
         if not self.match:
             self.accuracy = AverageMeter(loss)
         else:
+            if accuracy_score is None:
+                raise ConfigError('sklearn.metric.accuracy_score not available')
             self.accuracy = []
 
     def update(self, annotation, prediction):

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -79,6 +79,7 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
         else:
             accuracy = accuracy_score(annotation.label, prediction.label)
             self.accuracy.append(accuracy)
+            return accuracy
 
 
     def evaluate(self, annotations, predictions):

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -77,17 +77,18 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
 
     def update(self, annotation, prediction):
         if not self.match:
-            return self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
+            accuracy =  self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
         else:
             accuracy = accuracy_score(annotation.label, prediction.label)
             self.accuracy.append(accuracy)
-            return accuracy
+        return accuracy
 
     def evaluate(self, annotations, predictions):
         if not self.match:
-            return self.accuracy.evaluate()
+            accuracy =  self.accuracy.evaluate()
         else:
-            return np.mean(self.accuracy)
+            accuracy = np.mean(self.accuracy)
+        return accuracy
 
     def reset(self):
         if not self.match:

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -26,6 +26,7 @@ from ..representation import (
 from ..config import NumberField, StringField, ConfigError, BoolField
 from .metric import PerImageEvaluationMetric
 from .average_meter import AverageMeter
+from sklearn.metrics import accuracy_score
 
 try:
     from sklearn.metrics import roc_auc_score
@@ -82,7 +83,6 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
             accuracy = accuracy_score(annotation.label, prediction.label)
             self.accuracy.append(accuracy)
             return accuracy
-
 
     def evaluate(self, annotations, predictions):
         if not self.match:

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -77,7 +77,7 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
 
     def update(self, annotation, prediction):
         if not self.match:
-            accuracy =  self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
+            accuracy = self.accuracy.update(annotation.label, prediction.top_k(self.top_k))
         else:
             accuracy = accuracy_score(annotation.label, prediction.label)
             self.accuracy.append(accuracy)
@@ -85,7 +85,7 @@ class ClassificationAccuracy(PerImageEvaluationMetric):
 
     def evaluate(self, annotations, predictions):
         if not self.match:
-            accuracy =  self.accuracy.evaluate()
+            accuracy = self.accuracy.evaluate()
         else:
             accuracy = np.mean(self.accuracy)
         return accuracy


### PR DESCRIPTION
Work around too slow accuracy tests with DLRM models on Criteo datasets.

Key problem: prepare batch data for model inputs from record-oriented annotations consumes much more time than batch inference.
Solution: make processing batch-oriented 

Changes: 
1. Add "block" parameter to criteo_kaggle_dac converter to produce batch-oriented annotations
2. Add "block" parameter to numpy_reader to allow reading full batch input
3. Modification of DLSDKLauncher._data_to_blob() to correctly handle 3D data to 2D input layout
4. Add "block" parameter to ClassificationAdapter to allow whole batch output be transformed into single prediction object
5. Add "match" parameter to "accuracy" metric to allow sklearn.metric.accuracy_score in the context of AC "accuracy" metric 

Performance benefit from these changes is about 40x times