### PR TITLE
AC: fix ID search logic for super resolution directory based conversion

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/super_resolution_converter.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/super_resolution_converter.py
@@ -479,7 +479,9 @@ class SRDirectoryBased(BaseFormatConverter):
             return numbers
 
         idx = get_index(file_name)
-        found_files = list(search_dir.glob('*{}*'.format(idx)))
+        found_files = []
+        for i in idx:
+            found_files.extend(search_dir.glob('*{}*'.format(i)))
         if not found_files:
             return None
         return found_files[0]


### PR DESCRIPTION
majority SR datasets has several input images for different upscaling factor (x2, x3, x4, e.t.c.), sometimes, this index is also included to file name and matched to regular expression for index search if relaxed names given. 