### PR TITLE
hrnet-v2-c1-segmentation: use a custom model creation module instead of patches

### DIFF
--- a/models/public/hrnet-v2-c1-segmentation/model.py
+++ b/models/public/hrnet-v2-c1-segmentation/model.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch.nn
+
+from mit_semseg.models import SegmentationModule, ModelBuilder
+
+class HrnetV2C1(torch.nn.Module):
+    def __init__(self, encoder_weights, decoder_weights):
+        super().__init__()
+        self.impl = SegmentationModule(
+            net_enc=ModelBuilder.build_encoder(
+                arch="hrnetv2", fc_dim=720, weights=encoder_weights),
+            net_dec=ModelBuilder.build_decoder(
+                arch="c1", fc_dim=720, num_class=150, weights=decoder_weights, use_softmax=True),
+            crit=None,
+        )
+
+    def forward(self, image):
+        return self.impl({'img_data': image}, segSize=320)

--- a/models/public/hrnet-v2-c1-segmentation/model.yml
+++ b/models/public/hrnet-v2-c1-segmentation/model.yml
@@ -95,33 +95,15 @@ files:
     size: 262518297
     sha256: 0bba1a5da1484b21a42f89e05459e434119c829d6aae64d1c6d3ae0c38d2b43c
     source: http://sceneparsing.csail.mit.edu/model/pytorch/ade20k-hrnetv2-c1/encoder_epoch_30.pth
-postprocessing:
-  - $type: regex_replace
-    file: mit_semseg/models/models.py
-    pattern: 'segSize=None'
-    replacement: 'segSize=320'
-  - $type: regex_replace
-    file: mit_semseg/models/models.py
-    pattern: 'feed_dict\[\Wimg_data\W\]'
-    replacement: 'feed_dict'
-  - $type: regex_replace
-    file: mit_semseg/models/models.py
-    pattern: '= net_enc'
-    replacement: '= eval(net_enc)'
-  - $type: regex_replace
-    file: mit_semseg/models/models.py
-    pattern: '= net_dec'
-    replacement: '= eval(net_dec)'
 conversion_to_onnx_args:
+  - --model-path=$config_dir
   - --model-path=$dl_dir
-  - --model-name=SegmentationModule
-  - --import-module=mit_semseg.models
+  - --model-name=HrnetV2C1
+  - --import-module=model
   - --input-shape=1,3,320,320
   - --output-file=$conv_dir/hrnet-v2-c1-segmentation.onnx
-  - --model-param=net_enc=r'ModelBuilder.build_encoder("hrnetv2", 720, r"$dl_dir/ckpt/encoder_epoch_30.pth")'
-  - --model-param=net_dec=r'ModelBuilder.build_decoder("c1", 720, 150, r"$dl_dir/ckpt/decoder_epoch_30.pth",
-    True)'
-  - --model-param=crit=None
+  - --model-param=encoder_weights=r"$dl_dir/ckpt/encoder_epoch_30.pth"
+  - --model-param=decoder_weights=r"$dl_dir/ckpt/decoder_epoch_30.pth"
   - --input-names=data
   - --output-names=prob
 model_optimizer_args:


### PR DESCRIPTION
Put all the code needed to create the model into a source file, instead of splitting it into little regex patches and model arguments. This makes model configuration more readable.

This approach should also be helpful for any future models which cannot be easily created purely by supplying simple arguments to the constructor.
