### PR TITLE
Bump minimal Python version to 3.6

### DIFF
--- a/ci/update-requirements.py
+++ b/ci/update-requirements.py
@@ -18,7 +18,7 @@ from pathlib import Path
 # Package dependencies can vary depending on the Python version.
 # We thus have to run pip-compile with the lowest Python version that
 # the project supports.
-EXPECTED_PYTHON_VERSION = (3, 5)
+EXPECTED_PYTHON_VERSION = (3, 6)
 
 repo_root = Path(__file__).resolve().parent.parent
 script_name = Path(__file__).name

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -214,7 +214,7 @@ list(REMOVE_ITEM samples_dirs common thirdparty)
 add_samples_to_build(${samples_dirs})
 
 if(ENABLE_PYTHON)
-    find_package(PythonInterp 3.5 REQUIRED)
+    find_package(PythonInterp 3.6 REQUIRED)
     find_package(PythonLibs "${PYTHON_VERSION_STRING}" EXACT REQUIRED)
 
     execute_process(

--- a/tools/accuracy_checker/requirements-test.in
+++ b/tools/accuracy_checker/requirements-test.in
@@ -4,7 +4,5 @@ pytest-mock~=2.0
 # pytest depends on atomicwrites, but only on Windows.
 # This means that if we use pip-compile on Linux, the resulting requirements.txt
 # will not include atomicwrites and thus will not work on Windows.
-# And we _can't_ use pip-compile on Windows, because sentencepiece does not have
-# Python 3.5 Windows wheels on PyPI.
 # So as a workaround, make the atomicwrites dependency unconditional.
 atomicwrites

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -114,7 +114,7 @@ setup(
             "convert_annotation=accuracy_checker.annotation_converters.convert:main",
     ]},
     zip_safe=False,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=requirements if not is_arm else '',
     tests_require=[read("requirements-test.in")],
     cmdclass={'test': PyTest, 'install_core': CoreInstall}

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -22,7 +22,7 @@ future releases.
 
 ## Prerequisites
 
-1. Install Python (version 3.5.2 or higher)
+1. Install Python (version 3.6 or higher)
 2. Install the tools' dependencies with the following command:
 
 ```sh
@@ -44,20 +44,6 @@ For models from Caffe2:
 ```sh
 python3 -mpip install --user -r ./requirements-caffe2.in
 ```
-
-When running the model downloader with Python 3.5.x on macOS, you may encounter
-an error similar to the following:
-
-> requests.exceptions.SSLError: [...] (Caused by SSLError(SSLError(1, '[SSL: TLSV1_ALERT_PROTOCOL_VERSION]
-tlsv1 alert protocol version (\_ssl.c:719)'),))
-
-You can work around this by installing additional packages:
-
-```sh
-python3 -mpip install --user 'requests[security]'
-```
-
-Alternatively, upgrade to Python 3.6 or a later version.
 
 ## Model downloader usage
 

--- a/tools/downloader/requirements-caffe2.in
+++ b/tools/downloader/requirements-caffe2.in
@@ -1,5 +1,2 @@
 future
 onnx
-
-# fix version in order to be compatible with requirements-pytorch.in
-torch<1.5

--- a/tools/downloader/requirements-pytorch.in
+++ b/tools/downloader/requirements-pytorch.in
@@ -1,6 +1,2 @@
 onnx
 scipy           # via torchvision
-
-# can't use higher versions because of https://github.com/pytorch/vision/issues/2132
-torch==1.4.*
-torchvision==0.5.*


### PR DESCRIPTION
Python 3.5 is EOL and OpenVINO doesn't support it anymore, so I don't think we need to support it either.

This removes the need to cap the PyTorch version, so don't do that anymore.

We also technically don't need the workaround with the forced `atomicwrites` requirement in `requirements-test.in` anymore, since now it should be possible to regenerate the `requirements-*.txt` files on Windows. I don't want to only be able to do it to Windows, though, so I'd rather keep the workaround.