### PR TITLE
Add a script to prepare documentation for inclusion into OpenVINO docs

### DIFF
--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+This script prepares the OMZ documentation for inclusion into the OpenVINO
+documentation. This currently involves two things:
+
+* Inserting Doxygen page IDs into all pages. Without them, Doxygen autogenerates
+  ID based on the Markdown file paths. The advantages of explicit IDs are that:
+
+  a) the Doxygen page URLs look nicer;
+  b) if we decide to change the layout of the documentation files, we can
+     do so without affecting the page IDs (by updating this script so that it
+     assigns the same IDs as before), thus not breaking any documentation links.
+
+* Generating a Doxygen layout file.
+
+The script also runs some basic checks on the documentation contents.
+
+Install dependencies from requirements-documentation.in to use this script.
+'''
+
+import argparse
+import logging
+import re
+import shutil
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+
+from pathlib import Path
+
+import mistune
+import yaml
+
+OMZ_ROOT = Path(__file__).resolve().parents[1]
+
+# For most task types, a simple transformation yields a human-readable
+# English description, but for a few types it's useful to override it
+# to improve consistency and grammar.
+HUMAN_READABLE_TASK_TYPES = {
+    'detection': 'Object Detection',
+    'object_attributes': 'Object Attribute Estimation',
+    'text_to_speech': 'Text-to-speech',
+    **{id: id.replace('_', ' ').title() for id in [
+        'action_recognition',
+        'classification',
+        'colorization',
+        'face_recognition',
+        'feature_extraction',
+        'head_pose_estimation',
+        'human_pose_estimation',
+        'image_inpainting',
+        'image_processing',
+        'image_translation',
+        'instance_segmentation',
+        'machine_translation',
+        'monocular_depth_estimation',
+        'optical_character_recognition',
+        'question_answering',
+        'semantic_segmentation',
+        'sound_classification',
+        'speech_recognition',
+        'style_transfer',
+        'token_recognition',
+    ]},
+}
+
+parse_markdown = mistune.create_markdown(renderer=mistune.AstRenderer())
+
+
+def get_all_ast_nodes(ast_nodes):
+    for node in ast_nodes:
+        yield node
+        if 'children' in node:
+            # workaround for https://github.com/lepture/mistune/issues/269
+            if isinstance(node['children'], str):
+                yield {'type': 'text', 'text': node['children']}
+            else:
+                yield from get_all_ast_nodes(node['children'])
+
+
+def get_text_from_ast(ast_nodes):
+    def get_text_from_node(node):
+        if node['type'] != 'text':
+            raise RuntimeError(f'unsupported node type: {node["type"]}')
+        return node['text']
+
+    return ''.join(map(get_text_from_node, ast_nodes))
+
+
+def add_page(output_root, parent, *, id=None, path=None, title=None):
+    if parent.tag == 'tab':
+        parent.attrib['type'] = 'usergroup'
+
+    element = ET.SubElement(parent, 'tab', type='user', title=title, url='@ref ' + id if id else '')
+
+    if not path:
+        assert title, "title must be specified if path isn't"
+
+        element.attrib['title'] = title
+        return element
+
+    output_path = output_root / path
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with (OMZ_ROOT / path).open('r', encoding='utf-8') as input_file:
+        lines = input_file.readlines()
+
+    ast = parse_markdown(''.join(lines))
+
+    if not ast or ast[0]['type'] != 'heading' or ast[0]['level'] != 1:
+        raise RuntimeError(f'{path}: must begin with level 1 heading')
+
+    if not title:
+        title = get_text_from_ast(ast[0]['children'])
+
+    element.attrib['title'] = title
+
+    # the only way to override the ID that Doxygen gives Markdown pages
+    # is to add a label to the top-level heading. For simplicity, we hardcode
+    # the assumption that the file immediately begins with that heading.
+    if not lines[0].startswith('# '):
+        raise RuntimeError(f'{path}: line 1 must contain the level 1 heading')
+
+    assert id, "id must be specified if path is"
+    lines[0] = lines[0].rstrip('\n') + f' {{#{id}}}\n'
+
+    with (output_root / path).open('w', encoding='utf-8') as output_file:
+        output_file.writelines(lines)
+
+    # copy all referenced images
+    image_urls = [node['src'] for node in get_all_ast_nodes(ast) if node['type'] == 'image']
+
+    for image_url in image_urls:
+        parsed_image_url = urllib.parse.urlparse(image_url)
+        if parsed_image_url.scheme or parsed_image_url.netloc:
+            continue # not a relative URL
+
+        image_rel_path = path.parent / urllib.request.url2pathname(parsed_image_url.path)
+
+        (output_root / image_rel_path.parent).mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(OMZ_ROOT / image_rel_path, output_root / image_rel_path)
+
+    return element
+
+
+def sort_titles(element):
+    element[:] = sorted(element, key=lambda child: child.attrib['title'])
+
+
+def add_accuracy_checker_pages(output_root, parent_element):
+    ac_group_element = add_page(output_root, parent_element,
+        id='omz_tools_accuracy_checker', path='tools/accuracy_checker/README.md',
+        title='Accuracy Checker Tool')
+
+    for md_path in OMZ_ROOT.glob('tools/accuracy_checker/*/**/*.md'):
+        md_path_rel = md_path.relative_to(OMZ_ROOT)
+
+        if md_path_rel.stem == 'README':
+            id_suffix = ''
+        elif md_path_rel.stem.endswith('_readme'):
+            id_suffix = '_' + md_path_rel.stem[:-7]
+        else:
+            raise RuntimeError('{}: unexpected documentation file name')
+
+        add_page(output_root, ac_group_element,
+            id='omz_' + '_'.join(md_path_rel.parent.parts) + id_suffix, path=md_path_rel)
+
+    sort_titles(ac_group_element)
+
+
+def add_model_pages(output_root, parent_element, group, group_title):
+    group_element = add_page(output_root, parent_element, title=group_title,
+        id=f'omz_models_group_{group}', path=f'models/{group}/index.md')
+
+    task_type_elements = {}
+
+    for md_path in sorted(OMZ_ROOT.glob(f'models/{group}/*/**/*.md')):
+        md_path_rel = md_path.relative_to(OMZ_ROOT)
+
+        model_name = md_path_rel.parts[2]
+
+        expected_md_paths = [
+            Path('models', group, model_name, model_name + '.md'),
+            Path('models', group, model_name, 'description', model_name + '.md'),
+        ]
+
+        if md_path_rel not in expected_md_paths:
+            raise RuntimeError(f'{md_path_rel}: unexpected documentation file')
+
+        # FIXME: use the info dumper to query model information instead of
+        # parsing the configs. We're not doing that now, because the info
+        # dumper doesn't support composite models yet.
+        model_yml_path = OMZ_ROOT / 'models' / group / model_name / 'model.yml'
+        composite_model_yml_path = model_yml_path.with_name('composite-model.yml')
+
+        if model_yml_path.exists():
+            expected_title = model_name
+
+            with open(model_yml_path, 'rb') as f:
+                config = yaml.safe_load(f)
+
+            task_type = config['task_type']
+        elif composite_model_yml_path.exists():
+            expected_title = f'{model_name} (composite)'
+
+            with open(composite_model_yml_path, 'rb') as f:
+                config = yaml.safe_load(f)
+
+            task_type = config['task_type']
+        else:
+            logging.warning(
+                '{}: no corresponding model.yml or composite-model.yml found; skipping'
+                    .format(md_path_rel))
+            continue
+
+        if task_type not in task_type_elements:
+            task_type_elements[task_type] = add_page(output_root, group_element,
+                title=HUMAN_READABLE_TASK_TYPES[task_type] + ' Models')
+
+        # All model names are unique, so we don't need to include the group
+        # in the page ID. However, we do prefix "model_", so that model pages
+        # don't conflict with any other pages in the omz_models namespace that
+        # might be added later.
+        page_id = 'omz_models_model_' + re.sub(r'[^a-zA-Z0-9]', '_', model_name)
+
+        model_element = add_page(output_root, task_type_elements[task_type],
+            id=page_id, path=md_path_rel)
+
+        if model_element.attrib['title'] != expected_title:
+            raise RuntimeError(f'{md_path_rel}: should have title "{expected_title}"')
+
+    sort_titles(group_element)
+
+
+def main():
+    logging.basicConfig()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output_dir', type=Path,
+        help='directory to output prepared documentation files into')
+
+    args = parser.parse_args()
+
+    output_root = args.output_dir
+
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    doxygenlayout_element = ET.Element('doxygenlayout', version='1.0')
+    navindex_element = ET.SubElement(doxygenlayout_element, 'navindex')
+
+    add_accuracy_checker_pages(output_root, navindex_element)
+
+    add_page(output_root, navindex_element,
+        id='omz_tools_downloader', path='tools/downloader/README.md', title='Model Downloader')
+
+    trained_models_group_element = add_page(output_root, navindex_element,
+        title="Trained Models")
+
+    add_model_pages(output_root, trained_models_group_element,
+        'intel', "Intel's Pre-trained Models")
+    add_model_pages(output_root, trained_models_group_element,
+        'public', "Public Pre-trained Models")
+
+    demos_group_element = add_page(output_root, navindex_element,
+        title="Demos", id='omz_demos', path='demos/README.md')
+
+    for md_path in [
+        *OMZ_ROOT.glob('demos/*_demo/*/README.md'),
+        *OMZ_ROOT.glob('demos/*_demo_*/*/README.md'),
+    ]:
+        md_path_rel = md_path.relative_to(OMZ_ROOT)
+
+        # <name>_<implementation>
+        demo_id = '_'.join(md_path_rel.parts[1:3])
+
+        demo_element = add_page(output_root, demos_group_element,
+            id='omz_demos_' + demo_id, path=md_path_rel)
+
+        if not re.search(r'\bDemo\b', demo_element.attrib['title']):
+            raise RuntimeError(f'{md_path_rel}: title must contain "Demo"')
+
+    sort_titles(demos_group_element)
+
+    with (output_root / 'DoxygenLayout.xml').open('wb') as layout_file:
+        ET.ElementTree(doxygenlayout_element).write(layout_file)
+
+if __name__ == '__main__':
+    main()

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -172,14 +172,14 @@ def add_accuracy_checker_pages(output_root, parent_element):
         md_path_rel = md_path.relative_to(OMZ_ROOT)
 
         if md_path_rel.stem == 'README':
-            id_suffix = ''
+            id_suffix = md_path_rel.parent.name
         elif md_path_rel.stem.endswith('_readme'):
-            id_suffix = '_' + md_path_rel.stem[:-7]
+            id_suffix = md_path_rel.stem[:-7]
         else:
             raise RuntimeError('{}: unexpected documentation file name')
 
         add_page(output_root, ac_group_element,
-            id='omz_' + '_'.join(md_path_rel.parent.parts) + id_suffix, path=md_path_rel)
+            id=f'omz_tools_accuracy_checker_{id_suffix}', path=md_path_rel)
 
     sort_titles(ac_group_element)
 

--- a/ci/requirements-documentation.in
+++ b/ci/requirements-documentation.in
@@ -1,0 +1,2 @@
+mistune==2.0.0a6
+pyyaml

--- a/models/intel/action-recognition-0001/composite-model.yml
+++ b/models/intel/action-recognition-0001/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: action_recognition

--- a/models/intel/driver-action-recognition-adas-0002/composite-model.yml
+++ b/models/intel/driver-action-recognition-adas-0002/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: action_recognition

--- a/models/intel/formula-recognition-medium-scan-0001/composite-model.yml
+++ b/models/intel/formula-recognition-medium-scan-0001/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: token_recognition

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/composite-model.yml
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: token_recognition

--- a/models/intel/text-spotting-0003/composite-model.yml
+++ b/models/intel/text-spotting-0003/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: optical_character_recognition

--- a/models/public/forward-tacotron/composite-model.yml
+++ b/models/public/forward-tacotron/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: text_to_speech

--- a/models/public/mtcnn/composite-model.yml
+++ b/models/public/mtcnn/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: detection

--- a/models/public/wavernn/composite-model.yml
+++ b/models/public/wavernn/composite-model.yml
@@ -1,0 +1,1 @@
+task_type: text_to_speech


### PR DESCRIPTION
The layout file and page IDs generated by the script were previously maintained by the OpenVINO documentation team. Having them generated automatically lifts that burden off their shoulders and also makes it possible for us to autogenerate other aspects of the documentation in the future.

In the generated layout file, the titles of some pages are overridden. This is so that they match the titles in the table of contents from the previous releases of OpenVINO. Ideally, we should align the titles in the layout with the titles in the pages themselves, but I'm not yet sure which ones are better, so I'm deferring that for later.

About the requirements file: I used a pretty generic name for it (requirements-documentation), because I expect that other
documentation-related scripts (e.g. a model index checker) might be added later. I'll add a version with pinned dependencies
(`requirements-documentation.txt`) when I integrate this script into CI.