### PR TITLE
universal cmake changes

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -176,8 +176,8 @@ macro(ie_add_sample)
         target_include_directories(${IE_SAMPLE_NAME} PRIVATE ${IE_SAMPLE_INCLUDE_DIRECTORIES})
     endif()
 
-    target_link_libraries(${IE_SAMPLE_NAME} PRIVATE ${OpenCV_LIBRARIES} ${InferenceEngine_LIBRARIES}
-                                                    ${IE_SAMPLE_DEPENDENCIES} common gflags)
+    target_link_libraries(${IE_SAMPLE_NAME} PRIVATE ${TBB_IMPORTED_TARGETS} ${OpenCV_LIBRARIES} ${InferenceEngine_LIBRARIES}
+                                                    ngraph::ngraph ${IE_SAMPLE_DEPENDENCIES} common gflags)
 
     if(UNIX)
         target_link_libraries(${IE_SAMPLE_NAME} PRIVATE pthread)
@@ -206,6 +206,7 @@ else()
 endif()
 
 find_package(ngraph REQUIRED)
+find_package(TBB REQUIRED tbb)
 
 # collect all samples subdirectories
 file(GLOB samples_dirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)

--- a/demos/multi_channel/common/CMakeLists.txt
+++ b/demos/multi_channel/common/CMakeLists.txt
@@ -106,5 +106,5 @@ target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 find_package(Threads REQUIRED)
 
 target_link_libraries(${TARGET_NAME}
-    PRIVATE ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES}
+    PRIVATE ${TBB_IMPORTED_TARGETS} ${InferenceEngine_LIBRARIES} ngraph::ngraph gflags ${OpenCV_LIBRARIES}
     PUBLIC Threads::Threads common)

--- a/demos/multi_channel/face_detection_demo/CMakeLists.txt
+++ b/demos/multi_channel/face_detection_demo/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(${TARGET_NAME} ${MAIN_SRC} ${MAIN_HEADERS})
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_PDB_NAME ${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE
-    ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} multi_channel_common monitors)
+    ${TBB_IMPORTED_TARGETS} ${InferenceEngine_LIBRARIES} ngraph::ngraph gflags ${OpenCV_LIBRARIES} multi_channel_common monitors)
 
 if(COMMAND add_cpplint_target)
     add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})

--- a/demos/multi_channel/human_pose_estimation_demo/CMakeLists.txt
+++ b/demos/multi_channel/human_pose_estimation_demo/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(${TARGET_NAME} ${MAIN_SRC} ${MAIN_HEADERS})
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_PDB_NAME ${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE
-    ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} multi_channel_common monitors)
+    ${TBB_IMPORTED_TARGETS} ${InferenceEngine_LIBRARIES} ngraph::ngraph gflags ${OpenCV_LIBRARIES} multi_channel_common monitors)
 
 if(NOT TARGET ie_samples)
     add_custom_target(ie_samples ALL)

--- a/demos/multi_channel/object_detection_demo_yolov3/CMakeLists.txt
+++ b/demos/multi_channel/object_detection_demo_yolov3/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(${TARGET_NAME} ${MAIN_SRC} ${MAIN_HEADERS})
 set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_PDB_NAME ${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE
-    ${InferenceEngine_LIBRARIES} gflags ${OpenCV_LIBRARIES} ngraph::ngraph monitors multi_channel_common)
+    ${TBB_IMPORTED_TARGETS} ${InferenceEngine_LIBRARIES} ngraph::ngraph gflags ${OpenCV_LIBRARIES} ngraph::ngraph monitors multi_channel_common)
 
 if(COMMAND add_cpplint_target)
     add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})


### PR DESCRIPTION
This patch is to allow seamless building of demos between several different versions of OpenVino to include 1) open source OpenVINO 2) Released OpenVINO 3) cross-compiled OpenVINO 4) internal gitlab OpenVINO

For instance for 2020.4
export ngraph_DIR=/opt/intel/openvino_2020.4.287/deployment_tools/ngraph/cmake/
export TBB_DIR=/opt/intel/openvino_2020.4.287/deployment_tools/inference_engine/external/tbb/cmake/
export OpenCV_DIR=/opt/intel/openvino_2020.4.287/opencv/cmake
export InferenceEngine_DIR=/opt/intel/openvino_2020.4.287/deployment_tools/inference_engine/share

for opensource openVINO:
export InferenceEngine_DIR=/home/shubha/openvino/build
export ngraph_DIR=/home/shubha/openvino/build/ngraph
export TBB_DIR=/home/shubha/openvino/inference-engine/temp/tbb/cmake/
export OpenCV_DIR=/home/shubha/openvino/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/cmake

cd open_model_zoo/demos
mkdir build
cd build
cmake ..
make

*This recipe works across all types of OpenVINO builds
