### PR TITLE
AC: fix instance segmentation to polygon dumping

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -279,12 +279,12 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
             warnings.warn("Polygon can be found only for non-empty mask")
             return {}
 
-        if not self.labels:
+        if self.labels is None or np.size(self.labels) == 0:
             warnings.warn("Polygon can be found only for non-empty labels")
             return {}
 
         polygons = defaultdict(list)
-        for elem, label in zip(self.raw_mask, self.labels):
+        for elem, label in zip(self.mask, self.labels):
             elem = np.uint8(maskUtils.decode(elem))
             obj_contours = []
             contours, _ = cv.findContours(elem, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE)

--- a/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
+++ b/tools/accuracy_checker/accuracy_checker/representation/segmentation_representation.py
@@ -283,8 +283,14 @@ class CoCoInstanceSegmentationRepresentation(SegmentationRepresentation):
             warnings.warn("Polygon can be found only for non-empty labels")
             return {}
 
+        if all(not isinstance(value, dict) for value in self.raw_mask):
+            polygons = defaultdict(list)
+            for elem, label in zip(self.raw_mask, self.labels):
+                polygons[label].append(elem)
+            return polygons
+
         polygons = defaultdict(list)
-        for elem, label in zip(self.mask, self.labels):
+        for elem, label in zip(self.raw_mask, self.labels):
             elem = np.uint8(maskUtils.decode(elem))
             obj_contours = []
             contours, _ = cv.findContours(elem, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE)

--- a/tools/accuracy_checker/tests/test_segmentation_representation.py
+++ b/tools/accuracy_checker/tests/test_segmentation_representation.py
@@ -199,12 +199,30 @@ class TestSegmentationRepresentation:
 
 @pytest.mark.skipif(no_available_pycocotools(), reason='no installed pycocotools in the system')
 class TestCoCoInstanceSegmentationRepresentation:
-    def test_to_polygon_annotation(self):
+    def test_to_polygon_annotation_mask_rle(self):
         mask = [np.array([[1, 0, 0, 0], [1, 1, 0, 0], [1, 1, 1, 0]]),
                 np.array([[0, 1, 1, 1], [0, 0, 1, 1], [0, 0, 0, 1]])]
         raw_mask = encode_mask(mask)
         labels = [0, 1]
         annotation = make_instance_segmentation_representation(raw_mask, labels, True)[0]
+        expected = {
+            1: [np.array([[[1, 0], [3, 0], [3, 2]]])],
+            0: [np.array([[[0, 0], [0, 2], [2, 2]]])]}
+
+        actual = annotation.to_polygon()
+
+        for key in expected.keys():
+            assert actual[key]
+            for actual_arr, expected_arr in zip(actual[key], expected[key]):
+                actual_arr = np.sort(actual_arr, axis=1)
+                expected_arr = np.sort(expected_arr, axis=1)
+                assert np.array_equal(actual_arr, expected_arr)
+
+    def test_to_polygon_annotation_mask_polygon(self):
+        mask = [np.array([[[0, 0], [0, 2], [2, 2]]]),
+                np.array([[[1, 0], [3, 0], [3, 2]]])]
+        labels = [0, 1]
+        annotation = make_instance_segmentation_representation(mask, labels, True)[0]
         expected = {
             1: [np.array([[[1, 0], [3, 0], [3, 2]]])],
             0: [np.array([[[0, 0], [0, 2], [2, 2]]])]}


### PR DESCRIPTION
1. fix for labels stored in numpy array
2. fix for annotation decoding mask (original format stored in raw_mask is not applicable for decoding)