### PR TITLE
AC: support resize in padding and deprocessing padded mask

### DIFF
--- a/models/public/deeplabv3/accuracy-check.yml
+++ b/models/public/deeplabv3/accuracy-check.yml
@@ -9,6 +9,7 @@ models:
         preprocessing:
           - type: padding
             size: 513
+            enable_resize: True
         postprocessing:
           - type: encode_segmentation_mask
             apply_to: annotation

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
@@ -98,7 +98,8 @@ Accuracy Checker supports following set of preprocessors:
     You can also use `size` instead in case when destination sizes are equal for both dimensions.
   * `pad_type` - padding space location. Supported: `center`, `left_top`, `right_bottom` (Default is `center`).
   * `use_numpy` - allow to use numpy for padding instead default OpenCV.
-  * `numpy_pad_mode` - if using numpy for padding, numpy padding mode, including constant, edge, mean, etc. (Default is `constant`)
+  * `numpy_pad_mode` - if using numpy for padding, numpy padding mode, including constant, edge, mean, etc. (Default is `constant`).
+  * `enable_resize` - allow resize image to destination size, if source image greater that destination (Optional, default `False`).
 * `tiling` - image tiling.
   * `margin` - margin for tiled fragment of image.
   * `dst_width` and `dst_height` are destination width and height of tiled fragment respectively.


### PR DESCRIPTION
default deeplab v3 config written for specific image size in the dataset (if we provide image larger than 513x513, AC failed on input filling case, because padding will not applied), generalized it for case if images larger than default (can be useful in visualization case) and added deprocessing padded prediction mask for single image processing mode
