### PR TITLE
AC: support explicit identifiers list specification in dummy launcher

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dummy_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dummy_launcher.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ..utils import get_path
+from ..utils import get_path, read_txt
 from ..logging import print_info
 from ..config import PathField, StringField, BoolField
 from .loaders import Loader
@@ -34,7 +34,8 @@ class DummyLauncher(Launcher):
         parameters.update({
             'loader': StringField(choices=Loader.providers, description="Loader."),
             'data_path': PathField(description="Data path."),
-            'provide_identifiers': BoolField(optional=True, default=False)
+            'provide_identifiers': BoolField(optional=True, default=False),
+            'identifiers_list': PathField(optional=True)
         })
         return parameters
 
@@ -45,6 +46,9 @@ class DummyLauncher(Launcher):
         dummy_launcher_config.validate(self.config)
 
         self.data_path = get_path(self.get_value_from_config('data_path'))
+        identfiers_file = self.get_value_from_config('identifiers_list')
+        if identfiers_file is not None:
+            kwargs['identifiers'] = read_txt(identfiers_file)
 
         self._loader = Loader.provide(self.get_value_from_config('loader'), self.data_path, **kwargs)
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/loaders/json_loader.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/loaders/json_loader.py
@@ -33,6 +33,8 @@ class JSONLoader(DictLoaderMixin, Loader):
         for detection in detection_list:
             if 'timestamp' in detection:
                 idx = int(detection['timestamp']) // 1000000000
+            if identifiers and idx >= len(identifiers):
+                break
             identifier = identifiers[idx] if identifiers else idx
             idx += 1
             data[identifier] = detection


### PR DESCRIPTION
the idea in opportunity provide file with list of identifiers used in inference if it is not fully matched with annotation (e.g. inferrend whole dataset while in validation used only subset)