### PR TITLE
VideoCapWrapper refactoring

### DIFF
--- a/demos/common/src/images_capture.cpp
+++ b/demos/common/src/images_capture.cpp
@@ -129,7 +129,7 @@ public:
         if (cap.open(input)) {
             this->readLengthLimit = readLengthLimit;
             if (!cap.set(cv::CAP_PROP_POS_FRAMES, this->initialImageId))
-                throw std::runtime_error{ "Can't set the frame to begin with" };
+                throw std::runtime_error{"Can't set the frame to begin with"};
             return;
         }
 

--- a/demos/common/src/images_capture.cpp
+++ b/demos/common/src/images_capture.cpp
@@ -111,26 +111,31 @@ public:
     VideoCapWrapper(const std::string &input, bool loop, size_t initialImageId, size_t readLengthLimit,
                 cv::Size cameraResolution)
             : ImagesCapture{loop}, nextImgId{0}, initialImageId{static_cast<double>(initialImageId)} {
-        try {
-            cap.open(std::stoi(input));
-            this->readLengthLimit = loop ? std::numeric_limits<size_t>::max() : readLengthLimit;
-            cap.set(cv::CAP_PROP_BUFFERSIZE, 1);
-            cap.set(cv::CAP_PROP_FRAME_WIDTH, cameraResolution.width);
-            cap.set(cv::CAP_PROP_FRAME_HEIGHT, cameraResolution.height);
-            cap.set(cv::CAP_PROP_AUTOFOCUS, true);
-            cap.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('M', 'J', 'P', 'G'));
-        } catch (const std::invalid_argument&) {
-            cap.open(input);
-            this->readLengthLimit = readLengthLimit;
-            if (!cap.set(cv::CAP_PROP_POS_FRAMES, this->initialImageId))
-                throw std::runtime_error{"Can't set the frame to begin with"};
-        } catch (const std::out_of_range&) {
-            cap.open(input);
-            this->readLengthLimit = readLengthLimit;
-            if (!cap.set(cv::CAP_PROP_POS_FRAMES, this->initialImageId))
-                throw std::runtime_error{"Can't set the frame to begin with"};
+
+        try
+        {
+            if (cap.open(std::stoi(input)))
+            {
+                this->readLengthLimit = loop ? std::numeric_limits<size_t>::max() : readLengthLimit;
+                cap.set(cv::CAP_PROP_BUFFERSIZE, 1);
+                cap.set(cv::CAP_PROP_FRAME_WIDTH, cameraResolution.width);
+                cap.set(cv::CAP_PROP_FRAME_HEIGHT, cameraResolution.height);
+                cap.set(cv::CAP_PROP_AUTOFOCUS, true);
+                cap.set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('M', 'J', 'P', 'G'));
+                return;
+            }
         }
-        if (!cap.isOpened()) throw InvalidInput{};
+        catch(std::invalid_argument){} // If stoi conversion failed, let's try another way to open capture device
+        catch (std::out_of_range) {}
+
+        if (cap.open(input)) {
+            this->readLengthLimit = readLengthLimit;
+            if (!cap.set(cv::CAP_PROP_POS_FRAMES, this->initialImageId))
+                throw std::runtime_error{ "Can't set the frame to begin with" };
+            return;
+        }
+        
+        throw InvalidInput{};
     }
 
     double fps() const override {return cap.get(cv::CAP_PROP_FPS);}

--- a/demos/common/src/images_capture.cpp
+++ b/demos/common/src/images_capture.cpp
@@ -112,10 +112,8 @@ public:
                 cv::Size cameraResolution)
             : ImagesCapture{loop}, nextImgId{0}, initialImageId{static_cast<double>(initialImageId)} {
 
-        try
-        {
-            if (cap.open(std::stoi(input)))
-            {
+        try {
+            if (cap.open(std::stoi(input))) {
                 this->readLengthLimit = loop ? std::numeric_limits<size_t>::max() : readLengthLimit;
                 cap.set(cv::CAP_PROP_BUFFERSIZE, 1);
                 cap.set(cv::CAP_PROP_FRAME_WIDTH, cameraResolution.width);
@@ -134,7 +132,7 @@ public:
                 throw std::runtime_error{ "Can't set the frame to begin with" };
             return;
         }
-        
+
         throw InvalidInput{};
     }
 

--- a/demos/common/src/images_capture.cpp
+++ b/demos/common/src/images_capture.cpp
@@ -123,7 +123,7 @@ public:
                 return;
             }
         }
-        catch(std::invalid_argument){} // If stoi conversion failed, let's try another way to open capture device
+        catch (std::invalid_argument) {} // If stoi conversion failed, let's try another way to open capture device
         catch (std::out_of_range) {}
 
         if (cap.open(input)) {


### PR DESCRIPTION
Original implementation returned incorrect error message in case of invalid device name, also status of cap.open() was not checked.