### PR TITLE
googlenet-v?-tf: fix deprecated API usage in tf_slim

### DIFF
--- a/models/public/googlenet-v1-tf/model.yml
+++ b/models/public/googlenet-v1-tf/model.yml
@@ -71,6 +71,12 @@ postprocessing:
     pattern: '(?<=''inception_v1'': inception\.)inception_v3_arg_scope'
     replacement: 'inception_v1_arg_scope'
     file: models/research/slim/nets/nets_factory.py
+
+  # replace deprecated API usage
+  - $type: regex_replace
+    pattern: '\blayer\.apply\b'
+    replacement: 'layer'
+    file: models/research/slim/tf_slim/layers/layers.py
 model_optimizer_args:
   - --input_shape=[1,224,224,3]
   - --input=input

--- a/models/public/googlenet-v2-tf/model.yml
+++ b/models/public/googlenet-v2-tf/model.yml
@@ -71,6 +71,12 @@ postprocessing:
     pattern: '(?<=''inception_v2'': inception\.)inception_v3_arg_scope'
     replacement: 'inception_v2_arg_scope'
     file: models/research/slim/nets/nets_factory.py
+
+  # replace deprecated API usage
+  - $type: regex_replace
+    pattern: '\blayer\.apply\b'
+    replacement: 'layer'
+    file: models/research/slim/tf_slim/layers/layers.py
 model_optimizer_args:
   - --input_shape=[1,224,224,3]
   - --input=input

--- a/models/public/googlenet-v4-tf/model.yml
+++ b/models/public/googlenet-v4-tf/model.yml
@@ -64,6 +64,16 @@ postprocessing:
     pattern: 'from nets\.inception_(?!v4)'
     replacement: '# \g<0>'
     file: models/research/slim/nets/inception.py
+
+  # replace deprecated API usage
+  - $type: regex_replace
+    pattern: '\blayer\.apply\b'
+    replacement: 'layer'
+    file: models/research/slim/tf_slim/layers/layers.py
+  - $type: regex_replace
+    pattern: '\bcore_layers\.flatten\b'
+    replacement: 'tf.keras.layers.Flatten()'
+    file: models/research/slim/tf_slim/layers/layers.py
 model_optimizer_args:
   - --input_shape=[1,299,299,3]
   - --input=input


### PR DESCRIPTION
This removes some warnings during conversion and will hopefully prevent the pre-convert script from failing with future versions of TensorFlow.