### PR TITLE
person-vehicle-bike-detection-crossroad-0078

### DIFF
--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/description/person-vehicle-bike-detection-crossroad-0078.md
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/description/person-vehicle-bike-detection-crossroad-0078.md
@@ -15,7 +15,7 @@ conditions.
 | Metric                          | Value                                     |
 |---------------------------------|-------------------------------------------|
 | Mean Average Precision (mAP)    | 65.12%                                    |
-| AP people                       | 76.28%                                    |
+| AP people                       | 77.47%                                    |
 | AP vehicles                     | 74.94%                                    |
 | AP bikes                        | 44.14%                                    |
 | Max objects to detect           | 200                                       |


### PR DESCRIPTION
update model accuracy ref value for map@person metric. originally reported value can't be reproduced