### PR TITLE
Add CMake option to specify demos to build

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -121,7 +121,7 @@ function(add_samples_to_build)
                 if (BUILD_SAMPLE_NAME)
                     list(FIND BUILD_SAMPLE_NAME ${dir} index)
                 endif()
-                if ((index EQUAL -1 OR NOT dir IN_LIST DEMOS_LIST) AND NOT DEMOS STREQUAL "ALL")
+                if (index EQUAL -1 OR (NOT dir IN_LIST DEMOS_LIST AND NOT DEMOS STREQUAL "ALL"))
                     message(STATUS "${dir} SKIPPED")
                 else()
                     # Include subdirectory to the project.

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -8,7 +8,7 @@ project(Demos)
 
 option(ENABLE_PYTHON "Whether to build extension modules for Python demos" OFF)
 
-set(DEMOS "ALL" CACHE STRING "Specify demo to build using comma(ex. -DSPECIFIC_DEMOS classification_demo, text_detection_demo), Default is ALL")
+set(DEMOS "ALL" CACHE STRING "Specify demo to build using comma(ex. -DDEMOS=classification_demo,text_detection_demo). Default is ALL")
 string(REPLACE "," ";" DEMOS_LIST ${DEMOS})
 
 if (CMAKE_BUILD_TYPE STREQUAL "")
@@ -126,7 +126,7 @@ function(add_samples_to_build)
                 else()
                     # Include subdirectory to the project.
                     add_subdirectory(${dir})
-                    # message(STATUS "${dir} INCLUDED TO BUILD")
+                    message(STATUS "${dir} INCLUDED TO BUILD")
                 endif()
             endif()
         endif()

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -8,9 +8,6 @@ project(Demos)
 
 option(ENABLE_PYTHON "Whether to build extension modules for Python demos" OFF)
 
-set(DEMOS "ALL" CACHE STRING "Specify demo to build using comma(ex. -DDEMOS=classification_demo,text_detection_demo). Default is ALL")
-string(REPLACE "," ";" DEMOS_LIST ${DEMOS})
-
 if (CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE not defined, 'Release' will be used")
     set(CMAKE_BUILD_TYPE "Release")
@@ -121,12 +118,11 @@ function(add_samples_to_build)
                 if (BUILD_SAMPLE_NAME)
                     list(FIND BUILD_SAMPLE_NAME ${dir} index)
                 endif()
-                if (index EQUAL -1 OR NOT (dir IN_LIST DEMOS_LIST OR DEMOS STREQUAL "ALL"))
+                if (index EQUAL -1)
                     message(STATUS "${dir} SKIPPED")
                 else()
                     # Include subdirectory to the project.
                     add_subdirectory(${dir})
-                    message(STATUS "${dir} INCLUDED TO BUILD")
                 endif()
             endif()
         endif()

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -121,7 +121,7 @@ function(add_samples_to_build)
                 if (BUILD_SAMPLE_NAME)
                     list(FIND BUILD_SAMPLE_NAME ${dir} index)
                 endif()
-                if (index EQUAL -1 OR (NOT dir IN_LIST DEMOS_LIST AND NOT DEMOS STREQUAL "ALL"))
+                if (index EQUAL -1 OR NOT (dir IN_LIST DEMOS_LIST OR DEMOS STREQUAL "ALL"))
                     message(STATUS "${dir} SKIPPED")
                 else()
                     # Include subdirectory to the project.

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -8,6 +8,9 @@ project(Demos)
 
 option(ENABLE_PYTHON "Whether to build extension modules for Python demos" OFF)
 
+set(DEMOS "ALL" CACHE STRING "Specify demo to build using comma(ex. -DSPECIFIC_DEMOS classification_demo, text_detection_demo), Default is ALL")
+string(REPLACE "," ";" DEMOS_LIST ${DEMOS})
+
 if (CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE not defined, 'Release' will be used")
     set(CMAKE_BUILD_TYPE "Release")
@@ -118,11 +121,12 @@ function(add_samples_to_build)
                 if (BUILD_SAMPLE_NAME)
                     list(FIND BUILD_SAMPLE_NAME ${dir} index)
                 endif()
-                if (index EQUAL -1)
+                if ((index EQUAL -1 OR NOT dir IN_LIST DEMOS_LIST) AND NOT DEMOS STREQUAL "ALL")
                     message(STATUS "${dir} SKIPPED")
                 else()
                     # Include subdirectory to the project.
                     add_subdirectory(${dir})
+                    # message(STATUS "${dir} INCLUDED TO BUILD")
                 endif()
             endif()
         endif()

--- a/demos/README.md
+++ b/demos/README.md
@@ -212,7 +212,7 @@ cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON=ON <open_model_zoo>/demos
 
 To build specific demos, follow the instructions for building the demo applications above,
 but add `-DDEMOS=<list of demos>` to either the `cmake` or the `build_demos*` command, depending on which you use.
-Demos must be comma-separated without spaces, for `build_demos_msvc.bat`  list of demos must be eclosed with quotation marks.
+Demos must be comma-separated without spaces, for `build_demos_msvc.bat`  list of demos must be enclosed with quotation marks.
 For example:
 
 ```sh

--- a/demos/README.md
+++ b/demos/README.md
@@ -208,6 +208,21 @@ For example:
 cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON=ON <open_model_zoo>/demos
 ```
 
+### <a name="build_specific_demos"></a>Build Specific Demos
+
+To build specific demos, follow the instructions for building the demo applications above,
+but add `-DDEMOS=<list of demos>` to either the `cmake` or the `build_demos*` command, depending on which you use.
+Demos must be comma-separated without spaces, for `build_demos_msvc.bat`  list of demos must be eclosed with quotation marks.
+For example:
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=Release -DDEMOS=classification_demo,segmentation_demo <open_model_zoo>/demos
+```
+
+```bat
+build_demos_msvc.bat -DDEMOS="classification_demo,segmentation_demo" <open_model_zoo>/demos
+```
+
 ## Get Ready for Running the Demo Applications
 
 ### Get Ready for Running the Demo Applications on Linux*

--- a/demos/README.md
+++ b/demos/README.md
@@ -211,8 +211,8 @@ cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON=ON <open_model_zoo>/demos
 ### <a name="build_specific_demos"></a>Build Specific Demos
 
 To build specific demos, follow the instructions for building the demo applications above,
-but add `--target <list of demos>` to the `cmake` or `--target="<list of demos>"`  the `build_demos*` command.
-Note,  CMake `--build` tool support multiple targets starting with version 3.15. With lower versions you can specify only one target.
+but add `--target <list of demos>` to the `cmake` or `--target="<list of demos>"` to the `build_demos*` command.
+Note,  CMake `--build` tool supports multiple targets starting with version 3.15. With lower versions you can specify only one target.
 For example:
 
 ```sh

--- a/demos/README.md
+++ b/demos/README.md
@@ -211,16 +211,21 @@ cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_PYTHON=ON <open_model_zoo>/demos
 ### <a name="build_specific_demos"></a>Build Specific Demos
 
 To build specific demos, follow the instructions for building the demo applications above,
-but add `-DDEMOS=<list of demos>` to either the `cmake` or the `build_demos*` command, depending on which you use.
-Demos must be comma-separated without spaces, for `build_demos_msvc.bat`  list of demos must be enclosed with quotation marks.
+but add `--target <list of demos>` to the `cmake` or `--target="<list of demos>"`  the `build_demos*` command.
+Note,  CMake `--build` tool support multiple targets starting with version 3.15. With lower versions you can specify only one target.
 For example:
 
 ```sh
-cmake -DCMAKE_BUILD_TYPE=Release -DDEMOS=classification_demo,segmentation_demo <open_model_zoo>/demos
+cmake -DCMAKE_BUILD_TYPE=Release <open_model_zoo>/demos
+cmake --build . --config Release --target  <Demo_1> <Demo_2>
+```
+
+```sh
+build_demos.sh --target="classification_demo segmentation_demo"
 ```
 
 ```bat
-build_demos_msvc.bat -DDEMOS="classification_demo,segmentation_demo" <open_model_zoo>/demos
+build_demos_msvc.bat --target="classification_demo segmentation_demo"
 ```
 
 ## Get Ready for Running the Demo Applications

--- a/demos/build_demos.sh
+++ b/demos/build_demos.sh
@@ -26,14 +26,17 @@ error() {
 trap 'error ${LINENO}' ERR
 
 extra_cmake_opts=()
+extra_cmake_build_opts=()
 
 for opt in "$@"; do
     case "$opt" in
     -DENABLE_PYTHON=*)
         extra_cmake_opts+=("$opt")
         ;;
-    -DDEMOS=*)
-        extra_cmake_opts+=("$opt")
+    --target=*)
+        tmp="${opt%\"}"
+        tmp="${tmp#\"}"
+        extra_cmake_build_opts+=("${tmp//=/ }")
         ;;
     *)
         printf "Unknown option: %q\n" "$opt"
@@ -85,6 +88,7 @@ fi
 mkdir -p "$build_dir"
 
 (cd "$build_dir" && cmake -DCMAKE_BUILD_TYPE=Release "${extra_cmake_opts[@]}" "$DEMOS_PATH")
-cmake --build "$build_dir" -- "$NUM_THREADS"
+c="cmake --build $build_dir ${extra_cmake_build_opts[@]} -- $NUM_THREADS"
+eval "$c"
 
-printf "\nBuild completed, you can find binaries for all demos in the %s subfolder.\n\n" "$build_dir/$OS_PATH/Release"
+printf "\nBuild completed, you can find binaries for demos in the %s subfolder.\n\n" "$build_dir/$OS_PATH/Release"

--- a/demos/build_demos.sh
+++ b/demos/build_demos.sh
@@ -32,6 +32,9 @@ for opt in "$@"; do
     -DENABLE_PYTHON=*)
         extra_cmake_opts+=("$opt")
         ;;
+    -DDEMOS=*)
+        extra_cmake_opts+=("$opt")
+        ;;
     *)
         printf "Unknown option: %q\n" "$opt"
         exit 1

--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -35,10 +35,11 @@ if not "%1" == "" (
         goto argParse
     )
     rem to build more than one specific demo use quotation marks,
-    rem list the necessary demos comma-separated and without spaces,
-    rem ex. -DDEMOS="classification_demo,segmentation_demo"
-    if "%1" == "-DDEMOS" (
-        set EXTRA_CMAKE_OPTS=%EXTRA_CMAKE_OPTS% %1=%2
+    rem list the necessary demos separated by space,
+    rem ex. --target="classification_demo segmentation_demo"
+    :target
+    if "%1" == "--target" (
+        set EXTRA_CMAKE_BUILD_OPTS=%EXTRA_CMAKE_BUILD_OPTS% %1 %~2
         shift & shift
         goto argParse
     )
@@ -130,8 +131,7 @@ cd "%SOLUTION_DIR64%" && cmake -G "Visual Studio !VS_VERSION!" -A %PLATFORM% %EX
 echo.
 echo ###############^|^| Build Open Model Zoo Demos using MS Visual Studio ^|^|###############
 echo.
-echo cmake --build . --config Release
-cmake --build . --config Release
+cmake --build . --config Release %EXTRA_CMAKE_BUILD_OPTS%
 if ERRORLEVEL 1 goto errorHandling
 
 echo Done.

--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -37,7 +37,6 @@ if not "%1" == "" (
     rem to build more than one specific demo use quotation marks,
     rem list the necessary demos separated by space,
     rem ex. --target="classification_demo segmentation_demo"
-    :target
     if "%1" == "--target" (
         set EXTRA_CMAKE_BUILD_OPTS=%EXTRA_CMAKE_BUILD_OPTS% %1 %~2
         shift & shift

--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -35,6 +35,12 @@ if not "%1" == "" (
         goto argParse
     )
 
+    if "%1" == "-DDEMOS" (
+        set EXTRA_CMAKE_OPTS=%EXTRA_CMAKE_OPTS% %1=%2
+        shift & shift
+        goto argParse
+    )
+
     if not "%VS_VERSION%" == "" (
         echo Unexpected argument: "%1"
         goto errorHandling

--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -34,7 +34,9 @@ if not "%1" == "" (
         shift & shift
         goto argParse
     )
-
+    rem to build more than one specific demo use quotation marks,
+    rem list the necessary demos comma-separated and without spaces,
+    rem ex. -DDEMOS="classification_demo,segmentation_demo"
     if "%1" == "-DDEMOS" (
         set EXTRA_CMAKE_OPTS=%EXTRA_CMAKE_OPTS% %1=%2
         shift & shift


### PR DESCRIPTION
Add  `-DDEMOS=<list of demos"` option to CMake file and build scripts. It allows to specify one or more demos to build.