### PR TITLE
regnetx-3.2gf: use the weights file that we download

### DIFF
--- a/models/public/regnetx-3.2gf/model.py
+++ b/models/public/regnetx-3.2gf/model.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pycls.core.checkpoint
+import pycls.models.model_zoo
+
+def regnetx_32gf(weights_path):
+    model = pycls.models.model_zoo.regnetx("RegNetX-3.2GF")
+    pycls.core.checkpoint.load_checkpoint(weights_path, model)
+    return model

--- a/models/public/regnetx-3.2gf/model.yml
+++ b/models/public/regnetx-3.2gf/model.yml
@@ -87,11 +87,11 @@ postprocessing:
     pattern: 'from *'
     replacement: '# \g<0>'
 conversion_to_onnx_args:
+  - --model-path=$config_dir
   - --model-path=$dl_dir
-  - --model-name=regnetx
-  - --import-module=pycls.models.model_zoo
-  - --model-param=name="RegNetX-3.2GF"
-  - --model-param=pretrained=True
+  - --model-name=regnetx_32gf
+  - --import-module=model
+  - --model-param=weights_path=r"$dl_dir/ckpt/regnetx-3.2gf.pyth"
   - --input-shape=1,3,224,224
   - --input-names=data
   - --output-names=prob


### PR DESCRIPTION
Previously, it wasn't used in any way; the model constructor just downloaded the weights anew.