### PR TITLE
Add command line input option to specifiy model root path

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -551,6 +551,9 @@ def load_models(args):
     models = []
     model_names = set()
 
+    if args.model_root is not None:
+        MODEL_ROOT = Path(args.model_root)
+
     for config_path in sorted(MODEL_ROOT.glob('**/model.yml')):
         subdirectory = config_path.parent.relative_to(MODEL_ROOT)
 

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -78,7 +78,9 @@ def main():
         help='Print the conversion commands without running them')
     parser.add_argument('-j', '--jobs', type=num_jobs_arg, default=1,
         help='number of conversions to run concurrently')
-
+    parser.add_argument('--model_root', type=Path, default=None,
+        help='path to models folder')
+    
     # aliases for backwards compatibility
     parser.add_argument('--add-mo-arg', dest='extra_mo_args', action='append', help=argparse.SUPPRESS)
     parser.add_argument('--dry-run', action='store_true', help=argparse.SUPPRESS)

--- a/tools/downloader/downloader.py
+++ b/tools/downloader/downloader.py
@@ -311,6 +311,8 @@ def main():
     # relation to the optimal number of concurrent downloads
     parser.add_argument('-j', '--jobs', type=positive_int_arg, metavar='N', default=1,
         help='how many downloads to perform concurrently')
+    parser.add_argument('--model_root', type=Path, default=None,
+        help='path to models folder')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Added CLI option to specify path to a custom model zoo, for example if the user has a model collection in `~/mymodels/...`
Usage example:
`./downloader.py --model_root ~/mymodels/ ...`