### PR TITLE
AC: fix precision setting for compiled networks

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -866,11 +866,6 @@ class DLSDKLauncher(Launcher):
                         self.network.inputs[input_config['name']].precision = input_config['precision']
                     else:
                         self.network.input_info[input_config['name']].precision = input_config['precision']
-                else:
-                    if not has_info:
-                        self.exec_network.inputs[input_config['name']].precision = input_config['precision']
-                    else:
-                        self.exec_network.input_info[input_config['name']].precision = input_config['precision']
 
     def _configure_lstm_inputs(self):
         lstm_mapping = {}


### PR DESCRIPTION
compaled nets have constant input info, setting precision for this case leads to errors