### PR TITLE
Fix issues found by yamllint

### DIFF
--- a/models/intel/vehicle-detection-0203/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0203/accuracy-check.yml
@@ -4,7 +4,7 @@ models:
     launchers:
       - framework: dlsdk
         adapter:
-           type: class_agnostic_detection
+          type: class_agnostic_detection
 
     datasets:
       - name: crossroad_extra_untagged_vehicle_labels_from_1
@@ -14,7 +14,7 @@ models:
             dst_height: 800
         postprocessing:
           - type: resize_prediction_boxes
-            rescale: True 
+            rescale: True
           - type: clip_boxes
             apply_to: prediction
         metrics:

--- a/models/intel/vehicle-detection-0204/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0204/accuracy-check.yml
@@ -4,7 +4,7 @@ models:
     launchers:
       - framework: dlsdk
         adapter:
-           type: class_agnostic_detection
+          type: class_agnostic_detection
     datasets:
       - name: crossroad_extra_untagged_vehicle_labels_from_1
         preprocessing:
@@ -13,7 +13,7 @@ models:
             dst_height: 800
         postprocessing:
           - type: resize_prediction_boxes
-            rescale: True 
+            rescale: True
           - type: clip_boxes
             apply_to: prediction
         metrics:

--- a/models/intel/vehicle-detection-0205/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0205/accuracy-check.yml
@@ -4,7 +4,7 @@ models:
     launchers:
       - framework: dlsdk
         adapter:
-           type: class_agnostic_detection
+          type: class_agnostic_detection
     datasets:
       - name: crossroad_extra_untagged_vehicle_labels_from_1
         preprocessing:
@@ -13,7 +13,7 @@ models:
             dst_height: 800
         postprocessing:
           - type: resize_prediction_boxes
-            rescale: True 
+            rescale: True
           - type: clip_boxes
             apply_to: prediction
         metrics:

--- a/models/public/googlenet-v3-pytorch/accuracy-check.yml
+++ b/models/public/googlenet-v3-pytorch/accuracy-check.yml
@@ -28,8 +28,6 @@ models:
             mean: 127.5
             std: 127.5
 
-            # Using accuracy metric, achieved result of public model - 77.45% and 93.56% (top 1 and top 5 respectively)
-
   - name: googlenet-v3-pytorch
 
     # list of launchers
@@ -53,5 +51,3 @@ models:
             use_pillow: true
           # Image channels must be swapped, because "pillow_imread" reads in RGB, but converted model expect BGR
           - type: rgb_to_bgr
-
-            # Using accuracy metric, achieved result of public model - 77.45% and 93.56% (top 1 and top 5 respectively)

--- a/models/public/googlenet-v3-pytorch/googlenet-v3-pytorch.md
+++ b/models/public/googlenet-v3-pytorch/googlenet-v3-pytorch.md
@@ -28,8 +28,8 @@ matching with those in the ImageNet database.
 
 | Metric | Value |
 | ------ | ----- |
-| Top 1  | 77.696%|
-| Top 5  | 93.696%|
+| Top 1  | 77.45%|
+| Top 5  | 93.56%|
 
 ## Performance
 

--- a/models/public/mobilenet-v2-pytorch/accuracy-check.yml
+++ b/models/public/mobilenet-v2-pytorch/accuracy-check.yml
@@ -37,8 +37,6 @@ models:
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
 
-            # Using accuracy metric, achieved result of public model - 71.8
-
   - name: mobilenet-v2-pytorch
 
     # list of launchers for MobileNetV2.
@@ -64,5 +62,3 @@ models:
 
           # Image channels must be swapped, because "pillow_imread" reads in RGB, but converted model expect BGR
           - type: rgb_to_bgr
-
-            # Using accuracy metric, achieved result of public model - 71.8


### PR DESCRIPTION
In case of the deleted comments, yamllint was complaining about indentation, and while I could've fixed it, we already have reference metric values in the documentation, so I don't think we need to duplicate them in the config.

In the case of `googlenet-v3-pytorch`, the values in the config were different from the ones in the documentation. I chose to replace the values in the doc with the ones from the config, because:

1. The torchvision documentation lists the same values;
2. I ran AC on this model, and the results are closer to these values than the ones that are currently listed in the doc.