### PR TITLE
demos: fix warnings found with Clang

### DIFF
--- a/demos/common/models/include/models/detection_model_ssd.h
+++ b/demos/common/models/include/models/detection_model_ssd.h
@@ -30,8 +30,9 @@ public:
         float confidenceThreshold, bool useAutoResize,
         const std::vector<std::string>& labels = std::vector<std::string>());
 
-    std::shared_ptr<InternalModelData> preprocess(const InputData& inputData, InferenceEngine::InferRequest::Ptr& request);
-    virtual std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
+    std::shared_ptr<InternalModelData> preprocess(
+        const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
+    std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:
     virtual void prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) override;

--- a/demos/common/models/include/models/segmentation_model.h
+++ b/demos/common/models/include/models/segmentation_model.h
@@ -24,8 +24,9 @@ public:
     /// @param model_nameFileName of model to load
     SegmentationModel(const std::string& modelFileName) : ModelBase(modelFileName) {}
 
-    virtual std::shared_ptr<InternalModelData> preprocess(const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
-    virtual std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult);
+    std::shared_ptr<InternalModelData> preprocess(
+        const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
+    std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:
     virtual void prepareInputsOutputs(InferenceEngine::CNNNetwork & cnnNetwork) override;

--- a/demos/common/pipelines/src/async_pipeline.cpp
+++ b/demos/common/pipelines/src/async_pipeline.cpp
@@ -116,7 +116,7 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
                 }
                 catch (...) {
                     if (!this->callbackException) {
-                        this->callbackException = std::move(std::current_exception());
+                        this->callbackException = std::current_exception();
                     }
                 }
             }

--- a/demos/interactive_face_detection_demo/visualizer.cpp
+++ b/demos/interactive_face_detection_demo/visualizer.cpp
@@ -15,8 +15,8 @@
 EmotionBarVisualizer::EmotionBarVisualizer(std::vector<std::string> const& emotionNames, cv::Size size, cv::Size padding,
                                      double opacity, double textScale, int textThickness):
                                      emotionNames(emotionNames), size(size), padding(padding),
-                                     opacity(opacity), textScale(textScale), textThickness(textThickness),
-                                     internalPadding(0) {
+                                     opacity(opacity), textScale(textScale), textThickness(textThickness)
+{
     auto itMax = std::max_element(emotionNames.begin(), emotionNames.end(), [] (std::string const& lhs, std::string const& rhs) {
         return lhs.length() < rhs.length();
     });

--- a/demos/interactive_face_detection_demo/visualizer.hpp
+++ b/demos/interactive_face_detection_demo/visualizer.hpp
@@ -35,7 +35,6 @@ private:
     double opacity;
     double textScale;
     int textThickness;
-    int internalPadding;
 };
 
 // Drawing a photo frame around detected face


### PR DESCRIPTION
* inconsistent override qualifiers;
* unnecessary std::move;
* unused class member.