### PR TITLE
AC: Show a more useful context when emitting a warning

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/logging.py
+++ b/tools/accuracy_checker/accuracy_checker/logging.py
@@ -108,7 +108,7 @@ def exception(exc, *args, **kwargs):
 
 def warning(msg, *args, raise_warning=True, **kwargs):
     if raise_warning:
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
     else:
         _default_logger.warning(msg, *args, **kwargs)
 


### PR DESCRIPTION
Currently, the context shown is the `warning` function itself. Show its caller instead.