### PR TITLE
Add the handler of open video error in action_recognition demo

### DIFF
--- a/demos/python_demos/action_recognition/README.md
+++ b/demos/python_demos/action_recognition/README.md
@@ -43,9 +43,7 @@ Options:
   -h, --help            Show this help message and exit.
   -i INPUT, --input INPUT
                         Required. Id of the video capturing device to open (to
-                        open default camera just pass 0), path to a video or a
-                        .txt file with a list of ids or video files (one
-                        object per line)
+                        open default camera just pass 0), path to a video
   -m_en M_ENCODER, --m_encoder M_ENCODER
                         Required. Path to encoder model
   -m_de M_DECODER, --m_decoder M_DECODER
@@ -64,6 +62,7 @@ Options:
   -lb LABELS, --labels LABELS
                         Optional. Path to file with label names
   --no_show             Optional. Don't show output
+  --loop                Optional. Run a video in cycle mode
   -s LABEL_SMOOTHING, --smooth LABEL_SMOOTHING
                         Optional. Number of frames used for output label
                         smoothing

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -68,12 +68,6 @@ def build_argparser():
 
 def main():
     args = build_argparser().parse_args()
-    input_path = args.input
-    if not input_path:
-        raise ValueError('--input option is expected')
-    if not path.isfile(input_path):
-        raise ValueError('The input file does not exists')
-    video = [input_path]
 
     if args.labels:
         with open(args.labels) as f:
@@ -109,11 +103,11 @@ def main():
     else:
         decoder = DummyDecoder(num_requests=2)
         decoder_seq_size = args.decoder_seq_size
-    
+
     presenter = monitors.Presenter(args.utilization_monitors, 70)
     result_presenter = ResultRenderer(no_show=args.no_show, presenter=presenter, labels=labels,
                                       label_smoothing_window=args.label_smoothing)
-    run_pipeline(video, encoder, decoder, result_presenter.render_frame, args.loop, decoder_seq_size=decoder_seq_size, fps=args.fps)
+    run_pipeline(args.input, args.loop, encoder, decoder, result_presenter.render_frame, decoder_seq_size=decoder_seq_size, fps=args.fps)
     print(presenter.reportMeans())
 
 

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -36,8 +36,7 @@ def build_argparser():
     args.add_argument('-h', '--help', action='help', default=SUPPRESS, help='Show this help message and exit.')
     args.add_argument('-i', '--input',
                       help='Required. Id of the video capturing device to open (to open default camera just pass 0), '
-                           'path to a video or a .txt file with a list of ids or video files (one object per line)',
-                      required=True, type=str)
+                           'path to a video', required=True, type=str)
     args.add_argument('-m_en', '--m_encoder', help='Required. Path to encoder model', required=True, type=str)
     decoder_args = args.add_mutually_exclusive_group()
     decoder_args.add_argument('-m_de', '--m_decoder',
@@ -47,7 +46,6 @@ def build_argparser():
     decoder_args.add_argument('--seq', dest='decoder_seq_size',
                               help='Optional. Length of sequence that decoder takes as input',
                               default=16, type=int)
-
     args.add_argument('-l', '--cpu_extension',
                       help='Optional. For CPU custom layers, if any. Absolute path to a shared library with the '
                            'kernels implementation.', type=str, default=None)
@@ -59,7 +57,7 @@ def build_argparser():
     args.add_argument('--fps', help='Optional. FPS for renderer', default=30, type=int)
     args.add_argument('-lb', '--labels', help='Optional. Path to file with label names', type=str)
     args.add_argument('--no_show', action='store_true', help="Optional. Don't show output")
-    args.add_argument('--loop', default=False, action='store_true', help='Optional. Run video the video in cycle mode or not')
+    args.add_argument('--loop', default=False, action='store_true', help='Optional. Run the video in cycle mode')
     args.add_argument('-s', '--smooth', dest='label_smoothing', help='Optional. Number of frames used for output label smoothing',
                       default=30, type=int)
     args.add_argument('-u', '--utilization-monitors', default='', type=str,
@@ -71,17 +69,15 @@ def build_argparser():
 def main():
     args = build_argparser().parse_args()
 
-    full_name = path.basename(args.input)
-    extension = path.splitext(full_name)[1]
-
-    if '.txt' in  extension:
-        with open(args.input) as f:
-            videos = [line.strip() for line in f.read().split('\n')]
-    else:
-        videos = [args.input]
-
-    if not args.input:
+    input_path = args.input
+    
+    if not input_path:
         raise ValueError('--input option is expected')
+    
+    if not path.isfile(input_path):
+        raise ValueError('The input file does not exists')
+    
+    video = [input_path]
 
     if args.labels:
         with open(args.labels) as f:
@@ -121,7 +117,7 @@ def main():
     presenter = monitors.Presenter(args.utilization_monitors, 70)
     result_presenter = ResultRenderer(no_show=args.no_show, presenter=presenter, labels=labels,
                                       label_smoothing_window=args.label_smoothing)
-    run_pipeline(videos, encoder, decoder, result_presenter.render_frame, args.loop, decoder_seq_size=decoder_seq_size, fps=args.fps)
+    run_pipeline(video, encoder, decoder, result_presenter.render_frame, args.loop, decoder_seq_size=decoder_seq_size, fps=args.fps)
     print(presenter.reportMeans())
 
 

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -68,15 +68,11 @@ def build_argparser():
 
 def main():
     args = build_argparser().parse_args()
-
     input_path = args.input
-    
     if not input_path:
         raise ValueError('--input option is expected')
-    
     if not path.isfile(input_path):
         raise ValueError('The input file does not exists')
-    
     video = [input_path]
 
     if args.labels:

--- a/demos/python_demos/action_recognition/action_recognition.py
+++ b/demos/python_demos/action_recognition/action_recognition.py
@@ -59,6 +59,7 @@ def build_argparser():
     args.add_argument('--fps', help='Optional. FPS for renderer', default=30, type=int)
     args.add_argument('-lb', '--labels', help='Optional. Path to file with label names', type=str)
     args.add_argument('--no_show', action='store_true', help="Optional. Don't show output")
+    args.add_argument('--loop', default=False, action='store_true', help='Optional. Run video the video in cycle mode or not')
     args.add_argument('-s', '--smooth', dest='label_smoothing', help='Optional. Number of frames used for output label smoothing',
                       default=30, type=int)
     args.add_argument('-u', '--utilization-monitors', default='', type=str,
@@ -120,7 +121,7 @@ def main():
     presenter = monitors.Presenter(args.utilization_monitors, 70)
     result_presenter = ResultRenderer(no_show=args.no_show, presenter=presenter, labels=labels,
                                       label_smoothing_window=args.label_smoothing)
-    run_pipeline(videos, encoder, decoder, result_presenter.render_frame, decoder_seq_size=decoder_seq_size, fps=args.fps)
+    run_pipeline(videos, encoder, decoder, result_presenter.render_frame, args.loop, decoder_seq_size=decoder_seq_size, fps=args.fps)
     print(presenter.reportMeans())
 
 

--- a/demos/python_demos/action_recognition/action_recognition_demo/steps.py
+++ b/demos/python_demos/action_recognition/action_recognition_demo/steps.py
@@ -52,8 +52,13 @@ class DataStep(PipelineStep):
             self._video_cycle = iter(self.video_list)
 
     def setup(self):
+        for i, video in enumerate(self.video_list):
+            self.cap = cv2.VideoCapture(video)
+            opened = self.cap.isOpened()
+            if not opened:
+                raise Exception("The input video №{} cannot be opened".format(i+1))
         self._open_video()
-
+            
     def process(self, item):
         if not self.cap.isOpened() and not self._open_video():
             return Signal.STOP

--- a/demos/python_demos/action_recognition/action_recognition_demo/steps.py
+++ b/demos/python_demos/action_recognition/action_recognition_demo/steps.py
@@ -52,19 +52,16 @@ class DataStep(PipelineStep):
             self._video_cycle = iter(self.video_list)
 
     def setup(self):
-        for i, video in enumerate(self.video_list):
-            self.cap = cv2.VideoCapture(video)
-            opened = self.cap.isOpened()
-            if not opened:
-                raise Exception("The input video №{} cannot be opened".format(i+1))
         self._open_video()
-            
+
     def process(self, item):
-        if not self.cap.isOpened() and not self._open_video():
-            return Signal.STOP
         status, frame = self.cap.read()
         if not status:
-            return Signal.STOP
+             try:
+                 self._open_video()
+                 status, frame = self.cap.read()
+             except:
+                 return Signal.STOP
         return frame
 
     def end(self):
@@ -78,8 +75,7 @@ class DataStep(PipelineStep):
             pass
         self.cap = cv2.VideoCapture(next_video)
         if not self.cap.isOpened():
-            return False
-        return True
+            raise Exception("The input video cannot be opened")
 
 
 class EncoderStep(PipelineStep):

--- a/demos/python_demos/action_recognition/action_recognition_demo/steps.py
+++ b/demos/python_demos/action_recognition/action_recognition_demo/steps.py
@@ -41,21 +41,21 @@ def run_pipeline(video, encoder, decoder, render_fn, loop, decoder_seq_size=16, 
 
 class DataStep(PipelineStep):
 
-    def __init__(self, video_list, loop):
+    def __init__(self, video_filepath, loop):
         super().__init__()
-        self.video_list = video_list
+        self.video = video_filepath
         self.cap = None
         self.loop = loop
 
         if self.loop:
-            self._video_cycle = cycle(self.video_list)
+            self._video_cycle = cycle(self.video)
         else:
-            self._video_cycle = iter(self.video_list)
+            self._video_cycle = iter(self.video)
 
         try:
             self._open_video()
             if not self.loop:
-                self._video_cycle = iter(self.video_list)
+                self._video_cycle = iter(self.video)
         except:
             print("Error: The input video cannot be opened")
             exit(1)

--- a/demos/python_demos/action_recognition/action_recognition_demo/steps.py
+++ b/demos/python_demos/action_recognition/action_recognition_demo/steps.py
@@ -57,11 +57,10 @@ class DataStep(PipelineStep):
     def process(self, item):
         status, frame = self.cap.read()
         if not status:
-             try:
-                 self._open_video()
-                 status, frame = self.cap.read()
-             except:
-                 return Signal.STOP
+		    self._open_video()
+            status, frame = self.cap.read()
+            if not status:
+                return Signal.STOP
         return frame
 
     def end(self):


### PR DESCRIPTION
There was no handling of situation when the demo fails to open the input video (one or many). Add the handler of this error to prevent the demo further running.