### PR TITLE
Switch object_detection_demo and common/models to pathlib

### DIFF
--- a/demos/python_demos/common/models/model.py
+++ b/demos/python_demos/common/models/model.py
@@ -21,7 +21,7 @@ class Model:
     def __init__(self, ie, model_path):
         self.logger = logging.getLogger()
         self.logger.info('Reading network from IR...')
-        self.net = ie.read_network(model_path, model_path[:-4] + '.bin')
+        self.net = ie.read_network(model_path, model_path.with_suffix('.bin'))
         self.set_batch_size(1)
 
     def preprocess(self, inputs):

--- a/demos/python_demos/object_detection_demo/object_detection_demo.py
+++ b/demos/python_demos/object_detection_demo/object_detection_demo.py
@@ -17,17 +17,17 @@
 
 import colorsys
 import logging
-import os.path as osp
 import random
 import sys
 from argparse import ArgumentParser, SUPPRESS
+from pathlib import Path
 from time import perf_counter
 
 import cv2
 import numpy as np
 from openvino.inference_engine import IECore
 
-sys.path.append(osp.join(osp.dirname(osp.dirname(osp.abspath(__file__))), 'common'))
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'common'))
 
 from models import *
 import monitors
@@ -43,7 +43,7 @@ def build_argparser():
     args = parser.add_argument_group('Options')
     args.add_argument('-h', '--help', action='help', default=SUPPRESS, help='Show this help message and exit.')
     args.add_argument('-m', '--model', help='Required. Path to an .xml file with a trained model.',
-                      required=True, type=str)
+                      required=True, type=Path)
     args.add_argument('-at', '--architecture_type', help='Required. Specify model\' architecture type.',
                       type=str, required=True, choices=('ssd', 'yolo', 'faceboxes', 'centernet', 'retina'))
     args.add_argument('-i', '--input', required=True, type=str,


### PR DESCRIPTION
Using `pathlib` results in more compact and correct code compared to `os.path` (or just plain string manipulation), so I think it's about time we migrated the demos to it.

`object_detection_demo` is as good a place to start as any, and by updating `common/models` I create an incentive for future demos to use `pathlib` as well. :)