### PR TITLE
AC: correct image files search in inpainting and style transfer case

### DIFF
--- a/models/public/resnet-50-pytorch/accuracy-check.yml
+++ b/models/public/resnet-50-pytorch/accuracy-check.yml
@@ -44,7 +44,6 @@ models:
     launchers:
       - framework: dlsdk
         adapter: classification
-        model: /media/automation/omz_validation_datasets/users/eaidova/kmb_fp16/resnet-50-pytorch/caffe2/FP16/resnet-50-pytorch.xml
 
     datasets:
       - name: imagenet_1000_classes

--- a/models/public/resnet-50-pytorch/accuracy-check.yml
+++ b/models/public/resnet-50-pytorch/accuracy-check.yml
@@ -44,6 +44,7 @@ models:
     launchers:
       - framework: dlsdk
         adapter: classification
+        model: /media/automation/omz_validation_datasets/users/eaidova/kmb_fp16/resnet-50-pytorch/caffe2/FP16/resnet-50-pytorch.xml
 
     datasets:
       - name: imagenet_1000_classes

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/inpainting.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/inpainting.py
@@ -48,9 +48,15 @@ class InpaintingConverter(BaseFormatConverter):
         content_check_errors = [] if check_content else None
 
         annotations = []
-        images = list(im for im in self.image_dir.iterdir())
+        images = [
+            im for im in self.image_dir.iterdir()
+            if im.name.lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'))
+            ]
         if self.masks_dir is not None:
-            masks = list(mask for mask in self.masks_dir.iterdir())
+            masks = [
+                mask for mask in self.masks_dir.iterdir()
+                if mask.name.endswith('.npy')
+            ]
             if len(masks) < len(images):
                 warning('Number of masks is smaller than number of images.'
                         'Only {} first images will be used'.format(len(masks)))

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/style_transfer.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/style_transfer.py
@@ -40,7 +40,10 @@ class StyleTransferConverter(BaseFormatConverter):
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
         content_check_errors = [] if check_content else None
         annotations = []
-        images = list(im for im in self.image_dir.iterdir())
+        images = [
+            im for im in self.image_dir.iterdir()
+            if im.name.lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif'))
+        ]
         for image in images:
             identifiers = image.name
             annotation = StyleTransferAnnotation(identifiers, image.name)


### PR DESCRIPTION
the pipeline expects that in directory stored only images, however in some case this directory can contains other files (e.g. annotation file used in another task), so usage iterdir in this case is unsafe. Added check file extension