### PR TITLE
demos: clean up the compiler options

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -40,28 +40,18 @@ if (WIN32)
         message(FATAL_ERROR "Only 64-bit supported on Windows")
     endif()
 
-    set_property (DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS _CRT_SECURE_NO_WARNINGS)
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SCL_SECURE_NO_WARNINGS -DNOMINMAX")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc") #no asynchronous structured exception handling
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE")
+    add_definitions(-DNOMINMAX)
+endif()
 
-    if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251 /wd4275 /wd4267") #disable some warnings
-    endif()
-elseif(UNIX)
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wuninitialized -Winit-self")
-    if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmaybe-uninitialized")
-    endif()
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -DSCL_SECURE_NO_WARNINGS)
+    add_compile_options(/wd4251 /wd4275 /wd4267) #disable some warnings
 endif()
 
 ####################################
 ## to use C++11
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-    set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-endif()
 ####################################
 
 set (GFLAGS_IS_SUBPROJECT TRUE)
@@ -70,8 +60,14 @@ set (HAVE_INTTYPES_H 1)
 
 add_subdirectory(thirdparty/gflags)
 
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+if(CMAKE_CXX_COMPILER_ID MATCHES "^GNU|(Apple)?Clang$")
+    set(COMPILER_IS_GCC_LIKE TRUE)
+else()
+    set(COMPILER_IS_GCC_LIKE FALSE)
+endif()
+
+if(COMPILER_IS_GCC_LIKE)
+    add_compile_options(-Wall)
 endif()
 
 add_subdirectory(common)

--- a/demos/python_demos/speech_recognition_demo/ctcdecode-numpy/CMakeLists.txt
+++ b/demos/python_demos/speech_recognition_demo/ctcdecode-numpy/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(artifact IN ITEMS ARCHIVE LIBRARY PDB RUNTIME)
 endforeach()
 
 # SWIG-generated code causes some warnings; disable them.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(COMPILER_IS_GCC_LIKE)
     target_compile_options(${target_name} PRIVATE -Wno-narrowing)
 endif()
 


### PR DESCRIPTION
* Use the modern CMake commands for adding compiler options.
* Remove redundant options:
  * `/EHsc` is supplied by default;
  * the various `-W` options are included in `-Wall`;
  * `-std=c++11` isn't needed, because we now require a version of CMake that supports `CMAKE_CXX_STANDARD`.
  * `/LARGEADDRESSAWARE` only makes sense on 32-bit Windows, which is not supported.
* Distinguish between Windows-specific and MSVC-specific options.
* Enable `-Wall` for Clang and not just for GCC.
