### PR TITLE
AC: metrics ignoring for quantization POC

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/asr_encoder_decoder_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/asr_encoder_decoder_evaluator.py
@@ -64,6 +64,7 @@ class AutomaticSpeechRecognitionEvaluator(BaseEvaluator):
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs):
         if self.dataset is None or (dataset_tag and self.dataset.tag != dataset_tag):
             self.select_dataset(dataset_tag)
@@ -95,7 +96,7 @@ class AutomaticSpeechRecognitionEvaluator(BaseEvaluator):
                 batch_identifiers, batch_inputs_extr, encoder_callback=encoder_callback
             )
             metrics_result = None
-            if self.metric_executor:
+            if self.metric_executor and calculate_metrcis:
                 metrics_result, _ = self.metric_executor.update_metrics_on_batch(
                     batch_input_ids, batch_annotation, batch_prediction
                 )

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/colorization_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/colorization_evaluator.py
@@ -90,7 +90,8 @@ class ColorizationEvaluator(BaseEvaluator):
             dataset_tag='',
             output_callback=None,
             allow_pairwise_subset=False,
-            dump_prediction_to_annotgiation=False,
+            dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs):
 
         if self.dataset is None or (dataset_tag and self.dataset.tag != dataset_tag):

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/mtcnn_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/mtcnn_evaluator.py
@@ -621,6 +621,7 @@ class MTCNNEvaluator(BaseEvaluator):
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs):
         def no_detections(batch_pred):
             return batch_pred[0].size == 0

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/sequential_action_recognition_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/sequential_action_recognition_evaluator.py
@@ -64,6 +64,7 @@ class SequentialActionRecognitionEvaluator(BaseEvaluator):
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs):
         if self.dataset is None or (dataset_tag and self.dataset.tag != dataset_tag):
             self.select_dataset(dataset_tag)
@@ -95,7 +96,7 @@ class SequentialActionRecognitionEvaluator(BaseEvaluator):
                 batch_identifiers, batch_inputs_extr, encoder_callback=encoder_callback
             )
             metrics_result = None
-            if self.metric_executor:
+            if self.metric_executor and calculate_metrics:
                 metrics_result, _ = self.metric_executor.update_metrics_on_batch(
                     batch_input_ids, batch_annotation, batch_prediction
                 )

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_spotting_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_spotting_evaluator.py
@@ -63,6 +63,7 @@ class TextSpottingEvaluator(BaseEvaluator):
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs):
         self._prepare_dataset(dataset_tag)
         self._create_subset(subset, num_images, allow_pairwise_subset)
@@ -92,7 +93,7 @@ class TextSpottingEvaluator(BaseEvaluator):
                 batch_identifiers, batch_data, batch_meta, callback=temporal_output_callback
             )
             metrics_result = None
-            if self.metric_executor:
+            if self.metric_executor and calculate_metrics:
                 metrics_result, _ = self.metric_executor.update_metrics_on_batch(
                     batch_input_ids, batch_annotation, batch_prediction
                 )

--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -90,6 +90,7 @@ class ModelEvaluator:
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs
     ):
 
@@ -121,6 +122,7 @@ class ModelEvaluator:
                 output_callback,
                 allow_pairwise_subset,
                 dump_prediction_to_annotation,
+                calculate_metrics,
                 **kwargs
             )
 
@@ -163,7 +165,7 @@ class ModelEvaluator:
                                 annotations.append(generated_annotation)
                         self._dumped_annotations.extend(annotations)
                     metrics_result = None
-                    if self.metric_executor:
+                    if self.metric_executor and calculate_metrics:
                         metrics_result, _ = self.metric_executor.update_metrics_on_batch(
                             batch_input_ids, annotations, predictions
                         )
@@ -235,6 +237,7 @@ class ModelEvaluator:
             output_callback=None,
             allow_pairwise_subset=False,
             dump_prediction_to_annotation=False,
+            calculate_metrics=True,
             **kwargs
     ):
 
@@ -266,7 +269,7 @@ class ModelEvaluator:
                         annotations.append(generated_annotation)
                 self._dumped_annotations.extend(annotations)
             metrics_result = None
-            if self.metric_executor:
+            if self.metric_executor and calculate_metrics:
                 metrics_result, _ = self.metric_executor.update_metrics_on_batch(
                     batch_input_ids, annotations, predictions
                 )

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -114,7 +114,7 @@ setup(
             "convert_annotation=accuracy_checker.annotation_converters.convert:main",
     ]},
     zip_safe=False,
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     install_requires=requirements if not is_arm else '',
     tests_require=[read("requirements-test.in")],
     cmdclass={'test': PyTest, 'install_core': CoreInstall}


### PR DESCRIPTION
AC pipeline is always calculate metrics however sometimes they should be not used. Generally it is low-time-cost for metrics calculation, but with growth of the number supported metrics., it is not always true.

Proposed opportunity to turn off metrics calculation in quantization flow.