### PR TITLE
Enable object detection demo yolo v4 support

### DIFF
--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -134,10 +134,9 @@ class YOLO(Model):
         for row, col, n in np.ndindex(params.sides[0], params.sides[1], params.num):
             # Getting raw values for each detection bounding bFox
             bbox = predictions[0, n * bbox_size:(n + 1) * bbox_size, row, col]
-            if params.isYoloV3:
-                x, y, width, height, object_probability = bbox[:5]
-                class_probabilities = bbox[5:]
-            elif params.isYoloV4:
+            x, y, width, height, object_probability = bbox[:5]
+            class_probabilities = bbox[5:]
+            if params.isYoloV4:
                 x, y = sigmoid(bbox[:2])
                 width, height = bbox[2:4]
                 object_probability = sigmoid(bbox[4])

--- a/demos/object_detection_demo/python/models.lst
+++ b/demos/object_detection_demo/python/models.lst
@@ -48,3 +48,4 @@ yolo-v2-tiny-tf
 yolo-v2-tiny-vehicle-detection-0001
 yolo-v3-tf
 yolo-v3-tiny-tf
+yolo-v4-tf


### PR DESCRIPTION
Refer to https://github.com/openvinotoolkit/open_model_zoo/pull/1992
It was very good to get Yolov4 demo support by creating a YoloV4 optional class, but there are more parts to be changed.
Here I provide a slighter modification to enable YoloV4 support as a reference.
"-at yolo" can be useful for all yolo, yolov2, yolov3,  yolov4 series models.