### PR TITLE
AC: fix storing conversion meta if multiple path provided

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
@@ -266,6 +266,10 @@ def get_conversion_attributes(config, dataset_size):
     for key, value in config.get('annotation_conversion', {}).items():
         if key in config.get('_command_line_mapping', {}):
             m_path = config['_command_line_mapping'][key]
+            if not m_path:
+                conversion_parameters[key] = str(value)
+                continue
+
             if isinstance(m_path, list):
                 for m_path in config['_command_line_mapping'][key]:
                     if is_relative_to(value, m_path):

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
@@ -33,7 +33,7 @@ from ..representation import (
 from ..utils import get_path, OrderedSet
 from ..data_analyzer import BaseDataAnalyzer
 from .format_converter import BaseFormatConverter
-from ..utils import cast_to_bool
+from ..utils import cast_to_bool, is_relative_to
 
 DatasetConversionInfo = namedtuple('DatasetConversionInfo',
                                    [
@@ -265,7 +265,13 @@ def get_conversion_attributes(config, dataset_size):
     conversion_parameters = copy.deepcopy(config.get('annotation_conversion', {}))
     for key, value in config.get('annotation_conversion', {}).items():
         if key in config.get('_command_line_mapping', {}):
-            conversion_parameters[key] = str(value.relative_to(config['_command_line_mapping'][key]))
+            m_path = config['_command_line_mapping'][key]
+            if isinstance(m_path, list):
+                for m_path in config['_command_line_mapping'][key]:
+                    if is_relative_to(value, m_path):
+                        break
+            conversion_parameters[key] = str(value.relative_to(m_path))
+
     subset_size = config.get('subsample_size')
     subset_parameters = {}
     if subset_size is not None:

--- a/tools/accuracy_checker/accuracy_checker/config/config_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_reader.py
@@ -683,8 +683,10 @@ def process_config(
             if annotation_conversion_config:
                 command_line_conversion = (create_command_line_mapping(annotation_conversion_config,
                                                                        'source', ANNOTATION_CONVERSION_PATHS))
-                datasets_config['_command_line_mapping'] = {key: args[value]
-                                                            for key, value in command_line_conversion.items()}
+                datasets_config['_command_line_mapping'] = {
+                    key: args[value] if not isinstance(value, list) else [args[v] for v in value]
+                    for key, value in command_line_conversion.items()
+                }
                 merge_entry_paths(command_line_conversion, annotation_conversion_config, args)
             if 'preprocessing' in datasets_config:
                 for preprocessor in datasets_config['preprocessing']:

--- a/tools/accuracy_checker/accuracy_checker/config/config_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_reader.py
@@ -683,10 +683,9 @@ def process_config(
             if annotation_conversion_config:
                 command_line_conversion = (create_command_line_mapping(annotation_conversion_config,
                                                                        'source', ANNOTATION_CONVERSION_PATHS))
-                datasets_config['_command_line_mapping'] = {
-                    key: args[value] if not isinstance(value, list) else [args[v] for v in value]
-                    for key, value in command_line_conversion.items()
-                }
+                datasets_config['_command_line_mapping'] = prepare_commandline_conversion_mapping(
+                    command_line_conversion, args
+                )
                 merge_entry_paths(command_line_conversion, annotation_conversion_config, args)
             if 'preprocessing' in datasets_config:
                 for preprocessor in datasets_config['preprocessing']:
@@ -863,3 +862,19 @@ def _add_subset_specific_arg(dataset_entry, arguments):
 
     if 'subsample_size' in arguments and arguments.subsample_size is not None:
         dataset_entry['subsample_size'] = arguments.subsample_size
+
+
+def prepare_commandline_conversion_mapping(commandline_conversion, args):
+    mapping = {}
+    for key, value in commandline_conversion.items():
+        if not isinstance(value, list):
+            mapping[key] = args.get(value)
+        else:
+            possible_paths = []
+            for v in value:
+                if args.get(v) is None:
+                    continue
+                possible_paths.append(args[v])
+            mapping[key] = possible_paths
+
+    return mapping

--- a/tools/accuracy_checker/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/accuracy_checker/utils.py
@@ -490,6 +490,14 @@ class OrderedSet(MutableSet):
         return set(self) == set(other)
 
 
+def is_relative_to(path, *other):
+    try:
+        Path(path).relative_to(*other)
+        return True
+    except ValueError:
+        return False
+
+
 def get_parameter_value_from_config(config, parameters, key):
     if key not in parameters.keys():
         return None


### PR DESCRIPTION
some annotation conversion parameters have multiple possible sources (e.g. vocab files can be located in model_dir, data_dir or model_attributes_dir) stored as list of paths. Current fix resolves this situation.