### PR TITLE
Model Quantizer: supply the dataset definitions file path to POT

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -33,7 +33,8 @@ import requests
 import yaml
 
 DOWNLOAD_TIMEOUT = 5 * 60
-MODEL_ROOT = Path(__file__).resolve().parents[2] / 'models'
+OMZ_ROOT = Path(__file__).resolve().parents[2]
+MODEL_ROOT = OMZ_ROOT / 'models'
 
 # make sure to update the documentation if you modify these
 KNOWN_FRAMEWORKS = {

--- a/tools/downloader/quantizer.py
+++ b/tools/downloader/quantizer.py
@@ -43,6 +43,8 @@ DEFAULT_POT_CONFIG_BASE = {
     },
 }
 
+DATASET_DEFINITIONS_PATH = common.OMZ_ROOT / 'tools/accuracy_checker/dataset_definitions.yml'
+
 def quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
     input_precision = common.KNOWN_QUANTIZED_PRECISIONS[precision]
 
@@ -174,6 +176,7 @@ def main():
         pot_env = {
             'ANNOTATIONS_DIR': str(annotation_dir),
             'DATA_DIR': str(args.dataset_dir),
+            'DEFINITIONS_FILE': str(DATASET_DEFINITIONS_PATH),
         }
 
         for model in models:


### PR DESCRIPTION
This used to not be necessary, because the Accuracy Checker configs used to refer to this file, so everything worked automatically. However, since !1129 the configs no longer reference this file, which broke the quantizer.

Set the `DEFINITIONS_FILE` environment variable explicitly to fix it.
