### PR TITLE
ci/requirements-demos.txt: downgrade NumPy to work around a Windows bug

### DIFF
--- a/ci/requirements-demos.txt
+++ b/ci/requirements-demos.txt
@@ -21,7 +21,7 @@ matplotlib==3.3.3         # via -r demos/python_demos/requirements.txt
 mccabe==0.6.1             # via flake8
 motmetrics==1.2.0         # via -r demos/python_demos/requirements.txt
 nibabel==3.2.1            # via -r demos/python_demos/requirements.txt
-numpy==1.19.4 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/python_demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
+numpy==1.19.3 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/python_demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
 oauthlib==3.1.0           # via requests-oauthlib
 packaging==20.8           # via nibabel, pytest
 pandas==1.1.5             # via motmetrics


### PR DESCRIPTION
See https://github.com/numpy/numpy/issues/16744. Hopefully, this bug will be fixed in Windows by the time we bump the requirements next time, so we won't need to permanently pin the NumPy version.