### PR TITLE
Fix naming convention violations in Python demos

### DIFF
--- a/demos/python_demos/colorization_demo/colorization_demo.py
+++ b/demos/python_demos/colorization_demo/colorization_demo.py
@@ -89,9 +89,9 @@ if __name__ == '__main__':
     color_coeff = np.load(coeffs).astype(np.float32)
     assert color_coeff.shape == (313, 2), "Current shape of color coefficients does not match required shape"
 
-    imshowSize = (640, 480)
-    graphSize = (imshowSize[0] // 2, imshowSize[1] // 4)
-    presenter = monitors.Presenter(args.utilization_monitors, imshowSize[1] * 2 - graphSize[1], graphSize)
+    imshow_size = (640, 480)
+    graph_size = (imshow_size[0] // 2, imshow_size[1] // 4)
+    presenter = monitors.Presenter(args.utilization_monitors, imshow_size[1] * 2 - graph_size[1], graph_size)
 
     while True:
         log.debug("#############################")
@@ -121,10 +121,10 @@ if __name__ == '__main__':
         img_lab_out = np.concatenate((img_lab[:, :, 0][:, :, np.newaxis], out), axis=2)
         img_bgr_out = np.clip(cv.cvtColor(img_lab_out, cv.COLOR_Lab2BGR), 0, 1)
 
-        original_image = cv.resize(original_frame, imshowSize)
-        grayscale_image = cv.resize(frame, imshowSize)
-        colorize_image = (cv.resize(img_bgr_out, imshowSize) * 255).astype(np.uint8)
-        lab_image = (cv.resize(img_lab_out, imshowSize)).astype(np.uint8)
+        original_image = cv.resize(original_frame, imshow_size)
+        grayscale_image = cv.resize(frame, imshow_size)
+        colorize_image = (cv.resize(img_bgr_out, imshow_size) * 255).astype(np.uint8)
+        lab_image = cv.resize(img_lab_out, imshow_size).astype(np.uint8)
 
         original_image = cv.putText(original_image, 'Original', (25, 50),
                                     cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2, cv.LINE_AA)

--- a/demos/python_demos/image_inpainting_demo/inpainting_gui.py
+++ b/demos/python_demos/image_inpainting_demo/inpainting_gui.py
@@ -112,10 +112,10 @@ class InpaintingGUI:
         if self.is_original_shown:
             backbuffer = self.original_img.copy()
             sz = cv2.getTextSize("Original", cv2.FONT_HERSHEY_COMPLEX, 0.75, 1)[0]
-            imgWidth = backbuffer.shape[1]
-            labelArea = backbuffer[margin:sz[1]+pad*2+margin, imgWidth-margin-(sz[0]+pad*2):imgWidth-margin]
-            labelArea //= 2
-            cv2.putText(backbuffer, "Original", (imgWidth-margin-sz[0]-pad, margin+sz[1]+pad), cv2.FONT_HERSHEY_COMPLEX, 0.75, (128, 255, 128))
+            img_width = backbuffer.shape[1]
+            label_area = backbuffer[margin:sz[1]+pad*2+margin, img_width-margin-(sz[0]+pad*2):img_width-margin]
+            label_area //= 2
+            cv2.putText(backbuffer, "Original", (img_width-margin-sz[0]-pad, margin+sz[1]+pad), cv2.FONT_HERSHEY_COMPLEX, 0.75, (128, 255, 128))
         else:
             backbuffer = self.img.copy()
             backbuffer[np.squeeze(self.mask, -1) > 0] = self.mask_color
@@ -124,10 +124,10 @@ class InpaintingGUI:
             lines = self.label.split("\n")
             count = len(lines)
             w = max(cv2.getTextSize(line, cv2.FONT_HERSHEY_COMPLEX, 0.75, 1)[0][0] for line in lines) + pad*2
-            lineH = cv2.getTextSize(lines[0], cv2.FONT_HERSHEY_COMPLEX, 0.75, 1)[0][1] + pad
-            labelArea = backbuffer[margin:lineH*count+pad*2+margin, margin:w+margin]
-            labelArea //= 2
+            line_h = cv2.getTextSize(lines[0], cv2.FONT_HERSHEY_COMPLEX, 0.75, 1)[0][1] + pad
+            label_area = backbuffer[margin:line_h*count+pad*2+margin, margin:w+margin]
+            label_area //= 2
             for i, line in enumerate(lines):
-                cv2.putText(backbuffer, line, (pad+margin, margin+(i+1)*lineH), cv2.FONT_HERSHEY_COMPLEX, 0.75, (192, 192, 192))
+                cv2.putText(backbuffer, line, (pad+margin, margin+(i+1)*line_h), cv2.FONT_HERSHEY_COMPLEX, 0.75, (192, 192, 192))
 
         cv2.imshow(self.wnd_name, backbuffer)

--- a/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
+++ b/demos/python_demos/object_detection_demo_yolov3_async/object_detection_demo_yolov3_async.py
@@ -92,18 +92,18 @@ class YoloParams:
                         198.0,
                         373.0, 326.0] if 'anchors' not in param else [float(a) for a in param['anchors'].split(',')]
 
-        self.isYoloV3 = False
+        self.is_yolo_v3 = False
 
         if param.get('mask'):
             mask = [int(idx) for idx in param['mask'].split(',')]
             self.num = len(mask)
 
-            maskedAnchors = []
+            masked_anchors = []
             for idx in mask:
-                maskedAnchors += [self.anchors[idx * 2], self.anchors[idx * 2 + 1]]
-            self.anchors = maskedAnchors
+                masked_anchors += [self.anchors[idx * 2], self.anchors[idx * 2 + 1]]
+            self.anchors = masked_anchors
 
-            self.isYoloV3 = True # Weak way to determine but the only one.
+            self.is_yolo_v3 = True # Weak way to determine but the only one.
 
 
 class Modes(Enum):
@@ -149,7 +149,7 @@ def parse_yolo_region(predictions, resized_image_shape, original_im_shape, param
     orig_im_h, orig_im_w = original_im_shape
     resized_image_h, resized_image_w = resized_image_shape
     objects = list()
-    size_normalizer = (resized_image_w, resized_image_h) if params.isYoloV3 else (params.side, params.side)
+    size_normalizer = (resized_image_w, resized_image_h) if params.is_yolo_v3 else (params.side, params.side)
     bbox_size = params.coords + 1 + params.classes
     # ------------------------------------------- Parsing YOLO Region output -------------------------------------------
     for row, col, n in np.ndindex(params.side, params.side, params.num):

--- a/demos/python_demos/speech_recognition_demo/utils/audio_features.py
+++ b/demos/python_demos/speech_recognition_demo/utils/audio_features.py
@@ -178,7 +178,7 @@ def dct_compute(worked_filter, input_length, dct_coefficient_count, cosine):
 
 def mfcc(spectrogram, sample_rate, dct_coefficient_count):
     audio_channels, spectrogram_samples, spectrogram_channels  = spectrogram.shape
-    kFilterbankFloor = 1e-12
+    filterbank_floor = 1e-12
     filterbank_channel_count = 40
 
     mfcc_output = np.zeros((spectrogram_samples, dct_coefficient_count))
@@ -195,8 +195,8 @@ def mfcc(spectrogram, sample_rate, dct_coefficient_count):
             )
             for k in range(mel_filter.shape[0]):
                 val = mel_filter[k]
-                if val < kFilterbankFloor:
-                    val = kFilterbankFloor
+                if val < filterbank_floor:
+                    val = filterbank_floor
 
                 mel_filter[k] = np.log(val)
 


### PR DESCRIPTION
This gets rid of all camelCase variable names other than those in the monitors module. Which I think we should fix too, but that's a more involved change, so I'm putting it off.