### PR TITLE
Add missing override qualifiers

### DIFF
--- a/demos/gaze_estimation_demo/include/eye_state_estimator.hpp
+++ b/demos/gaze_estimation_demo/include/eye_state_estimator.hpp
@@ -18,9 +18,9 @@ public:
     EyeStateEstimator(InferenceEngine::Core& ie,
                       const std::string& modelPath,
                       const std::string& deviceName);
-    void virtual estimate(const cv::Mat& image, FaceInferenceResults& outputResults);
-    void virtual printPerformanceCounts() const;
-    virtual ~EyeStateEstimator();
+    void estimate(const cv::Mat& image, FaceInferenceResults& outputResults) override;
+    void printPerformanceCounts() const override;
+    ~EyeStateEstimator() override;
 
 private:
     cv::Rect createEyeBoundingBox(const cv::Point2i& p1, const cv::Point2i& p2, float scale = 1.8) const;

--- a/demos/gaze_estimation_demo/include/gaze_estimator.hpp
+++ b/demos/gaze_estimation_demo/include/gaze_estimator.hpp
@@ -19,10 +19,10 @@ public:
                   const std::string& modelPath,
                   const std::string& deviceName,
                   bool doRollAlign = true);
-    void virtual estimate(const cv::Mat& image,
-                          FaceInferenceResults& outputResults);
-    void virtual printPerformanceCounts() const;
-    virtual ~GazeEstimator();
+    void estimate(const cv::Mat& image,
+                  FaceInferenceResults& outputResults) override;
+    void printPerformanceCounts() const override;
+    ~GazeEstimator() override;
 
 private:
     IEWrapper ieWrapper;

--- a/demos/gaze_estimation_demo/include/head_pose_estimator.hpp
+++ b/demos/gaze_estimation_demo/include/head_pose_estimator.hpp
@@ -18,10 +18,10 @@ public:
     HeadPoseEstimator(InferenceEngine::Core& ie,
                       const std::string& modelPath,
                       const std::string& deviceName);
-    void virtual estimate(const cv::Mat& image,
-                          FaceInferenceResults& outputResults);
-    void virtual printPerformanceCounts() const;
-    virtual ~HeadPoseEstimator();
+    void estimate(const cv::Mat& image,
+                  FaceInferenceResults& outputResults) override;
+    void printPerformanceCounts() const override;
+    ~HeadPoseEstimator() override;
 
 private:
     IEWrapper ieWrapper;

--- a/demos/gaze_estimation_demo/include/landmarks_estimator.hpp
+++ b/demos/gaze_estimation_demo/include/landmarks_estimator.hpp
@@ -18,10 +18,10 @@ public:
     LandmarksEstimator(InferenceEngine::Core& ie,
                        const std::string& modelPath,
                        const std::string& deviceName);
-    void virtual estimate(const cv::Mat& image,
-                          FaceInferenceResults& outputResults);
-    void virtual printPerformanceCounts() const;
-    virtual ~LandmarksEstimator();
+    void estimate(const cv::Mat& image,
+                  FaceInferenceResults& outputResults) override;
+    void printPerformanceCounts() const override;
+    ~LandmarksEstimator() override;
 
 private:
     IEWrapper ieWrapper;

--- a/demos/human_pose_estimation_demo/src/human_pose_estimator.cpp
+++ b/demos/human_pose_estimation_demo/src/human_pose_estimator.cpp
@@ -225,7 +225,7 @@ public:
           minPeaksDistance(minPeaksDistance),
           peaksFromHeatMap(peaksFromHeatMap) {}
 
-    virtual void operator()(const cv::Range& range) const {
+    void operator()(const cv::Range& range) const override {
         for (int i = range.start; i < range.end; i++) {
             findPeaks(heatMaps, minPeaksDistance, peaksFromHeatMap, i);
         }

--- a/demos/multi_channel/common/input.cpp
+++ b/demos/multi_channel/common/input.cpp
@@ -177,7 +177,7 @@ public:
         return running;
     }
 
-    void start() {
+    void start() override {
         running = true;
         workThread = std::thread([&]() {
             while (running) {
@@ -224,7 +224,7 @@ public:
         }
     }
 
-    bool read(VideoFrame& frame)  {
+    bool read(VideoFrame& frame) override {
         queue_elem_t elem;
 
         if (!running)
@@ -244,7 +244,7 @@ public:
         return elem.first && running;
     }
 
-    float getAvgReadTime() const {
+    float getAvgReadTime() const override {
         return perfTimer.getValue();
     }
 };
@@ -279,18 +279,18 @@ public:
     GeneralCaptureSource(bool async, bool collectStats_, const std::string& name, bool loopVideo,
                 size_t queueSize_, size_t pollingTimeMSec_, bool realFps_);
 
-    ~GeneralCaptureSource();
+    ~GeneralCaptureSource() override;
 
-    void start();
+    void start() override;
 
     bool isRunning() const override;
 
     void stop();
 
     bool read(cv::Mat& frame);
-    bool read(VideoFrame& frame);
+    bool read(VideoFrame& frame) override;
 
-    float getAvgReadTime() const {
+    float getAvgReadTime() const override {
         return perfTimer.getValue();
     }
 
@@ -328,15 +328,15 @@ public:
            const std::string& source, const mcam::camera::settings& settings,
            size_t queueSize, bool realFps, bool collectStats);
 
-    ~VideoSourceNative();
+    ~VideoSourceNative() override;
 
-    void start();
+    void start() override;
 
     bool isRunning() const override;
 
-    bool read(VideoFrame& frame);
+    bool read(VideoFrame& frame) override;
 
-    float getAvgReadTime() const {
+    float getAvgReadTime() const override {
         return perfTimer.getValue();
     }
 };

--- a/demos/multi_channel/human_pose_estimation_demo/postprocess.cpp
+++ b/demos/multi_channel/human_pose_estimation_demo/postprocess.cpp
@@ -29,7 +29,7 @@ public:
           minPeaksDistance(minPeaksDistance),
           peaksFromHeatMap(peaksFromHeatMap) {}
 
-    virtual void operator()(const cv::Range& range) const {
+    void operator()(const cv::Range& range) const override {
         for (int i = range.start; i < range.end; i++) {
             findPeaks(heatMaps, minPeaksDistance, peaksFromHeatMap, i);
         }

--- a/demos/pedestrian_tracker_demo/include/descriptor.hpp
+++ b/demos/pedestrian_tracker_demo/include/descriptor.hpp
@@ -121,7 +121,7 @@ public:
     /// \brief Descriptor size getter.
     /// \return Descriptor size.
     ///
-    virtual cv::Size size() const {
+    cv::Size size() const override {
         return cv::Size(1, handler.size());
     }
 
@@ -130,7 +130,7 @@ public:
     /// \param[in] mat Color image.
     /// \param[out] descr Computed descriptor.
     ///
-    virtual void Compute(const cv::Mat &mat, cv::Mat *descr) {
+    void Compute(const cv::Mat &mat, cv::Mat *descr) override {
         handler.Compute(mat, descr);
     }
 
@@ -139,12 +139,12 @@ public:
     /// \param[in] mats Images of interest.
     /// \param[out] descrs Matrices to store the computed descriptors.
     ///
-    virtual void Compute(const std::vector<cv::Mat> &mats,
-                         std::vector<cv::Mat> *descrs) {
+    void Compute(const std::vector<cv::Mat> &mats,
+                 std::vector<cv::Mat> *descrs) override {
         handler.Compute(mats, descrs);
     }
 
-    virtual void PrintPerformanceCounts(std::string fullDeviceName) const {
+    void PrintPerformanceCounts(std::string fullDeviceName) const override {
         handler.PrintPerformanceCounts(fullDeviceName);
     }
 };

--- a/demos/smart_classroom_demo/main.cpp
+++ b/demos/smart_classroom_demo/main.cpp
@@ -501,7 +501,7 @@ public:
     }
 
     void PrintPerformanceCounts(
-            const std::string &landmarks_device, const std::string &reid_device) {
+            const std::string &landmarks_device, const std::string &reid_device) override {
         landmarks_detector.PrintPerformanceCounts(landmarks_device);
         face_reid.PrintPerformanceCounts(reid_device);
     }


### PR DESCRIPTION
This is a) a good thing to do, and b) fixes a failure to build on macOS, because Clang has `-Winconsistent-missing-override` as part of `-Wall`, and so, thanks to `-Werror`, fails to compile `demos/multi_channel/common/input.cpp`.

I'd like to add `-Wsuggest-override` to compiler options, but we still have to support CentOS 7, and the version of GCC in there doesn't have it.