### PR TITLE
docs: replace HTML links with Markdown links

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -128,7 +128,7 @@ Please run the following command before the demos build (assuming that the binar
 source <INSTALL_DIR>/deployment_tools/bin/setupvars.sh
 ```
 You can also build demos manually using Inference Engine built from the [openvino](https://github.com/openvinotoolkit/openvino) repo. In this case please set `InferenceEngine_DIR` environment variable to a folder containing `InferenceEngineConfig.cmake` and `ngraph_DIR` to a folder containing `ngraphConfig.cmake` in a build folder. Please also set the `OpenCV_DIR` to point to the OpenCV package to use. The same OpenCV version should be used both for Inference Engine and demos build. Alternatively these values can be provided via command line while running `cmake`. See [CMake's search procedure](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure).
-Please refer to the Inference Engine <a href="https://github.com/openvinotoolkit/openvino/blob/master/build-instruction.md">build instructions</a>
+Please refer to the Inference Engine [build instructions](https://github.com/openvinotoolkit/openvino/blob/master/build-instruction.md)
 for details. Please also add path to built Inference Engine libraries to `LD_LIBRARY_PATH` (Linux*) or `PATH` (Windows*) variable before building the demos.
 
 ### <a name="build_demos_linux"></a>Build the Demo Applications on Linux*

--- a/models/intel/driver-action-recognition-adas-0002/description/driver-action-recognition-adas-0002.md
+++ b/models/intel/driver-action-recognition-adas-0002/description/driver-action-recognition-adas-0002.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-This is an action recognition composite model for the driver monitoring use case, consisting of encoder and decoder parts. The encoder model uses Video Transformer approach with MobileNetv2 encoder. It is able to recognize actions such as drinking, doing hair or making up, operating the radio, reaching behind, safe driving, talking on the phone, texting. The full list of recognized actions is located <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/demos/action_recognition_demo/python/driver_actions.txt">here</a>.
+This is an action recognition composite model for the driver monitoring use case, consisting of encoder and decoder parts. The encoder model uses Video Transformer approach with MobileNetv2 encoder. It is able to recognize actions such as drinking, doing hair or making up, operating the radio, reaching behind, safe driving, talking on the phone, texting. The full list of recognized actions is located [here](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/demos/action_recognition_demo/python/driver_actions.txt).
 
 ## Example
 

--- a/tools/accuracy_checker/README.md
+++ b/tools/accuracy_checker/README.md
@@ -48,7 +48,7 @@ In order to evaluate some models required frameworks have to be installed. Accur
 - [MXNet](https://mxnet.apache.org/).
 - [OpenCV DNN](https://docs.opencv.org/4.1.0/d2/de6/tutorial_py_setup_in_ubuntu.html).
 - [TensorFlow](https://www.tensorflow.org/).
-- <a href="https://github.com/microsoft/onnxruntime/blob/master/README.md">ONNX Runtime</a>.
+- [ONNX Runtime](https://github.com/microsoft/onnxruntime/blob/master/README.md).
 - [PyTorch](https://pytorch.org/)
 
 You can use any of them or several at a time. For correct work, Accuracy Checker requires at least one. You are able postpone installation of other frameworks and install them when they will be necessary.
@@ -156,7 +156,7 @@ models:
     - name: dataset_name
 ```
 Optionally you can use global configuration. It can be useful for avoiding duplication if you have several models which should be run on the same dataset.
-Example of global definitions file can be found <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/dataset_definitions.yml">here</a>. Global definitions will be merged with evaluation config in the runtime by dataset name.
+Example of global definitions file can be found [here](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/dataset_definitions.yml). Global definitions will be merged with evaluation config in the runtime by dataset name.
 Parameters of global configuration can be overwritten by local config (e.g. if in definitions specified resize with destination size 224 and in the local config used resize with size 227, the value in config - 227 will be used as resize parameter)
 You can use field `global_definitions` for specifying path to global definitions directly in the model config or via command line arguments (`-d`, `--definitions`).
 
@@ -186,7 +186,7 @@ If your dataset data is a well-known competition problem (COCO, Pascal VOC, and 
 it is reasonable to declare it in some global configuration file ([definition file](dataset_definitions.yml)). This way in your local configuration file you can provide only
 `name` and all required steps will be picked from global one. To pass path to this global configuration use `--definition` argument of CLI.
 
-If you want to evaluate models using prepared config files and well-known datasets, you need to organize folders with validation datasets in a certain way. More detailed information about dataset preparation you can find in <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md">Dataset Preparation Guide</a>.
+If you want to evaluate models using prepared config files and well-known datasets, you need to organize folders with validation datasets in a certain way. More detailed information about dataset preparation you can find in [Dataset Preparation Guide](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md).
 
 Each dataset must have:
 

--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/README.md
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/README.md
@@ -23,29 +23,29 @@ Optionally you can provide `module_config` section which contains config for cus
 
 ## Examples
 * **Sequential Action Recognition Evaluator** demonstrates how to run Action Recognition models with encoder + decoder architecture.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/sequential_action_recognition_evaluator.py">Evaluator code</a>.
-  Configuration file example: <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/action-recognition-0001.yml">action-recognition-0001</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/sequential_action_recognition_evaluator.py).
+  Configuration file example: [action-recognition-0001](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/action-recognition-0001.yml).
 
 * **MTCNN Evaluator** shows how to run MTCNN model.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/mtcnn_evaluator.py">Evaluator code</a>.
-  Configuration file example: <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/mtcnn.yml">mtcnn</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/mtcnn_evaluator.py).
+  Configuration file example: [mtcnn](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/mtcnn.yml).
 
 * **Text Spotting Evaluator** demonstrates how to evaluate the `text-spotting-0003` model via Accuracy Checker.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_spotting_evaluator.py">Evaluator code</a>.
-  Configuration file example: <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/text-spotting-0003.yml">text-spotting-0003</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_spotting_evaluator.py).
+  Configuration file example: [text-spotting-0003](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/text-spotting-0003.yml).
 
 * **Automatic Speech Recognition Evaluator** shows how to evaluate speech recognition pipeline (encoder + decoder).
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/asr_encoder_decoder_evaluator.py">Evaluator code</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/asr_encoder_decoder_evaluator.py).
 
 * **Im2latex formula recognition** demonstrates how to run encoder-decoder model for extractring latex formula from image.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/im2latex_evaluator.py">Evaluator code</a>.
-  Configuration file example: <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/im2latex-medium-0002.yml">im2latex-medium-0002</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/im2latex_evaluator.py).
+  Configuration file example: [im2latex-medium-0002](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/configs/im2latex-medium-0002.yml).
 
 * **I3D Evaluator** demonstrates how to evaluate two-stream I3D model (RGB + Flow).
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/i3d_evaluator.py">Evaluator code</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/i3d_evaluator.py).
 
 * **Text to speech Evaluator** demonstrates how to evaluate text to speech pipeline for Forward Tacotron and MelGAN upsampler.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_to_speech_evaluator.py">Evaluator code</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/text_to_speech_evaluator.py).
 
 * **LPCNet Evaluator** demonstrates how to evaluate LPCNet vocoder pipeline.
-  <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/lpcnet_evaluator.py">Evaluator code</a>.
+  [Evaluator code](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/lpcnet_evaluator.py).

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
@@ -54,7 +54,7 @@ Each supported device has own set of supported configuration parameters which ca
 CPU:
    ENFORCE_BF16: "NO"
 ```
-Device config example can be found [here](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/sample/disable_bfloat16_device_config.yml)
+Device config example can be found [here](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/sample/disable_bfloat16_device_config.yml).
 
 Beside that, you can launch model in `async_mode`, enable this option and optionally provide the number of infer requests (`num_requests`), which will be used in evaluation process. By default, if `num_requests` not provided or used value `AUTO`, automatic number request assignment for specific device will be performed
 For multi device configuration async mode used always. You can provide number requests for each device as part device specification: `MULTI:device_1(num_req_1),device_2(num_req_2)` or in `num_requests` config section (for this case comma-separated list of integer numbers or one value if number requests for all devices equal can be used).

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher_readme.md
@@ -54,7 +54,7 @@ Each supported device has own set of supported configuration parameters which ca
 CPU:
    ENFORCE_BF16: "NO"
 ```
-Device config example can be found <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/sample/disable_bfloat16_device_config.yml">here</a>
+Device config example can be found [here](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/tools/accuracy_checker/sample/disable_bfloat16_device_config.yml)
 
 Beside that, you can launch model in `async_mode`, enable this option and optionally provide the number of infer requests (`num_requests`), which will be used in evaluation process. By default, if `num_requests` not provided or used value `AUTO`, automatic number request assignment for specific device will be performed
 For multi device configuration async mode used always. You can provide number requests for each device as part device specification: `MULTI:device_1(num_req_1),device_2(num_req_2)` or in `num_requests` config section (for this case comma-separated list of integer numbers or one value if number requests for all devices equal can be used).

--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
@@ -5,7 +5,7 @@ For enabling ONNX Runtime launcher you need to add `framework: onnx_runtime` in 
 * `device` - specifies which device will be used for infer (`cpu`, `gpu` and so on). Optional, cpu used as default or can depend on used executable provider.
 * `model`- path to the network file in ONNX format.
 * `adapter` - approach how raw output will be converted to representation of dataset problem, some adapters can be specific to framework. You can find detailed instruction how to use adapters [here](../adapters/README.md).
-* `execution_providers` - list of execution providers for evaluation, e.g. <a href="https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md">OpenVINO Execution Provider</a>. Default [`CPUExecutionProvider`] used.
+* `execution_providers` - list of execution providers for evaluation, e.g. [OpenVINO Execution Provider](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md). Default [`CPUExecutionProvider`] used.
 
 **Note: execution providers available only with newest versions of ONNXRuntime, if your installed version does not support such API, please update or does not specify this field.**
 

--- a/tools/accuracy_checker/sample/README.md
+++ b/tools/accuracy_checker/sample/README.md
@@ -40,7 +40,7 @@ Now try edit config, to run SampLeNet on other device or framework (e.g. Caffe, 
 
 ###  Additional useful resources
 
-* <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/opencv_sample_config.yml">config</a>() for running SampleNet via [OpenCV launcher](../accuracy_checker/launcher/opencv_launcher_readme.md)
-* <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/sample_blob_config.yml">config</a> for running SampleNet using compiled executable network blob.
+* [config](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/opencv_sample_config.yml)() for running SampleNet via [OpenCV launcher](../accuracy_checker/launcher/opencv_launcher_readme.md)
+* [config](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/sample_blob_config.yml) for running SampleNet using compiled executable network blob.
 
 >**NOTE**: Not all Inference Engine plugins support compiled network blob execution.

--- a/tools/accuracy_checker/sample/README.md
+++ b/tools/accuracy_checker/sample/README.md
@@ -40,7 +40,7 @@ Now try edit config, to run SampLeNet on other device or framework (e.g. Caffe, 
 
 ###  Additional useful resources
 
-* [config](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/opencv_sample_config.yml)() for running SampleNet via [OpenCV launcher](../accuracy_checker/launcher/opencv_launcher_readme.md)
+* [config](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/opencv_sample_config.yml) for running SampleNet via [OpenCV launcher](../accuracy_checker/launcher/opencv_launcher_readme.md).
 * [config](https://github.com/openvinotoolkit/open_model_zoo/blob/master/tools/accuracy_checker/sample/sample_blob_config.yml) for running SampleNet using compiled executable network blob.
 
 >**NOTE**: Not all Inference Engine plugins support compiled network blob execution.

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -303,7 +303,7 @@ the script.
 Before you run the model quantizer, you must prepare a directory with
 the datasets required for the quantization process. This directory will be
 referred to as `<DATASET_DIR>` below. You can find more detailed information
-about dataset preparation in the <a href="https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md">Dataset Preparation Guide</a>.
+about dataset preparation in the [Dataset Preparation Guide](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md).
 
 The basic usage is to run the script like this:
 


### PR DESCRIPTION
Markdown links are shorter and more readable than HTML links, so they should be used whenever possible.

The HTML links were originally used because Doxygen didn't process external links to Markdown files correctly. This was fixed in Doxygen 1.8.16, and the OpenVINO documentation is now built using a newer version, so that bug is no longer relevant.