### PR TITLE
mask_rcnn_demo: skip zero-size boxes

### DIFF
--- a/demos/mask_rcnn_demo/main.cpp
+++ b/demos/mask_rcnn_demo/main.cpp
@@ -252,10 +252,10 @@ int main(int argc, char *argv[]) {
             float y1 = std::min(std::max(0.0f, box_info[4] * images[batch].rows), static_cast<float>(images[batch].rows));
             float x2 = std::min(std::max(0.0f, box_info[5] * images[batch].cols), static_cast<float>(images[batch].cols));
             float y2 = std::min(std::max(0.0f, box_info[6] * images[batch].rows), static_cast<float>(images[batch].rows));
-            int box_width = std::min(static_cast<int>(std::max(0.0f, x2 - x1)), images[batch].cols);
-            int box_height = std::min(static_cast<int>(std::max(0.0f, y2 - y1)), images[batch].rows);
+            int box_width = static_cast<int>(x2 - x1);
+            int box_height = static_cast<int>(y2 - y1);
             auto class_id = static_cast<size_t>(box_info[1] + 1e-6f);
-            if (prob > PROBABILITY_THRESHOLD) {
+            if (prob > PROBABILITY_THRESHOLD && box_width > 0 && box_height > 0) {
                 size_t color_index = class_color.emplace(class_id, class_color.size()).first->second;
                 auto& color = CITYSCAPES_COLORS[color_index % arraySize(CITYSCAPES_COLORS)];
                 float* mask_arr = masks_data + box_stride * box + H * W * (class_id - 1);


### PR DESCRIPTION
These aren't normally supposed to occur, but there's a currently a bug in OpenVINO master where the GPU plugin produces invalid boxes when inferring with `mask_rcnn_resnet101_atrous_coco`. This change works around that (and, in general, makes the demo more resilient to misbehaving networks).