### PR TITLE
Raise the ONNX opset version used for converting PyTorch models to 11

### DIFF
--- a/models/public/midasnet/model.yml
+++ b/models/public/midasnet/model.yml
@@ -43,10 +43,6 @@ framework: pytorch
 postprocessing:
   - $type: regex_replace
     file: models/blocks.py
-    pattern: 'align_corners=True'
-    replacement: 'align_corners=False'
-  - $type: regex_replace
-    file: models/blocks.py
     pattern: 'import torch.nn as nn'
     replacement: 'import torch.nn as nn\nimport torchvision.models as models'
   - $type: regex_replace

--- a/tools/downloader/pytorch_to_onnx.py
+++ b/tools/downloader/pytorch_to_onnx.py
@@ -98,7 +98,7 @@ def convert_to_onnx(model, input_shape, output_file, input_names, output_names):
     model.eval()
     dummy_input = torch.randn(input_shape)
     model(dummy_input)
-    torch.onnx.export(model, dummy_input, str(output_file), verbose=False, opset_version=9,
+    torch.onnx.export(model, dummy_input, str(output_file), verbose=False, opset_version=11,
                       input_names=input_names.split(','), output_names=output_names.split(','))
 
     model = onnx.load(str(output_file))


### PR DESCRIPTION
This has a few beneficial effects:

* it removes conversion warnings that used to be printed for several models about how certain layers don't work the same way in ONNX until opset 11;

* it allows us to remove one of the regex replacements in the midasnet model, which, I believe, was originally added to work around ONNX limitations;

* it allows us to add future models which require a newer opset.

I have run an accuracy check on all affected models (on CPU), and didn't see any degradation. midasnet actually improved, going from an RMSE of 0.08 to 0.07.