### PR TITLE
downloader: update the list of representative models

### DIFF
--- a/tools/downloader/tests/representative-models.lst
+++ b/tools/downloader/tests/representative-models.lst
@@ -1,9 +1,9 @@
 # A list of models that covers all Model Downloader/Converter features
 
+faceboxes-pytorch # PyTorch (external module), Google Drive downloads, --model-param
 mobilenet-v1-0.25-128 # TensorFlow, HTTP downloads
-mobilenet-v2-pytorch # PyTorch (external module), Google Drive downloads
+mobilenet-v2-pytorch # PyTorch (torchvision)
 mtcnn-p # Caffe, HTTPS downloads, regex replacement
 octave-densenet-121-0.125 # MXNet, archive unpacking
 resnet-50-caffe2 # Caffe2
-resnet-50-pytorch # PyTorch (torchvision)
 single-image-super-resolution-1032 # DLDT


### PR DESCRIPTION
`mobilenet-v2-pytorch` can no longer be used to test external module support, because we've recently replaced it with the equivalent torchvision model. However, it _can_ be used to test torchvision support, and it's a better representative for that than `resnet-50-tf`, due to being much smaller.

Its replacement will be `faceboxes-pytorch`, because it's very small and yet covers external modules, Google Drive downloads and even custom model parameters.