### PR TITLE
downloader: fix archive unpacking when --output_dir is a relative path

### DIFF
--- a/tools/downloader/common.py
+++ b/tools/downloader/common.py
@@ -448,7 +448,7 @@ class PostprocUnpackArchive(Postproc):
 
         reporter.print_section_heading('Unpacking {}', postproc_file)
 
-        shutil.unpack_archive(str(postproc_file), str(output_dir / postproc_file.parent), self.format)
+        shutil.unpack_archive(str(postproc_file), str(postproc_file.parent), self.format)
         postproc_file.unlink()  # Remove the archive
 
 Postproc.types['unpack_archive'] = PostprocUnpackArchive


### PR DESCRIPTION
`postproc_file` already contains `output_dir` in it.