### PR TITLE
tools/downloader: restore the PyTorch dependencies

### DIFF
--- a/tools/downloader/requirements-caffe2.in
+++ b/tools/downloader/requirements-caffe2.in
@@ -1,2 +1,3 @@
 future
 onnx
+torch

--- a/tools/downloader/requirements-pytorch.in
+++ b/tools/downloader/requirements-pytorch.in
@@ -1,2 +1,4 @@
 onnx
 scipy           # via torchvision
+torch>=1.4
+torchvision


### PR DESCRIPTION
I got a bit overzealous when I was removing the workarounds in 5cc0a7abae7d2f20c177025b6944d3de1c1bb231.