### PR TITLE
run_tests.py: explicitly pass the modified environment to demos

### DIFF
--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -150,8 +150,10 @@ def main():
 
         num_failures = 0
 
-        os.putenv('PYTHONPATH', "{}:{}/lib".format(os.environ['PYTHONPATH'], args.demo_build_dir))
-        os.putenv('PYTHONIOENCODING', 'utf-8')
+        demo_environment = {**os.environ,
+            'PYTHONIOENCODING': 'utf-8',
+            'PYTHONPATH': "{}:{}/lib".format(os.environ['PYTHONPATH'], args.demo_build_dir),
+        }
 
         for demo in demos_to_test:
             print('Testing {}...'.format(demo.full_name))
@@ -211,7 +213,8 @@ def main():
                         try:
                             start_time = timeit.default_timer()
                             subprocess.check_output(fixed_args + dev_arg + case_args,
-                                stderr=subprocess.STDOUT, universal_newlines=True, encoding='utf-8')
+                                stderr=subprocess.STDOUT, universal_newlines=True, encoding='utf-8',
+                                env=demo_environment)
                             execution_time = timeit.default_timer() - start_time
                         except subprocess.CalledProcessError as e:
                             print(e.output)


### PR DESCRIPTION
This makes it more clear that we're running the demos with a modified environment, and ensures we're not modifying the environment of any non-demo child process.