### PR TITLE
AC: enable non-inferenece based metrics for colorization

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/image_processing.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/image_processing.py
@@ -80,12 +80,12 @@ class ImageProcessingAdapter(Adapter):
 
         for identifier, out_img in zip(identifiers, raw_outputs[self.target_out]):
             out_img = self._basic_postprocess(out_img)
-            result.append(SuperResolutionPrediction(identifier, out_img))
+            result.append(ImageProcessingPrediction(identifier, out_img))
 
         return result
 
     def _basic_postprocess(self, img):
-        img = img.transpose((1, 2, 0)) if img.shape[-1] not in [3, 4, 1] else img
+        img = img.transpose((1, 2, 0)) if img.shape[-1] > 4 else img
         img *= self.std
         img += self.mean
         if self.cast_to_uint8:

--- a/tools/accuracy_checker/accuracy_checker/config/config_validator.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_validator.py
@@ -275,7 +275,7 @@ class ListField(BaseField):
 
 
 class InputField(BaseField):
-    INPUTS_TYPES = ('CONST_INPUT', 'INPUT', 'IMAGE_INFO', 'ORIG_IMAGE_INFO', 'LSTM_INPUT')
+    INPUTS_TYPES = ('CONST_INPUT', 'INPUT', 'IMAGE_INFO', 'ORIG_IMAGE_INFO', 'LSTM_INPUT', 'IGNORE_INPUT')
     LAYOUT_TYPES = ('NCHW', 'NHWC', 'NCWH', 'NWHC')
     PRECISIONS = ('FP32', 'FP16', 'U8', 'U16', 'I8', 'I16', 'I32', 'I64')
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/caffe_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/caffe_launcher_readme.md
@@ -19,6 +19,7 @@ Each input description should has following info:
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     Optionally you can determine `shape` of input (actually does not used, Caffe launcher uses info given from network), `layout` in case when your model was trained with non-standard data layout (For Caffe default layout is `NCHW`).
     and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
@@ -71,6 +71,7 @@ Each input description should has following info:
         * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
     * `LSTM_INPUT` - input which should be filled by hidden state from previous iteration. The hidden state layer name should be provided via `value` parameter.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     Optionally you can determine `shape` of input (by default DLSDK launcher uses info given from network, this option allows override default. It required for running ONNX\* models with dynamic input shape on devices, where dynamic shape is not supported), `layout` in case when your model was trained with non-standard data layout (For DLSDK default layout is `NCHW`)
     and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/input_feeder.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/input_feeder.py
@@ -83,7 +83,7 @@ class InputFeeder:
             parsing_results = self._parse_inputs_config(inputs_config, self.default_layout, precisions_list)
             self.const_inputs, self.non_constant_inputs, self.inputs_mapping = parsing_results[:3]
             self.image_info_inputs, self.orig_image_info_inputs, self.lstm_inputs = parsing_results[3:6]
-            self.layouts_mapping, self.precision_mapping, self.inputs_config = parsing_results[6:]
+            self.ignore_inputs, self.layouts_mapping, self.precision_mapping, self.inputs_config = parsing_results[6:]
             if not self.non_constant_inputs:
                 raise ConfigError('Network should contain at least one layer for setting variable data.')
 
@@ -181,6 +181,7 @@ class InputFeeder:
         image_info_inputs = []
         orig_image_info_inputs = []
         lstm_inputs = []
+        ignore_inputs = []
 
         for input_ in inputs_entry:
             name = input_['name']
@@ -202,6 +203,10 @@ class InputFeeder:
                 self.get_layer_precision(input_, name, precision_info, precisions)
                 continue
 
+            if input_['type'] == 'IGNORE_INPUT':
+                ignore_inputs.append(name)
+                continue
+
             value = input_.get('value')
 
             if input_['type'] == 'CONST_INPUT':
@@ -221,7 +226,7 @@ class InputFeeder:
 
         all_config_inputs = (
             config_non_constant_inputs + list(constant_inputs.keys()) +
-            image_info_inputs + lstm_inputs + orig_image_info_inputs
+            image_info_inputs + lstm_inputs + orig_image_info_inputs + ignore_inputs
         )
         not_config_inputs = [input_layer for input_layer in self.network_inputs if input_layer not in all_config_inputs]
         if config_non_constant_inputs and not_config_inputs:
@@ -239,6 +244,7 @@ class InputFeeder:
             image_info_inputs,
             orig_image_info_inputs,
             lstm_inputs,
+            ignore_inputs,
             layouts,
             precisions,
             inputs_entry

--- a/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/launcher.py
@@ -76,6 +76,7 @@ class Launcher(ClassProvider):
         self.const_inputs = self.config.get('_list_const_inputs', [])
         self.image_info_inputs = self.config.get('_list_image_infos', [])
         self._lstm_inputs = self.config.get('_list_lstm_inputs', [])
+        self._ignore_inputs = self.config.get('_list_ignore_inputs', [])
 
     @classmethod
     def parameters(cls):
@@ -101,6 +102,9 @@ class Launcher(ClassProvider):
             ),
             '_list_lstm_inputs': ListField(
                 allow_empty=True, optional=True, default=[], description="List of lstm inputs."
+            ),
+            '_list_ignore_inputs': ListField(
+                allow_empty=True, optional=True, default=[], description='List of ignored inputs'
             ),
             '_input_precision': ListField(
                 allow_empty=True, optional=True, default=[], description='Input precision list from command line.'
@@ -158,7 +162,7 @@ class Launcher(ClassProvider):
     def inputs_info_for_meta(self):
         return {
             layer_name: shape for layer_name, shape in self.inputs.items()
-            if layer_name not in self.const_inputs + self.image_info_inputs
+            if layer_name not in self.const_inputs + self.image_info_inputs + self._ignore_inputs
         }
 
     def update_input_configuration(self, input_config):

--- a/tools/accuracy_checker/accuracy_checker/launcher/mxnet_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/mxnet_launcher_readme.md
@@ -13,6 +13,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
   * `shape` - shape of input layer described as comma-separated of all dimensions size except batch size.
     Optionally you can determine `layout` in case when your model was trained with non-standard data layout (For MXNet default layout is `NCHW`)

--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
@@ -19,6 +19,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
     Optionally you can determine `shape` of input (actually does not used, ONNX Runtime launcher uses info given from network),`layout` in case when your model was trained with non-standard data layout (For ONNX Runtime default layout is `NCHW`)
     and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).

--- a/tools/accuracy_checker/accuracy_checker/launcher/opencv_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/opencv_launcher_readme.md
@@ -15,6 +15,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
   * `shape` - shape of input layer described as comma-separated of all dimensions size except batch size.
     Optionally you can determine `layout` in case when your model was trained with non-standard data layout (For OpenCV default layout is `NCHW`) and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
@@ -17,6 +17,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
   * `shape` - shape of input layer described as comma-separated of all dimensions size except batch size.
     Optionally you can determine `layout` in case when your model was trained with non-standard data layout (For PyTorch default layout is `NCHW`) and`precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).

--- a/tools/accuracy_checker/accuracy_checker/launcher/tf_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/tf_launcher_readme.md
@@ -16,6 +16,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
     Optionally you can determine `shape` of input and `layout` in case when your model was trained with non-standard data layout (For TensorFlow default layout is `NHWC`)
     and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).

--- a/tools/accuracy_checker/accuracy_checker/launcher/tf_lite_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/tf_lite_launcher_readme.md
@@ -15,6 +15,7 @@ Each input description should has following info:
     * `CONST_INPUT` - input will be filled using constant provided in config. It also requires to provide `value`.
     * `IMAGE_INFO` - specific key for setting information about input shape to layer (used in Faster RCNN based topologies). You do not need provide `value`, because it will be calculated in runtime. Format value is `Nx[H, W, S]`, where `N` is batch size, `H` - original image height, `W` - original image width, `S` - scale of original image (default 1).
     * `ORIG_IMAGE_INFO` - specific key for setting information about original image size before preprocessing.
+    * `IGNORE_INPUT` - input which should be stayed empty during evaluation.
     * `INPUT` - network input for main data stream (e. g. images). If you have several data inputs, you should provide regular expression for identifier as `value` for specifying which one data should be provided in specific input.
     Optionally you can determine `shape` of input and `layout` in case when your model was trained with non-standard data layout (For TensorFlow Lite default layout is `NHWC`)
     and `precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -101,6 +101,7 @@ Accuracy Checker supports following set of postprocessors:
   * `target_color` - target color space for super resolution image - `bgr` and `rgb` are supported. (Optional, default `rgb`).
   * `size` - size of model input for recovering YCrCb image.
   * `dst_width` and `dst_height` - width and height of model input respectively for recovering YCrCb image.
+* `colorization_recovery` - restores RGB image from Colorization models results represented as AB-channels in LAB color space. Supported representations: `ImageProcessingAnnotation`, `ImageProcessingPrediction`.
 * `argmax_segmentation_mask` - translates categorical annotation segmentation mask to numerical. Supported representations: `SegmentationAnnotation`, `SegmentationPrediction`.
 * `shift_labels` - shifts predicted detection labels. Supported representation: `DetectionPrediction`.
   * `offset` - value for shift.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
@@ -56,7 +56,7 @@ from .resize import Resize
 from .to_gray_scale_ref_image import RGB2GRAYAnnotation, BGR2GRAYAnnotation
 from .remove_repeats import RemoveRepeatTokens
 from .tokens_to_lower_case import TokensToLowerCase
-from .super_resolution_image_recovery import SRImageRecovery
+from .super_resolution_image_recovery import SRImageRecovery, ColorizationLABRecovery
 from .argmax_segmentation_mask import ArgMaxSegmentationMask
 from .normalize_salient_map import SalientMapNormalizer
 
@@ -122,7 +122,9 @@ __all__ = [
 
     'RemoveRepeatTokens',
     'TokensToLowerCase',
+
     'SRImageRecovery',
+    'ColorizationLABRecovery',
 
     'SalientMapNormalizer'
 ]

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/super_resolution_image_recovery.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/super_resolution_image_recovery.py
@@ -20,15 +20,17 @@ from PIL import Image
 
 from ..config import StringField, NumberField, ConfigError
 from .postprocessor import Postprocessor
-from ..representation import SuperResolutionPrediction, SuperResolutionAnnotation
+from ..representation import (
+    SuperResolutionPrediction, SuperResolutionAnnotation, ImageProcessingAnnotation, ImageProcessingPrediction
+)
 from ..utils import get_size_from_config
 
 
 class SRImageRecovery(Postprocessor):
     __provider__ = 'sr_image_recovery'
 
-    annotation_types = (SuperResolutionAnnotation, )
-    prediction_types = (SuperResolutionPrediction, )
+    annotation_types = (SuperResolutionAnnotation, ImageProcessingAnnotation)
+    prediction_types = (SuperResolutionPrediction, ImageProcessingPrediction)
 
     @classmethod
     def parameters(cls):
@@ -71,4 +73,22 @@ class SRImageRecovery(Postprocessor):
             cb = np.expand_dims(np.array(cb).astype(np.uint8), axis=-1)
             ycrcb = np.concatenate([prediction_.value, cr, cb], axis=2)
             prediction_.value = cv2.cvtColor(ycrcb, self.color)
+        return annotation, prediction
+
+
+class ColorizationLABRecovery(Postprocessor):
+    __provider__ = 'colorization_recovery'
+    annotation_types = (ImageProcessingAnnotation, )
+    prediction_types = (ImageProcessingPrediction, )
+
+    def process_image(self, annotation, prediction):
+        for ann, pred in zip(annotation, prediction):
+            target = ann.value
+            h, w = pred.value.shape[:2]
+            r_target = cv2.resize(target, (w, h))
+            target_l = cv2.cvtColor(r_target, cv2.COLOR_RGB2Lab)[:, :, 0]
+            pred_ab = pred.value
+            out_lab = np.concatenate((target_l[:, :, np.newaxis], pred_ab), axis=2)
+            result_rgb = cv2.cvtColor(out_lab, cv2.COLOR_Lab2RGB)
+            pred.value = result_rgb
         return annotation, prediction


### PR DESCRIPTION
it is difficult to quantize colorization models due to composite config struture and metrics based on inference classification model.
Now standard image processing metrics (PSNR, SSIM, MAE can be calculated on colorization models) 