### PR TITLE
get-jobs-for-changes.py: request a models.lst check when a model is deleted

### DIFF
--- a/ci/get-jobs-for-changes.py
+++ b/ci/get-jobs-for-changes.py
@@ -44,7 +44,7 @@ def main():
     args = parser.parse_args()
 
     git_diff_output = subprocess.check_output(
-        ["git", "diff", "--name-only", "-z", args.base_commit + "...HEAD"])
+        ["git", "diff", "--name-only", "--no-renames", "-z", args.base_commit + "...HEAD"])
     changed_files = list(map(PurePosixPath, git_diff_output.decode()[:-1].split("\0")))
 
     models_dir = PurePosixPath("models")
@@ -55,6 +55,9 @@ def main():
         if models_dir in changed_file.parents and changed_file.name == "model.yml":
             if Path(changed_file).exists(): # it might've been deleted in the branch
                 jobs.setdefault("models", []).append(changed_file.parent.name)
+            else:
+                # make sure no models.lst files reference the deleted model
+                jobs["models_lst"] = True
 
     git_check_attr_output = subprocess.run(
         ["git", "check-attr", "--stdin", "-z", "--all"],


### PR DESCRIPTION
Occasionally we merge a PR that deletes a model and then demo tests start failing, because one of the demos depended on it. This change is a step towards preventing that from happening.

Right now, there isn't anything actually connected to this "models_lst" identifier. I plan to add a check to the demo job that just runs the info dumper on every models.lst file in the repository, and to trigger that check when the "models_lst" job is requested.

I could just set it to run the full demo job when a model is deleted, but that seems like an overkill; the demo tests take a while, and a model can only be used in tests if it's listed in models.lst, thus checking models.lst is sufficient.