### PR TITLE
pytorch_to_onnx.py: fix the definitions of --input-names and --output-names

### DIFF
--- a/tools/downloader/pytorch_to_onnx.py
+++ b/tools/downloader/pytorch_to_onnx.py
@@ -59,10 +59,10 @@ def parse_args():
                         help='Path to PyTorch model\'s source code')
     parser.add_argument('--import-module', type=str, required=True,
                         help='Name of module, which contains model\'s constructor')
-    parser.add_argument('--input-names', type=str, metavar='L[,L...]',
-                        help='Space separated names of the input layers')
-    parser.add_argument('--output-names', type=str, metavar='L[,L...]',
-                        help='Space separated names of the output layers')
+    parser.add_argument('--input-names', type=str, metavar='L[,L...]', required=True,
+                        help='Comma-separated names of the input layers')
+    parser.add_argument('--output-names', type=str, metavar='L[,L...]', required=True,
+                        help='Comma-separated names of the output layers')
     parser.add_argument('--model-param', type=model_parameter, default=[], action='append',
                         help='Pair "name"="value" of model constructor parameter')
     return parser.parse_args()


### PR DESCRIPTION
1. Mark them as required, because they are; the script won't work without them.
2. Describe the values correctly in the description.