### PR TITLE
demos: clarify build procedure on *Config.cmake

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -121,10 +121,7 @@ Please run the following command before the demos build (assuming that the binar
 ```sh
 source <INSTALL_DIR>/deployment_tools/bin/setupvars.sh
 ```
-You can also build demos manually using Inference Engine binaries from the
-[openvino](https://github.com/openvinotoolkit/openvino) repo. In this case please set `InferenceEngine_DIR` to a CMake folder you built the Inference Engine from, for example `<openvino_repo>/inference-engine/build`.
-Please also set the `OpenCV_DIR` variable pointing to the required OpenCV package. The same OpenCV
-version should be used both for the inference engine and demos build.
+You can also build demos manually using Inference Engine built from the [openvino](https://github.com/openvinotoolkit/openvino) repo. In this case please set `InferenceEngine_DIR` environmen variable to a folder containing `InferenceEngineConfig.cmake` and `ngraph_DIR` to a folder containing `ngraphConfig.cmake` in a build folder. Please also set the `OpenCV_DIR` to point to the OpenCV package to use. The same OpenCV version should be used both for Inference Engine and demos build. Alternatively these values can be provided via command line while running `cmake`. See [CMake's search procedure](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure).
 Please refer to the Inference Engine <a href="https://github.com/openvinotoolkit/openvino/blob/master/build-instruction.md">build instructions</a>
 for details. Please also add path to built Inference Engine libraries to `LD_LIBRARY_PATH` (Linux*) or `PATH` (Windows*) variable before building the demos.
 


### PR DESCRIPTION
Only multi_channel demos need TBB vars and they don't document the
possibility of being built with TBB. Moreover, I couldn't come up
with easy-to-understand formulation describing TBB var for root demos
readme. So, this var is not included in the patch.