### PR TITLE
Remove labels list adjustment in object detection models (SSD and Yolo).

### DIFF
--- a/demos/common/models/src/detection_model_ssd.cpp
+++ b/demos/common/models/src/detection_model_ssd.cpp
@@ -126,35 +126,6 @@ void ModelSSD::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) {
     DataPtr& output = outputInfo.begin()->second;
     outputsNames.push_back(outputInfo.begin()->first);
 
-    int num_classes = 0;
-
-    if (auto ngraphFunction = cnnNetwork.getFunction()) {
-        for (const auto op : ngraphFunction->get_ops()) {
-            if (op->get_friendly_name() == outputsNames[0]) {
-                auto detOutput = std::dynamic_pointer_cast<ngraph::op::DetectionOutput>(op);
-                if (!detOutput) {
-                    throw std::logic_error("Object Detection network output layer(" + op->get_friendly_name() +
-                        ") should be DetectionOutput, but was " + op->get_type_info().name);
-                }
-
-                num_classes = detOutput->get_attrs().num_classes;
-                break;
-            }
-        }
-    }
-    else {
-        throw std::logic_error("This demo requires IR version no older than 10");
-    }
-
-    if (labels.size()) {
-        if (static_cast<int>(labels.size()) == (num_classes - 1)) {  // if network assumes default "background" class, having no label
-            labels.insert(labels.begin(), "fake");
-        }
-        else if (static_cast<int>(labels.size()) != num_classes) {
-            throw std::logic_error("The number of labels is different from numbers of model classes");
-        }
-    }
-
     const SizeVector outputDims = output->getTensorDesc().getDims();
 
     if (outputDims.size() != 4) {

--- a/demos/common/models/src/detection_model_yolo.cpp
+++ b/demos/common/models/src/detection_model_yolo.cpp
@@ -79,11 +79,6 @@ void ModelYolo3::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) {
     else {
         throw std::runtime_error("Can't get ngraph::Function. Make sure the provided model is in IR version 10 or greater.");
     }
-
-    if (!this->labels.empty() && static_cast<int>(labels.size()) != regions.begin()->second.classes) {
-        throw std::runtime_error(std::string("The number of labels (") + std::to_string(labels.size()) +
-            ") is different from numbers of model classes (" + std::to_string(regions.begin()->second.classes) + ")");
-    }
 }
 
 std::unique_ptr<ResultBase> ModelYolo3::postprocess(InferenceResult & infResult) {

--- a/demos/object_detection_demo/README.md
+++ b/demos/object_detection_demo/README.md
@@ -96,7 +96,7 @@ To run the demo, you can use public or pre-trained models. To download the pre-t
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
-If labels file is used, it should correspond to model output. Demo suggests labels listed in the file to be indexed from 0, one line - one label (i.e. very first line contains label for ID 0). Note that s	ome models may return labels IDs in range 1..N, in this case label file should contain "background" label at the very first line.
+If labels file is used, it should correspond to model output. Demo suggests labels listed in the file to be indexed from 0, one line - one label (i.e. very first line contains label for ID 0). Note that some models may return labels IDs in range 1..N, in this case label file should contain "background" label at the very first line.
 
 You can use the following command to do inference on GPU with a pre-trained object detection model:
 ```sh

--- a/demos/object_detection_demo/README.md
+++ b/demos/object_detection_demo/README.md
@@ -96,6 +96,8 @@ To run the demo, you can use public or pre-trained models. To download the pre-t
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
+If labels file is used, it should correspond to model output. Demo suggests labels listed in the file to be indexed from 0, one line - one label (i.e. very first line contains label for ID 0). Note that s	ome models may return labels IDs in range 1..N, in this case label file should contain "background" label at the very first line.
+
 You can use the following command to do inference on GPU with a pre-trained object detection model:
 ```sh
 ./object_detection_demo -i <path_to_video>/inputVideo.mp4 -at ssd -m <path_to_model>/ssd.xml -d GPU


### PR DESCRIPTION
Algorithm for labels list adjustment (adding class for background) is removed. Check for labels list to correspond to number of output classes is removed.
If there's no label to some particular ID it will be shown as Label #N