### PR TITLE
AC: added info about dumped annotation

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/__init__.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from .format_converter import BaseFormatConverter
-from .convert import make_subset, save_annotation, analyze_dataset
+from .convert import make_subset, save_annotation, analyze_dataset, DatasetConversionInfo
 from .market1501 import Market1501Converter
 from .veri776 import VeRi776Converter
 from .mars import MARSConverter
@@ -99,6 +99,7 @@ from .wflw import WFLWConverter
 
 __all__ = [
     'BaseFormatConverter',
+    'DatasetConversionInfo',
     'make_subset',
     'save_annotation',
     'analyze_dataset',

--- a/tools/accuracy_checker/accuracy_checker/dataset.py
+++ b/tools/accuracy_checker/accuracy_checker/dataset.py
@@ -17,9 +17,10 @@ limitations under the License.
 from copy import deepcopy
 from pathlib import Path
 import warnings
+import pickle
 import numpy as np
 
-from .annotation_converters import BaseFormatConverter, save_annotation, make_subset, analyze_dataset
+from .annotation_converters import BaseFormatConverter, DatasetConversionInfo, save_annotation, make_subset, analyze_dataset
 from .config import (
     ConfigValidator,
     StringField,
@@ -122,7 +123,7 @@ class Dataset:
                     dataset_name=self._config['name'], file=meta_name))
             print_info('Converted annotation for {dataset_name} dataset will be saved to {file}'.format(
                 dataset_name=self._config['name'], file=Path(annotation_name)))
-            save_annotation(annotation, meta, Path(annotation_name), meta_name)
+            save_annotation(annotation, meta, Path(annotation_name), meta_name, self._config)
 
         self._annotation = annotation
         self._meta = meta or {}
@@ -329,6 +330,14 @@ def read_annotation(annotation_file: Path):
 
     result = []
     with annotation_file.open('rb') as file:
+        try:
+            first_obj = pickle.load(file)
+            if isinstance(first_obj, DatasetConversionInfo):
+                describe_cached_dataset(first_obj)
+            else:
+                result.append(first_obj)
+        except EOFError:
+            return result
         while True:
             try:
                 result.append(BaseRepresentation.load(file))
@@ -356,6 +365,21 @@ def create_subset(annotation, subsample_size, subsample_seed, shuffle=True):
     if subsample_size < 1:
         raise ConfigError('subsample_size should be > 0')
     return make_subset(annotation, subsample_size, subsample_seed, shuffle)
+
+
+def describe_cached_dataset(dataset_info):
+    print_info('Loaded dataset info:')
+    if dataset_info.dataset_name:
+        print_info('\tDataset name: {}'.format(dataset_info.dataset_name))
+    print_info('\tAccuracy Checker version {}'.format(dataset_info.ac_version))
+    print_info('\tDataset size {}'.format(dataset_info.dataset_size))
+    print_info('\tConversion parameters:')
+    for key, value in dataset_info.conversion_parameters.items():
+        print_info('\t\t{key}: {value}'.format(key=key, value=value))
+    if dataset_info.subset_parameters:
+        print_info('\nSubset selection parameters:')
+        for key, value in dataset_info.subset_parameters.items():
+            print_info('\t\t{key}: {value}'.format(key=key, value=value))
 
 
 class DatasetWrapper:

--- a/tools/accuracy_checker/accuracy_checker/dataset.py
+++ b/tools/accuracy_checker/accuracy_checker/dataset.py
@@ -20,7 +20,9 @@ import warnings
 import pickle
 import numpy as np
 
-from .annotation_converters import BaseFormatConverter, DatasetConversionInfo, save_annotation, make_subset, analyze_dataset
+from .annotation_converters import (
+    BaseFormatConverter, DatasetConversionInfo, save_annotation, make_subset, analyze_dataset
+)
 from .config import (
     ConfigValidator,
     StringField,

--- a/tools/accuracy_checker/tests/test_dataset.py
+++ b/tools/accuracy_checker/tests/test_dataset.py
@@ -130,7 +130,7 @@ class TestAnnotationConversion:
         )
         Dataset(config)
 
-        annotation_saver_mock.assert_called_once_with(converted_annotation, None, Path('custom'), None)
+        annotation_saver_mock.assert_called_once_with(converted_annotation, None, Path('custom'), None, config)
 
     def test_annotation_conversion_subset_size(self, mocker):
         addition_options = {
@@ -326,7 +326,7 @@ class TestAnnotationConversion:
         )
         mocker.patch('pathlib.Path.exists', return_value=False)
         Dataset(config)
-        annotation_saver_mock.assert_called_once_with([converted_annotation[1]], None, Path('custom'), None)
+        annotation_saver_mock.assert_called_once_with([converted_annotation[1]], None, Path('custom'), None, config)
 
     def test_annotation_conversion_subset_with_disabled_shuffle(self, mocker):
         addition_options = {


### PR DESCRIPTION
now converted annotation will store info about conversion.
These changes are backward compatible, so old annotations without such info still can be used