### PR TITLE
faceboxes-pytorch: use human-friendly names for outputs

### DIFF
--- a/models/public/faceboxes-pytorch/accuracy-check.yml
+++ b/models/public/faceboxes-pytorch/accuracy-check.yml
@@ -5,8 +5,8 @@ models:
       - framework: dlsdk
         adapter:
           type: faceboxes
-          boxes_out: "342"
-          scores_out: "353"
+          boxes_out: "boxes"
+          scores_out: "scores"
 
     datasets:
       - name: wider

--- a/models/public/faceboxes-pytorch/faceboxes-pytorch.md
+++ b/models/public/faceboxes-pytorch/faceboxes-pytorch.md
@@ -55,13 +55,13 @@ Image, name - `input.1` , shape - [1x3x1024x1024], format [BxCxHxW],
 
 ### Original model
 
-1. Bounding boxes deltas , name: `342`, shape - [1x21824x4]. Presented in format [BxAx4],
+1. Bounding boxes deltas , name: `boxes`, shape - [1x21824x4]. Presented in format [BxAx4],
     where:
 
     - B - batch size
     - A - number of prior box anchors
 
-2. Scores, name: `353`, shape - [1x21824x2]. Contains scores for 2 classes - the first is background, the second is face.
+2. Scores, name: `scores`, shape - [1x21824x2]. Contains scores for 2 classes - the first is background, the second is face.
 
 ### Converted model
 

--- a/models/public/faceboxes-pytorch/model.yml
+++ b/models/public/faceboxes-pytorch/model.yml
@@ -37,13 +37,13 @@ conversion_to_onnx_args:
   - --weights=$dl_dir/FaceBoxesProd.pth
   - --input-shape=1,3,1024,1024
   - --input-names=input.1
-  - --output-names=342,353
+  - --output-names=boxes,scores
   - --output-file=$conv_dir/faceboxes-pytorch.onnx
 model_optimizer_args:
   - --input_shape=[1,3,1024,1024]
   - --input=input.1
   - --input_model=$conv_dir/faceboxes-pytorch.onnx
   - --mean_values=input.1[104.0,117.0,123.0]
-  - --output=342,353
+  - --output=boxes,scores
 framework: pytorch
 license: https://github.com/zisianw/FaceBoxes.PyTorch/blob/master/LICENSE


### PR DESCRIPTION
I don't see any advantage in using numeric names, and it has a disadvantage: PyTorch fails to export the model to ONNX if opset is set to version 11 (presumably numeric names are disallowed). So replace them with descriptive names.

The demo doesn't seem to care what the names are, so I'm not modifying it.