### PR TITLE
flake8: enable the pycodestyle deprecation warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,3 +21,5 @@ select=
     F8,
     # raise NotImplemented should be raise NotImplementedError
     F901,
+    # deprecation warnings
+    W6,

--- a/ci/documentation_updater/documentation_updater.py
+++ b/ci/documentation_updater/documentation_updater.py
@@ -79,7 +79,7 @@ def convert(lines):
             result += ' '
         result += line.rstrip('\n')
     result = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1 <\2>", result) # Links transformation
-    result = result.replace("`", "\"").replace("\*", "*")
+    result = result.replace("`", "\"").replace("\\*", "*")
     return result.strip()
 
 

--- a/demos/python_demos/bert_question_answering_demo/bert_question_answering_demo.py
+++ b/demos/python_demos/bert_question_answering_demo/bert_question_answering_demo.py
@@ -71,13 +71,13 @@ def build_argparser():
 def find_sentence_range(context, s, e):
     # find start of sentence
     for c_s in range(s, max(-1, s - 200), -1):
-        if context[c_s] in "\n\.":
+        if context[c_s] in "\n.":
             c_s += 1
             break
 
     # find end of sentence
     for c_e in range(max(0, e - 1), min(len(context), e + 200), +1):
-        if context[c_e] in "\n\.":
+        if context[c_e] in "\n.":
             break
 
     return c_s, c_e

--- a/demos/python_demos/common/html_reader.py
+++ b/demos/python_demos/common/html_reader.py
@@ -32,7 +32,7 @@ def get_paragraphs(url_list):
             parser = HTMLDataExtractor(['title', 'p'])
             charset='utf-8'
             if 'Content-type' in response.headers:
-                m = re.match('.*charset=(\S+).*', response.headers['Content-type'])
+                m = re.match(r'.*charset=(\S+).*', response.headers['Content-type'])
                 if m:
                     charset = m.group(1)
             data = response.read()


### PR DESCRIPTION
Fix all existing instances of these warnings, all of which are invalid escape sequences.