### PR TITLE
Corner crop of ground truth image

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -81,6 +81,14 @@ Accuracy Checker supports following set of postprocessors:
 * `resize_style_transfer` - resizing style transfer predicted image. Supported representations: `StyleTransferAnotation`, `StyleTransferPrediction`.
   * `dst_width` and `dst_height` - destination width and height for resizing respectively.
 * `crop_ground_truth_image` - cropping ground truth image. Supported representations: `ImageInpaintingAnnotation`.
+* `corner_crop_ground_truth_image` - Corner crop of the ground truth image. Supported representations: `ImageInpaintingAnnotation`.
+  * `dst_width` and `dst_height` are destination width and height
+  * `corner_type` is type of the corner crop. Options are:
+    * `top-left`
+    * `top-right`
+    * `bottom-left`
+    * `bottom-right`
+  Default choice is `top-left`
 * `resize` - resizing image or segmentation mask. Supported representations: `SegmentationAnotation`, `SegmentationPrediction`, `StyleTransferAnotation`, `StyleTransferPrediction`, `SuperResolutionAnotation`, `SuperResolutionPrediction`, `ImageProcessingAnnotation`, `ImageProcessingPrediction`, `SalientRegionAnnotation`, `SalientRegionPrediction`.
   * `dst_width` and `dst_height` - destination width and height for resize respectively. You can also use `size` instead in case when destination sizes are equal.
     If any of these parameters are not specified, image size will be used as default.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
@@ -51,7 +51,7 @@ from .align_prediction_depth_map import AlignDepth
 from .resize_prediction_depth_map import ResizeDepthMap
 from .resize_super_resolution import ResizeSuperResolution
 from .resize_style_transfer import ResizeStyleTransfer
-from .crop_ground_truth_image import CropGTImage
+from .crop_ground_truth_image import CropGTImage, CornerCropGTImage
 from .resize import Resize
 from .to_gray_scale_ref_image import RGB2GRAYAnnotation, BGR2GRAYAnnotation
 from .remove_repeats import RemoveRepeatTokens
@@ -116,6 +116,7 @@ __all__ = [
     'BGR2GRAYAnnotation',
 
     'CropGTImage',
+    'CornerCropGTImage',
 
     'Resize',
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/crop_ground_truth_image.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/crop_ground_truth_image.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 
 from .postprocessor import Postprocessor
-from ..preprocessor import Crop
+from ..preprocessor import Crop, CornerCrop
 from ..representation import ImageInpaintingAnnotation, ImageInpaintingPrediction
-from ..config import NumberField
+from ..config import NumberField, StringField
 from ..utils import get_size_from_config
 
 
@@ -52,5 +52,38 @@ class CropGTImage(Postprocessor):
             target.value = Crop.process_data(
                 target.value, self.dst_height, self.dst_width, None, False, False, True, {}
             )
+
+        return annotation, prediction
+
+class CornerCropGTImage(Postprocessor):
+    __provider__ = "corner_crop_ground_truth_image"
+
+    annotation_types = (ImageInpaintingAnnotation,)
+    prediction_types = (ImageInpaintingPrediction,)
+
+    @classmethod
+    def parameters(cls):
+        parameters = super().parameters()
+        parameters.update({
+            'dst_width': NumberField(
+                value_type=int, optional=True, min_value=1, description="Destination width for mask cropping."
+            ),
+            'dst_height': NumberField(
+                value_type=int, optional=True, min_value=1, description="Destination height for mask cropping."
+            ),
+            'corner_type': StringField(
+                optional=True, choices=['top_left', 'top_right', 'bottom_left', 'bottom_right'],
+                default='top_left', description="Destination height for image cropping respectively."
+            ),
+        })
+        return parameters
+
+    def configure(self):
+        self.corner_type = self.get_value_from_config('corner_type')
+        self.dst_height, self.dst_width = get_size_from_config(self.config)
+
+    def process_image(self, annotation, prediction):
+        for target in annotation:
+            target.value = CornerCrop.process_data(target.value, self.dst_height, self.dst_width, self.corner_type)
 
         return annotation, prediction


### PR DESCRIPTION
Corner crop of ground truth image can be used for predictable crop of reference images  in accuracy checking pipelines of super resolution models