### PR TITLE
security_barrier_camera: check every lpr output dimension

### DIFF
--- a/demos/security_barrier_camera_demo/net_wrappers.hpp
+++ b/demos/security_barrier_camera_demo/net_wrappers.hpp
@@ -249,9 +249,17 @@ public:
         LprOutputName = LprOutputInfo.begin()->first;
         auto lprOutputInfo = (LprOutputInfo.begin());
 
-        // Shape of output tensor for model that converted from Caffe is [1,88,1,1], from TF [1,1,88,1]
-        size_t indexOfSequenceSize = LprInputSeqName == "" ? 2 : 1;
-        maxSequenceSizePerPlate = lprOutputInfo->second->getTensorDesc().getDims()[indexOfSequenceSize];
+        maxSequenceSizePerPlate = 1;
+        for (size_t dim : lprOutputInfo->second->getTensorDesc().getDims()) {
+            if (dim == 1) {
+                continue;
+            }
+            if (maxSequenceSizePerPlate == 1) {
+                maxSequenceSizePerPlate = dim;
+            } else {
+                throw std::logic_error("Every dimension of LPR output except for one must be of size 1");
+            }
+        }
 
         net = ie_.LoadNetwork(network, deviceName, pluginConfig);
     }


### PR DESCRIPTION
That avoids a mismatch when the model wrapper have an implicit assumption which dimension is of non 1 size.

Every LPR model output shape is [1, 88, 1, 1] now.
But the implemented approach relaxes the requirement to have a specific order of dimensions.