### PR TITLE
downloader: add a separate requirements file for TensorFlow model conversion

### DIFF
--- a/ci/update-requirements.py
+++ b/ci/update-requirements.py
@@ -69,7 +69,7 @@ def main():
         'tools/accuracy_checker/requirements-core.in')
     pc('ci/requirements-check-basics.txt', 'ci/requirements-check-basics.in')
     pc('ci/requirements-conversion.txt',
-        'tools/downloader/requirements-pytorch.in', 'tools/downloader/requirements-caffe2.in',
+        *(f'tools/downloader/requirements-{suffix}.in' for suffix in ['caffe2', 'pytorch', 'tensorflow']),
         *(openvino_dir / f'deployment_tools/model_optimizer/requirements_{suffix}.txt'
             for suffix in ['caffe', 'mxnet', 'onnx', 'tf2']))
     pc('ci/requirements-demos.txt',

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -33,16 +33,25 @@ For the model converter, you will also need to install the OpenVINO&trade;
 toolkit and the prerequisite libraries for Model Optimizer. See the
 [OpenVINO toolkit documentation](https://docs.openvinotoolkit.org/) for details.
 
-If you using models from PyTorch or Caffe2 framework, you will also need to use intermediate
-conversion to ONNX format. To use automatic conversion install additional dependencies.
+To convert models from certain frameworks, you will also need to install
+additional dependencies.
+
+For models from Caffe2:
+
+```sh
+python3 -mpip install --user -r ./requirements-caffe2.in
+```
 
 For models from PyTorch:
+
 ```sh
 python3 -mpip install --user -r ./requirements-pytorch.in
 ```
-For models from Caffe2:
+
+For models from TensorFlow:
+
 ```sh
-python3 -mpip install --user -r ./requirements-caffe2.in
+python3 -mpip install --user -r ./requirements-tensorflow.in
 ```
 
 ## Model downloader usage

--- a/tools/downloader/requirements-tensorflow.in
+++ b/tools/downloader/requirements-tensorflow.in
@@ -1,0 +1,4 @@
+tensorflow>=2.3
+
+# workaround for https://github.com/tensorflow/tensorflow/issues/44467
+h5py<3


### PR DESCRIPTION
There are two reasons why such a file is needed:

* The EfficientDet models are only convertible with TF 2.3+, while Model Optimizer requires 1.15+. This, if the user just uses the requirements from Model Optimizer, they can install an incompatible version of TF.

* TensorFlow is incompatible with h5py 3.x, but it doesn't say so in its requirements. If the user just uses the requirements from MO, they may end up installing an incompatible version of h5py, which will break the conversion of YOLO models. This should be fixed in TensorFlow 2.4, but it has not yet been released. Meanwhile, we can add a workaround via this file.