### PR TITLE
mobilenet-v2-pytorch: switch to the torchvision implementation

### DIFF
--- a/models/public/mobilenet-v2-pytorch/mobilenet-v2-pytorch.md
+++ b/models/public/mobilenet-v2-pytorch/mobilenet-v2-pytorch.md
@@ -15,8 +15,6 @@ matching with those in the ImageNet database.
 
 ## Example
 
-See [here](https://github.com/tonylins/pytorch-mobilenet-v2)
-
 ## Specification
 
 | Metric            | Value         |
@@ -30,8 +28,8 @@ See [here](https://github.com/tonylins/pytorch-mobilenet-v2)
 
 | Metric | Original model | Converted model |
 |--------|----------------|-----------------|
-| Top 1  | 71.8%          | 71.8%           |
-| Top 5  | 90.396%          | 90.396%       |
+| Top 1  | 71.9%          | 71.9%           |
+| Top 5  | 90.3%          | 90.3%           |
 
 ## Performance
 
@@ -78,6 +76,37 @@ Object classifier according to ImageNet classes, name - `prob`,  shape - `1,1000
 
 ## Legal Information
 
-The original model is distributed under the
-[Apache License, Version 2.0](https://raw.githubusercontent.com/tonylins/pytorch-mobilenet-v2/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+The original model is distributed under the following
+[license](https://raw.githubusercontent.com/pytorch/vision/master/LICENSE):
+
+```
+BSD 3-Clause License
+
+Copyright (c) Soumith Chintala 2016,
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/models/public/mobilenet-v2-pytorch/model.yml
+++ b/models/public/mobilenet-v2-pytorch/model.yml
@@ -25,22 +25,15 @@ description: >-
   matching with those in the ImageNet database.
 task_type: classification
 files:
-  - name: MobileNetV2.py
-    size: 4213
-    sha256: 7071e01e07e5f1b6127a2628d1be9c65cc20edfa745f4f4eb6354e7b27f5b444
-    source: https://raw.githubusercontent.com/tonylins/pytorch-mobilenet-v2/fa86a85e4026caa217fe8d62f370848195cedf4b/MobileNetV2.py
-  - name: mobilenet-v2.pth
-    sha256: ecbe2b568c8602549fa9e1d5833c63848f490a48d92e5d224d1eb2063e152cf8
-    size: 14205652
-    source:
-      $type: google_drive
-      id: 1jlto6HRVD3ipNkAl1lNhDbkBp7HylaqR
+  - name: mobilenet_v2-b0353104.pth
+    size: 14212972
+    sha256: b03531047ffacf1e2488318dcd2aba1126cde36e3bfe1aa5cb07700aeeee9889
+    source: https://download.pytorch.org/models/mobilenet_v2-b0353104.pth
 framework: pytorch
 conversion_to_onnx_args:
-  - --model-name=MobileNetV2
-  - --model-path=$dl_dir
-  - --weights=$dl_dir/mobilenet-v2.pth
-  - --import-module=MobileNetV2
+  - --model-name=mobilenet_v2
+  - --weights=$dl_dir/mobilenet_v2-b0353104.pth
+  - --import-module=torchvision.models
   - --input-shape=1,3,224,224
   - --output-file=$conv_dir/mobilenet-v2.onnx
   - --input-names=data
@@ -53,4 +46,4 @@ model_optimizer_args:
   - --output=prob
   - --input_model=$conv_dir/mobilenet-v2.onnx
 quantizable: yes
-license: https://raw.githubusercontent.com/tonylins/pytorch-mobilenet-v2/master/LICENSE
+license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE


### PR DESCRIPTION
It's the exact same topology, and, although the weights are different, it has nearly the same accuracy metrics. However, its weights are hosted on PyTorch's website rather than the author's personal Google Drive, so I think they're less likely to vanish in the future.