### PR TITLE
AC: requirements update

### DIFF
--- a/tools/accuracy_checker/requirements-core.in
+++ b/tools/accuracy_checker/requirements-core.in
@@ -1,4 +1,4 @@
 # core components
-numpy>=1.11,<1.18
+numpy>=1.16.3,<1.18
 PyYAML
 pillow>=2.6.1

--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -28,8 +28,6 @@ nltk
 # editdistance calculation
 editdistance
 
-# speech recognition with language modeling
-pypi-kenlm
 
 # DNA sequence matching
 parasail<=1.2


### PR DESCRIPTION
increase minimal numpy version like in common OV requirements, remove kenlm as obligated requirement due to issues in Windows install