### PR TITLE
Public models: remove deprecated keep_shape_ops option

### DIFF
--- a/models/public/ctpn/model.yml
+++ b/models/public/ctpn/model.yml
@@ -27,6 +27,5 @@ model_optimizer_args:
   - --mean_values=Placeholder[102.9801,115.9465,122.7717]
   - --output=Reshape_2,rpn_bbox_pred/Reshape_1
   - --input_model=$dl_dir/ctpn.pb
-  - --keep_shape_ops
 framework: tf
 license: https://raw.githubusercontent.com/eragonruan/text-detection-ctpn/banjin-dev/LICENSE

--- a/models/public/densenet-121-tf/model.yml
+++ b/models/public/densenet-121-tf/model.yml
@@ -37,7 +37,6 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet121/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet121.ckpt.meta
-  - --keep_shape_ops
 framework: tf
 quantizable: yes
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE

--- a/models/public/densenet-161-tf/model.yml
+++ b/models/public/densenet-161-tf/model.yml
@@ -37,7 +37,6 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet161/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet161.ckpt.meta
-  - --keep_shape_ops
 framework: tf
 quantizable: yes
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE

--- a/models/public/densenet-169-tf/model.yml
+++ b/models/public/densenet-169-tf/model.yml
@@ -37,7 +37,6 @@ model_optimizer_args:
   - --scale_values=Placeholder[58.8235294117647]
   - --output=densenet169/predictions/Reshape_1
   - --input_meta_graph=$dl_dir/tf-densenet169.ckpt.meta
-  - --keep_shape_ops
 framework: tf
 quantizable: yes
 license: https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE


### PR DESCRIPTION
--keep_shape_ops key enabled by default in MO and the option is gone. Updated model.yml do not use it