### PR TITLE
Bump all CI requirement versions

### DIFF
--- a/ci/requirements-ac-test.txt
+++ b/ci/requirements-ac-test.txt
@@ -8,16 +8,16 @@ decorator==4.4.2          # via networkx
 editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
 fast-ctc-decode==0.2.5    # via -r tools/accuracy_checker/requirements.in
 imageio==2.9.0            # via scikit-image
-importlib-metadata==3.3.0  # via pluggy, pytest
-joblib==0.17.0            # via nltk, scikit-learn
+importlib-metadata==3.4.0  # via pluggy, pytest
+joblib==1.0.0             # via nltk, scikit-learn
 kiwisolver==1.3.1         # via matplotlib
-matplotlib==3.3.3         # via scikit-image
+matplotlib==3.3.4         # via scikit-image
 more-itertools==8.6.0     # via pytest
 networkx==2.5             # via scikit-image
 nibabel==3.2.1            # via -r tools/accuracy_checker/requirements.in
 nltk==3.5                 # via -r tools/accuracy_checker/requirements.in
-numpy==1.17.5             # via -r tools/accuracy_checker/requirements-core.in, -r tools/accuracy_checker/requirements.in, imageio, matplotlib, nibabel, parasail, pywavelets, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.8           # via nibabel, pytest
+numpy==1.19.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, parasail, pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
+packaging==20.9           # via nibabel, pytest
 parasail==1.2             # via -r tools/accuracy_checker/requirements.in
 pillow==8.1.0             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
 pluggy==0.13.1            # via pytest
@@ -29,18 +29,19 @@ pytest-mock==2.0.0        # via -r tools/accuracy_checker/requirements-test.in
 pytest==5.4.3             # via -r tools/accuracy_checker/requirements-test.in, pytest-mock
 python-dateutil==2.8.1    # via matplotlib
 pywavelets==1.1.1         # via scikit-image
-pyyaml==5.3.1             # via -r tools/accuracy_checker/requirements-core.in
+pyyaml==5.4.1             # via -r tools/accuracy_checker/requirements-core.in
+rawpy==0.16.0             # via -r tools/accuracy_checker/requirements.in
 regex==2020.11.13         # via nltk
 scikit-image==0.17.2      # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.23.2      # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1      # via -r tools/accuracy_checker/requirements.in
 scipy==1.5.4              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.94     # via -r tools/accuracy_checker/requirements.in
+sentencepiece==0.1.95     # via -r tools/accuracy_checker/requirements.in
 shapely==1.7.1            # via -r tools/accuracy_checker/requirements.in
 six==1.15.0               # via python-dateutil
 threadpoolctl==2.1.0      # via scikit-learn
 tifffile==2020.9.3        # via scikit-image
-tokenizers==0.9.4         # via -r tools/accuracy_checker/requirements.in
-tqdm==4.54.1              # via -r tools/accuracy_checker/requirements.in, nltk
+tokenizers==0.10.0        # via -r tools/accuracy_checker/requirements.in
+tqdm==4.56.0              # via -r tools/accuracy_checker/requirements.in, nltk
 typing-extensions==3.7.4.3  # via importlib-metadata
 wcwidth==0.2.5            # via pytest
 wheel==0.36.2             # via parasail

--- a/ci/requirements-ac-test.txt
+++ b/ci/requirements-ac-test.txt
@@ -1,48 +1,124 @@
 # use update-requirements.py to update this file
 
-atomicwrites==1.4.0       # via -r tools/accuracy_checker/requirements-test.in
-attrs==20.3.0             # via pytest
-click==7.1.2              # via nltk
-cycler==0.10.0            # via matplotlib
-decorator==4.4.2          # via networkx
-editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
-fast-ctc-decode==0.2.5    # via -r tools/accuracy_checker/requirements.in
-imageio==2.9.0            # via scikit-image
-importlib-metadata==3.4.0  # via pluggy, pytest
-joblib==1.0.0             # via nltk, scikit-learn
-kiwisolver==1.3.1         # via matplotlib
-matplotlib==3.3.4         # via scikit-image
-more-itertools==8.6.0     # via pytest
-networkx==2.5             # via scikit-image
-nibabel==3.2.1            # via -r tools/accuracy_checker/requirements.in
-nltk==3.5                 # via -r tools/accuracy_checker/requirements.in
-numpy==1.19.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, parasail, pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.9           # via nibabel, pytest
-parasail==1.2             # via -r tools/accuracy_checker/requirements.in
-pillow==8.1.0             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
-pluggy==0.13.1            # via pytest
-py-cpuinfo==7.0.0         # via -r tools/accuracy_checker/requirements.in
-py==1.10.0                # via pytest
-pydicom==2.1.2            # via -r tools/accuracy_checker/requirements.in
-pyparsing==2.4.7          # via matplotlib, packaging
-pytest-mock==2.0.0        # via -r tools/accuracy_checker/requirements-test.in
-pytest==5.4.3             # via -r tools/accuracy_checker/requirements-test.in, pytest-mock
-python-dateutil==2.8.1    # via matplotlib
-pywavelets==1.1.1         # via scikit-image
-pyyaml==5.4.1             # via -r tools/accuracy_checker/requirements-core.in
-rawpy==0.16.0             # via -r tools/accuracy_checker/requirements.in
-regex==2020.11.13         # via nltk
-scikit-image==0.17.2      # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.24.1      # via -r tools/accuracy_checker/requirements.in
-scipy==1.5.4              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.95     # via -r tools/accuracy_checker/requirements.in
-shapely==1.7.1            # via -r tools/accuracy_checker/requirements.in
-six==1.15.0               # via python-dateutil
-threadpoolctl==2.1.0      # via scikit-learn
-tifffile==2020.9.3        # via scikit-image
-tokenizers==0.10.0        # via -r tools/accuracy_checker/requirements.in
-tqdm==4.56.0              # via -r tools/accuracy_checker/requirements.in, nltk
-typing-extensions==3.7.4.3  # via importlib-metadata
-wcwidth==0.2.5            # via pytest
-wheel==0.36.2             # via parasail
-zipp==3.4.0               # via importlib-metadata
+atomicwrites==1.4.0
+    # via -r tools/accuracy_checker/requirements-test.in
+attrs==20.3.0
+    # via pytest
+click==7.1.2
+    # via nltk
+cycler==0.10.0
+    # via matplotlib
+decorator==4.4.2
+    # via networkx
+editdistance==0.5.3
+    # via -r tools/accuracy_checker/requirements.in
+fast-ctc-decode==0.2.5
+    # via -r tools/accuracy_checker/requirements.in
+imageio==2.9.0
+    # via scikit-image
+importlib-metadata==3.4.0
+    # via
+    #   pluggy
+    #   pytest
+joblib==1.0.0
+    # via
+    #   nltk
+    #   scikit-learn
+kiwisolver==1.3.1
+    # via matplotlib
+matplotlib==3.3.4
+    # via scikit-image
+more-itertools==8.6.0
+    # via pytest
+networkx==2.5
+    # via scikit-image
+nibabel==3.2.1
+    # via -r tools/accuracy_checker/requirements.in
+nltk==3.5
+    # via -r tools/accuracy_checker/requirements.in
+numpy==1.19.5
+    # via
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   imageio
+    #   matplotlib
+    #   nibabel
+    #   parasail
+    #   pywavelets
+    #   rawpy
+    #   scikit-image
+    #   scikit-learn
+    #   scipy
+    #   tifffile
+packaging==20.9
+    # via
+    #   nibabel
+    #   pytest
+parasail==1.2
+    # via -r tools/accuracy_checker/requirements.in
+pillow==8.1.0
+    # via
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   imageio
+    #   matplotlib
+    #   scikit-image
+pluggy==0.13.1
+    # via pytest
+py-cpuinfo==7.0.0
+    # via -r tools/accuracy_checker/requirements.in
+py==1.10.0
+    # via pytest
+pydicom==2.1.2
+    # via -r tools/accuracy_checker/requirements.in
+pyparsing==2.4.7
+    # via
+    #   matplotlib
+    #   packaging
+pytest-mock==2.0.0
+    # via -r tools/accuracy_checker/requirements-test.in
+pytest==5.4.3
+    # via
+    #   -r tools/accuracy_checker/requirements-test.in
+    #   pytest-mock
+python-dateutil==2.8.1
+    # via matplotlib
+pywavelets==1.1.1
+    # via scikit-image
+pyyaml==5.4.1
+    # via -r tools/accuracy_checker/requirements-core.in
+rawpy==0.16.0
+    # via -r tools/accuracy_checker/requirements.in
+regex==2020.11.13
+    # via nltk
+scikit-image==0.17.2
+    # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1
+    # via -r tools/accuracy_checker/requirements.in
+scipy==1.5.4
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   scikit-image
+    #   scikit-learn
+sentencepiece==0.1.95
+    # via -r tools/accuracy_checker/requirements.in
+shapely==1.7.1
+    # via -r tools/accuracy_checker/requirements.in
+six==1.15.0
+    # via python-dateutil
+threadpoolctl==2.1.0
+    # via scikit-learn
+tifffile==2020.9.3
+    # via scikit-image
+tokenizers==0.10.0
+    # via -r tools/accuracy_checker/requirements.in
+tqdm==4.56.0
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   nltk
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+wcwidth==0.2.5
+    # via pytest
+wheel==0.36.2
+    # via parasail
+zipp==3.4.0
+    # via importlib-metadata

--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -1,37 +1,96 @@
 # use update-requirements.py to update this file
 
-click==7.1.2              # via nltk
-cycler==0.10.0            # via matplotlib
-decorator==4.4.2          # via networkx
-editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
-fast-ctc-decode==0.2.5    # via -r tools/accuracy_checker/requirements.in
-imageio==2.9.0            # via scikit-image
-joblib==1.0.0             # via nltk, scikit-learn
-kiwisolver==1.3.1         # via matplotlib
-matplotlib==3.3.4         # via scikit-image
-networkx==2.5             # via scikit-image
-nibabel==3.2.1            # via -r tools/accuracy_checker/requirements.in
-nltk==3.5                 # via -r tools/accuracy_checker/requirements.in
-numpy==1.19.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, parasail, pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.9           # via nibabel
-parasail==1.2             # via -r tools/accuracy_checker/requirements.in
-pillow==8.1.0             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
-py-cpuinfo==7.0.0         # via -r tools/accuracy_checker/requirements.in
-pydicom==2.1.2            # via -r tools/accuracy_checker/requirements.in
-pyparsing==2.4.7          # via matplotlib, packaging
-python-dateutil==2.8.1    # via matplotlib
-pywavelets==1.1.1         # via scikit-image
-pyyaml==5.4.1             # via -r tools/accuracy_checker/requirements-core.in
-rawpy==0.16.0             # via -r tools/accuracy_checker/requirements.in
-regex==2020.11.13         # via nltk
-scikit-image==0.17.2      # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.24.1      # via -r tools/accuracy_checker/requirements.in
-scipy==1.5.4              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.95     # via -r tools/accuracy_checker/requirements.in
-shapely==1.7.1            # via -r tools/accuracy_checker/requirements.in
-six==1.15.0               # via python-dateutil
-threadpoolctl==2.1.0      # via scikit-learn
-tifffile==2020.9.3        # via scikit-image
-tokenizers==0.10.0        # via -r tools/accuracy_checker/requirements.in
-tqdm==4.56.0              # via -r tools/accuracy_checker/requirements.in, nltk
-wheel==0.36.2             # via parasail
+click==7.1.2
+    # via nltk
+cycler==0.10.0
+    # via matplotlib
+decorator==4.4.2
+    # via networkx
+editdistance==0.5.3
+    # via -r tools/accuracy_checker/requirements.in
+fast-ctc-decode==0.2.5
+    # via -r tools/accuracy_checker/requirements.in
+imageio==2.9.0
+    # via scikit-image
+joblib==1.0.0
+    # via
+    #   nltk
+    #   scikit-learn
+kiwisolver==1.3.1
+    # via matplotlib
+matplotlib==3.3.4
+    # via scikit-image
+networkx==2.5
+    # via scikit-image
+nibabel==3.2.1
+    # via -r tools/accuracy_checker/requirements.in
+nltk==3.5
+    # via -r tools/accuracy_checker/requirements.in
+numpy==1.19.5
+    # via
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   imageio
+    #   matplotlib
+    #   nibabel
+    #   parasail
+    #   pywavelets
+    #   rawpy
+    #   scikit-image
+    #   scikit-learn
+    #   scipy
+    #   tifffile
+packaging==20.9
+    # via nibabel
+parasail==1.2
+    # via -r tools/accuracy_checker/requirements.in
+pillow==8.1.0
+    # via
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   imageio
+    #   matplotlib
+    #   scikit-image
+py-cpuinfo==7.0.0
+    # via -r tools/accuracy_checker/requirements.in
+pydicom==2.1.2
+    # via -r tools/accuracy_checker/requirements.in
+pyparsing==2.4.7
+    # via
+    #   matplotlib
+    #   packaging
+python-dateutil==2.8.1
+    # via matplotlib
+pywavelets==1.1.1
+    # via scikit-image
+pyyaml==5.4.1
+    # via -r tools/accuracy_checker/requirements-core.in
+rawpy==0.16.0
+    # via -r tools/accuracy_checker/requirements.in
+regex==2020.11.13
+    # via nltk
+scikit-image==0.17.2
+    # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1
+    # via -r tools/accuracy_checker/requirements.in
+scipy==1.5.4
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   scikit-image
+    #   scikit-learn
+sentencepiece==0.1.95
+    # via -r tools/accuracy_checker/requirements.in
+shapely==1.7.1
+    # via -r tools/accuracy_checker/requirements.in
+six==1.15.0
+    # via python-dateutil
+threadpoolctl==2.1.0
+    # via scikit-learn
+tifffile==2020.9.3
+    # via scikit-image
+tokenizers==0.10.0
+    # via -r tools/accuracy_checker/requirements.in
+tqdm==4.56.0
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   nltk
+wheel==0.36.2
+    # via parasail

--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -6,14 +6,14 @@ decorator==4.4.2          # via networkx
 editdistance==0.5.3       # via -r tools/accuracy_checker/requirements.in
 fast-ctc-decode==0.2.5    # via -r tools/accuracy_checker/requirements.in
 imageio==2.9.0            # via scikit-image
-joblib==0.17.0            # via nltk, scikit-learn
+joblib==1.0.0             # via nltk, scikit-learn
 kiwisolver==1.3.1         # via matplotlib
-matplotlib==3.3.3         # via scikit-image
+matplotlib==3.3.4         # via scikit-image
 networkx==2.5             # via scikit-image
 nibabel==3.2.1            # via -r tools/accuracy_checker/requirements.in
 nltk==3.5                 # via -r tools/accuracy_checker/requirements.in
-numpy==1.17.5             # via -r tools/accuracy_checker/requirements-core.in, -r tools/accuracy_checker/requirements.in, imageio, matplotlib, nibabel, parasail, pywavelets, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.8           # via nibabel
+numpy==1.19.5             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, nibabel, parasail, pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
+packaging==20.9           # via nibabel
 parasail==1.2             # via -r tools/accuracy_checker/requirements.in
 pillow==8.1.0             # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
 py-cpuinfo==7.0.0         # via -r tools/accuracy_checker/requirements.in
@@ -21,16 +21,17 @@ pydicom==2.1.2            # via -r tools/accuracy_checker/requirements.in
 pyparsing==2.4.7          # via matplotlib, packaging
 python-dateutil==2.8.1    # via matplotlib
 pywavelets==1.1.1         # via scikit-image
-pyyaml==5.3.1             # via -r tools/accuracy_checker/requirements-core.in
+pyyaml==5.4.1             # via -r tools/accuracy_checker/requirements-core.in
+rawpy==0.16.0             # via -r tools/accuracy_checker/requirements.in
 regex==2020.11.13         # via nltk
 scikit-image==0.17.2      # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.23.2      # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1      # via -r tools/accuracy_checker/requirements.in
 scipy==1.5.4              # via -r tools/accuracy_checker/requirements.in, scikit-image, scikit-learn
-sentencepiece==0.1.94     # via -r tools/accuracy_checker/requirements.in
+sentencepiece==0.1.95     # via -r tools/accuracy_checker/requirements.in
 shapely==1.7.1            # via -r tools/accuracy_checker/requirements.in
 six==1.15.0               # via python-dateutil
 threadpoolctl==2.1.0      # via scikit-learn
 tifffile==2020.9.3        # via scikit-image
-tokenizers==0.9.4         # via -r tools/accuracy_checker/requirements.in
-tqdm==4.54.1              # via -r tools/accuracy_checker/requirements.in, nltk
+tokenizers==0.10.0        # via -r tools/accuracy_checker/requirements.in
+tqdm==4.56.0              # via -r tools/accuracy_checker/requirements.in, nltk
 wheel==0.36.2             # via parasail

--- a/ci/requirements-check-basics.txt
+++ b/ci/requirements-check-basics.txt
@@ -1,15 +1,25 @@
 # use update-requirements.py to update this file
 
-flake8==3.8.4             # via -r ci/requirements-check-basics.in
-importlib-metadata==3.4.0  # via flake8
-mccabe==0.6.1             # via flake8
-pathspec==0.8.1           # via yamllint
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pyyaml==5.4.1             # via yamllint
-typing-extensions==3.7.4.3  # via importlib-metadata
-yamllint==1.26.0          # via -r ci/requirements-check-basics.in
-zipp==3.4.0               # via importlib-metadata
+flake8==3.8.4
+    # via -r ci/requirements-check-basics.in
+importlib-metadata==3.4.0
+    # via flake8
+mccabe==0.6.1
+    # via flake8
+pathspec==0.8.1
+    # via yamllint
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pyyaml==5.4.1
+    # via yamllint
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+yamllint==1.26.0
+    # via -r ci/requirements-check-basics.in
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-check-basics.txt
+++ b/ci/requirements-check-basics.txt
@@ -1,14 +1,14 @@
 # use update-requirements.py to update this file
 
 flake8==3.8.4             # via -r ci/requirements-check-basics.in
-importlib-metadata==3.3.0  # via flake8
+importlib-metadata==3.4.0  # via flake8
 mccabe==0.6.1             # via flake8
 pathspec==0.8.1           # via yamllint
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
-pyyaml==5.3.1             # via yamllint
+pyyaml==5.4.1             # via yamllint
 typing-extensions==3.7.4.3  # via importlib-metadata
-yamllint==1.25.0          # via -r ci/requirements-check-basics.in
+yamllint==1.26.0          # via -r ci/requirements-check-basics.in
 zipp==3.4.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -2,49 +2,50 @@
 
 absl-py==0.11.0           # via tensorboard, tensorflow
 astunparse==1.6.3         # via tensorflow
-cachetools==4.2.0         # via google-auth
+cachetools==4.2.1         # via google-auth
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 decorator==4.4.2          # via networkx
 defusedxml==0.6.0         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+flatbuffers==1.12         # via tensorflow
 future==0.18.2            # via -r tools/downloader/requirements-caffe2.in, torch
 gast==0.3.3               # via tensorflow
 google-auth-oauthlib==0.4.2  # via tensorboard
 google-auth==1.24.0       # via google-auth-oauthlib, tensorboard
 google-pasta==0.2.0       # via tensorflow
 graphviz==0.8.4           # via mxnet
-grpcio==1.34.0            # via tensorboard, tensorflow
+grpcio==1.32.0            # via tensorboard, tensorflow
 h5py==2.10.0              # via -r tools/downloader/requirements-tensorflow.in, tensorflow
 idna==2.10                # via requests
-importlib-metadata==3.3.0  # via markdown
+importlib-metadata==3.4.0  # via markdown
 keras-preprocessing==1.1.2  # via tensorflow
 markdown==3.3.3           # via tensorboard
 mxnet==1.5.1              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
 networkx==2.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
-numpy==1.18.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, h5py, keras-preprocessing, mxnet, onnx, opt-einsum, scipy, tensorboard, tensorflow, torch, torchvision
+numpy==1.19.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, h5py, keras-preprocessing, mxnet, onnx, opt-einsum, scipy, tensorboard, tensorflow, torch, torchvision
 oauthlib==3.1.0           # via requests-oauthlib
-onnx==1.8.0               # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in
+onnx==1.8.1               # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in
 opt-einsum==3.3.0         # via tensorflow
 pillow==8.1.0             # via torchvision
 protobuf==3.14.0          # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, onnx, tensorboard, tensorflow
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
-pyyaml==5.3.1             # via yacs
+pyyaml==5.4.1             # via yacs
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.25.0          # via mxnet, requests-oauthlib, tensorboard
-rsa==4.6                  # via google-auth
+requests==2.25.1          # via mxnet, requests-oauthlib, tensorboard
+rsa==4.7                  # via google-auth
 scipy==1.5.4              # via -r tools/downloader/requirements-pytorch.in
 six==1.15.0               # via absl-py, astunparse, google-auth, google-pasta, grpcio, h5py, keras-preprocessing, onnx, protobuf, tensorboard, tensorflow, test-generator
-tensorboard-plugin-wit==1.7.0  # via tensorboard
-tensorboard==2.4.0        # via tensorflow
-tensorflow-estimator==2.3.0  # via tensorflow
-tensorflow==2.3.1         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, -r tools/downloader/requirements-tensorflow.in
+tensorboard-plugin-wit==1.8.0  # via tensorboard
+tensorboard==2.4.1        # via tensorflow
+tensorflow-estimator==2.4.0  # via tensorflow
+tensorflow==2.4.1         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, -r tools/downloader/requirements-tensorflow.in
 termcolor==1.1.0          # via tensorflow
 test-generator==0.1.1     # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
 torch==1.6.0              # via -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in, torchvision
 torchvision==0.7.0        # via -r tools/downloader/requirements-pytorch.in
-typing-extensions==3.7.4.3  # via importlib-metadata, onnx
-urllib3==1.26.2           # via requests
+typing-extensions==3.7.4.3  # via importlib-metadata, onnx, tensorflow
+urllib3==1.26.3           # via requests
 werkzeug==1.0.1           # via tensorboard
 wheel==0.36.2             # via astunparse, tensorboard, tensorflow
 wrapt==1.12.1             # via tensorflow

--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -1,56 +1,178 @@
 # use update-requirements.py to update this file
 
-absl-py==0.11.0           # via tensorboard, tensorflow
-astunparse==1.6.3         # via tensorflow
-cachetools==4.2.1         # via google-auth
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-decorator==4.4.2          # via networkx
-defusedxml==0.6.0         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
-flatbuffers==1.12         # via tensorflow
-future==0.18.2            # via -r tools/downloader/requirements-caffe2.in, torch
-gast==0.3.3               # via tensorflow
-google-auth-oauthlib==0.4.2  # via tensorboard
-google-auth==1.24.0       # via google-auth-oauthlib, tensorboard
-google-pasta==0.2.0       # via tensorflow
-graphviz==0.8.4           # via mxnet
-grpcio==1.32.0            # via tensorboard, tensorflow
-h5py==2.10.0              # via -r tools/downloader/requirements-tensorflow.in, tensorflow
-idna==2.10                # via requests
-importlib-metadata==3.4.0  # via markdown
-keras-preprocessing==1.1.2  # via tensorflow
-markdown==3.3.3           # via tensorboard
-mxnet==1.5.1              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
-networkx==2.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
-numpy==1.19.5             # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, h5py, keras-preprocessing, mxnet, onnx, opt-einsum, scipy, tensorboard, tensorflow, torch, torchvision
-oauthlib==3.1.0           # via requests-oauthlib
-onnx==1.8.1               # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in
-opt-einsum==3.3.0         # via tensorflow
-pillow==8.1.0             # via torchvision
-protobuf==3.14.0          # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, onnx, tensorboard, tensorflow
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via pyasn1-modules, rsa
-pyyaml==5.4.1             # via yacs
-requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.25.1          # via mxnet, requests-oauthlib, tensorboard
-rsa==4.7                  # via google-auth
-scipy==1.5.4              # via -r tools/downloader/requirements-pytorch.in
-six==1.15.0               # via absl-py, astunparse, google-auth, google-pasta, grpcio, h5py, keras-preprocessing, onnx, protobuf, tensorboard, tensorflow, test-generator
-tensorboard-plugin-wit==1.8.0  # via tensorboard
-tensorboard==2.4.1        # via tensorflow
-tensorflow-estimator==2.4.0  # via tensorflow
-tensorflow==2.4.1         # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt, -r tools/downloader/requirements-tensorflow.in
-termcolor==1.1.0          # via tensorflow
-test-generator==0.1.1     # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt, -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
-torch==1.6.0              # via -r tools/downloader/requirements-caffe2.in, -r tools/downloader/requirements-pytorch.in, torchvision
-torchvision==0.7.0        # via -r tools/downloader/requirements-pytorch.in
-typing-extensions==3.7.4.3  # via importlib-metadata, onnx, tensorflow
-urllib3==1.26.3           # via requests
-werkzeug==1.0.1           # via tensorboard
-wheel==0.36.2             # via astunparse, tensorboard, tensorflow
-wrapt==1.12.1             # via tensorflow
-yacs==0.1.8               # via -r tools/downloader/requirements-pytorch.in
-zipp==3.4.0               # via importlib-metadata
+absl-py==0.11.0
+    # via
+    #   tensorboard
+    #   tensorflow
+astunparse==1.6.3
+    # via tensorflow
+cachetools==4.2.1
+    # via google-auth
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+decorator==4.4.2
+    # via networkx
+defusedxml==0.6.0
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+flatbuffers==1.12
+    # via tensorflow
+future==0.18.2
+    # via
+    #   -r tools/downloader/requirements-caffe2.in
+    #   torch
+gast==0.3.3
+    # via tensorflow
+google-auth-oauthlib==0.4.2
+    # via tensorboard
+google-auth==1.24.0
+    # via
+    #   google-auth-oauthlib
+    #   tensorboard
+google-pasta==0.2.0
+    # via tensorflow
+graphviz==0.8.4
+    # via mxnet
+grpcio==1.32.0
+    # via
+    #   tensorboard
+    #   tensorflow
+h5py==2.10.0
+    # via
+    #   -r tools/downloader/requirements-tensorflow.in
+    #   tensorflow
+idna==2.10
+    # via requests
+importlib-metadata==3.4.0
+    # via markdown
+keras-preprocessing==1.1.2
+    # via tensorflow
+markdown==3.3.3
+    # via tensorboard
+mxnet==1.5.1
+    # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
+networkx==2.5
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+numpy==1.19.5
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+    #   h5py
+    #   keras-preprocessing
+    #   mxnet
+    #   onnx
+    #   opt-einsum
+    #   scipy
+    #   tensorboard
+    #   tensorflow
+    #   torch
+    #   torchvision
+oauthlib==3.1.0
+    # via requests-oauthlib
+onnx==1.8.1
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
+    #   -r tools/downloader/requirements-caffe2.in
+    #   -r tools/downloader/requirements-pytorch.in
+opt-einsum==3.3.0
+    # via tensorflow
+pillow==8.1.0
+    # via torchvision
+protobuf==3.14.0
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt
+    #   onnx
+    #   tensorboard
+    #   tensorflow
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyyaml==5.4.1
+    # via yacs
+requests-oauthlib==1.3.0
+    # via google-auth-oauthlib
+requests==2.25.1
+    # via
+    #   mxnet
+    #   requests-oauthlib
+    #   tensorboard
+rsa==4.7
+    # via google-auth
+scipy==1.5.4
+    # via -r tools/downloader/requirements-pytorch.in
+six==1.15.0
+    # via
+    #   absl-py
+    #   astunparse
+    #   google-auth
+    #   google-pasta
+    #   grpcio
+    #   h5py
+    #   keras-preprocessing
+    #   onnx
+    #   protobuf
+    #   tensorboard
+    #   tensorflow
+    #   test-generator
+tensorboard-plugin-wit==1.8.0
+    # via tensorboard
+tensorboard==2.4.1
+    # via tensorflow
+tensorflow-estimator==2.4.0
+    # via tensorflow
+tensorflow==2.4.1
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+    #   -r tools/downloader/requirements-tensorflow.in
+termcolor==1.1.0
+    # via tensorflow
+test-generator==0.1.1
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_caffe.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt
+torch==1.6.0
+    # via
+    #   -r tools/downloader/requirements-caffe2.in
+    #   -r tools/downloader/requirements-pytorch.in
+    #   torchvision
+torchvision==0.7.0
+    # via -r tools/downloader/requirements-pytorch.in
+typing-extensions==3.7.4.3
+    # via
+    #   importlib-metadata
+    #   onnx
+    #   tensorflow
+urllib3==1.26.3
+    # via requests
+werkzeug==1.0.1
+    # via tensorboard
+wheel==0.36.2
+    # via
+    #   astunparse
+    #   tensorboard
+    #   tensorflow
+wrapt==1.12.1
+    # via tensorflow
+yacs==0.1.8
+    # via -r tools/downloader/requirements-pytorch.in
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-demos.txt
+++ b/ci/requirements-demos.txt
@@ -1,63 +1,163 @@
 # use update-requirements.py to update this file
 
-absl-py==0.11.0           # via tensorboard
-attrs==20.3.0             # via pytest
-cachetools==4.2.1         # via google-auth
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-cycler==0.10.0            # via matplotlib
-flake8-import-order==0.18.1  # via motmetrics
-flake8==3.8.4             # via motmetrics
-google-auth-oauthlib==0.4.2  # via tensorboard
-google-auth==1.24.0       # via google-auth-oauthlib, tensorboard
-grpcio==1.35.0            # via tensorboard
-idna==2.10                # via requests
-importlib-metadata==3.4.0  # via flake8, markdown, pluggy, pytest
-iniconfig==1.1.1          # via pytest
-joblib==1.0.0             # via scikit-learn
-kiwisolver==1.3.1         # via matplotlib
-markdown==3.3.3           # via tensorboard
-matplotlib==3.3.4         # via -r demos/requirements.txt
-mccabe==0.6.1             # via flake8
-motmetrics==1.2.0         # via -r demos/requirements.txt
-nibabel==3.2.1            # via -r demos/requirements.txt
-numpy==1.19.5 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
-oauthlib==3.1.0           # via requests-oauthlib
-packaging==20.9           # via nibabel, pytest
-pandas==1.1.5             # via motmetrics
-pillow==8.1.0             # via matplotlib
-pluggy==0.13.1            # via pytest
-protobuf==3.14.0          # via tensorboard, tensorboardx
-py-cpuinfo==7.0.0         # via pytest-benchmark
-py==1.10.0                # via pytest
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via pyasn1-modules, rsa
-pycodestyle==2.6.0        # via flake8, flake8-import-order
-pyflakes==2.2.0           # via flake8
-pyparsing==2.4.7          # via matplotlib, packaging
-pytest-benchmark==3.2.3   # via motmetrics
-pytest==6.2.2             # via motmetrics, pytest-benchmark
-python-dateutil==2.8.1    # via matplotlib, pandas
-pytz==2021.1              # via pandas
-requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.25.1          # via requests-oauthlib, tensorboard
-rsa==4.7                  # via google-auth
-scikit-learn==0.24.1      # via -r demos/requirements.txt
-scipy==1.5.4              # via -r demos/requirements.txt, motmetrics, scikit-learn
-six==1.15.0               # via absl-py, google-auth, grpcio, protobuf, python-dateutil, tensorboard, tensorboardx
-tensorboard-plugin-wit==1.8.0  # via tensorboard
-tensorboard==2.4.1        # via -r demos/requirements.txt
-tensorboardx==2.1         # via -r demos/requirements.txt
-threadpoolctl==2.1.0      # via scikit-learn
-tokenizers==0.10.0        # via -r demos/requirements.txt
-toml==0.10.2              # via pytest
-tqdm==4.56.0              # via -r demos/requirements.txt
-typing-extensions==3.7.4.3  # via importlib-metadata
-urllib3==1.26.3           # via requests
-werkzeug==1.0.1           # via tensorboard
-wheel==0.36.2             # via tensorboard
-xmltodict==0.12.0         # via motmetrics
-zipp==3.4.0               # via importlib-metadata
+absl-py==0.11.0
+    # via tensorboard
+attrs==20.3.0
+    # via pytest
+cachetools==4.2.1
+    # via google-auth
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+cycler==0.10.0
+    # via matplotlib
+flake8-import-order==0.18.1
+    # via motmetrics
+flake8==3.8.4
+    # via motmetrics
+google-auth-oauthlib==0.4.2
+    # via tensorboard
+google-auth==1.24.0
+    # via
+    #   google-auth-oauthlib
+    #   tensorboard
+grpcio==1.35.0
+    # via tensorboard
+idna==2.10
+    # via requests
+importlib-metadata==3.4.0
+    # via
+    #   flake8
+    #   markdown
+    #   pluggy
+    #   pytest
+iniconfig==1.1.1
+    # via pytest
+joblib==1.0.0
+    # via scikit-learn
+kiwisolver==1.3.1
+    # via matplotlib
+markdown==3.3.3
+    # via tensorboard
+matplotlib==3.3.4
+    # via -r demos/requirements.txt
+mccabe==0.6.1
+    # via flake8
+motmetrics==1.2.0
+    # via -r demos/requirements.txt
+nibabel==3.2.1
+    # via -r demos/requirements.txt
+numpy==1.19.5 ; python_version >= "3.4"
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/python/requirements.txt
+    #   -r demos/requirements.txt
+    #   matplotlib
+    #   motmetrics
+    #   nibabel
+    #   pandas
+    #   scikit-learn
+    #   scipy
+    #   tensorboard
+    #   tensorboardx
+oauthlib==3.1.0
+    # via requests-oauthlib
+packaging==20.9
+    # via
+    #   nibabel
+    #   pytest
+pandas==1.1.5
+    # via motmetrics
+pillow==8.1.0
+    # via matplotlib
+pluggy==0.13.1
+    # via pytest
+protobuf==3.14.0
+    # via
+    #   tensorboard
+    #   tensorboardx
+py-cpuinfo==7.0.0
+    # via pytest-benchmark
+py==1.10.0
+    # via pytest
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pycodestyle==2.6.0
+    # via
+    #   flake8
+    #   flake8-import-order
+pyflakes==2.2.0
+    # via flake8
+pyparsing==2.4.7
+    # via
+    #   matplotlib
+    #   packaging
+pytest-benchmark==3.2.3
+    # via motmetrics
+pytest==6.2.2
+    # via
+    #   motmetrics
+    #   pytest-benchmark
+python-dateutil==2.8.1
+    # via
+    #   matplotlib
+    #   pandas
+pytz==2021.1
+    # via pandas
+requests-oauthlib==1.3.0
+    # via google-auth-oauthlib
+requests==2.25.1
+    # via
+    #   requests-oauthlib
+    #   tensorboard
+rsa==4.7
+    # via google-auth
+scikit-learn==0.24.1
+    # via -r demos/requirements.txt
+scipy==1.5.4
+    # via
+    #   -r demos/requirements.txt
+    #   motmetrics
+    #   scikit-learn
+six==1.15.0
+    # via
+    #   absl-py
+    #   google-auth
+    #   grpcio
+    #   protobuf
+    #   python-dateutil
+    #   tensorboard
+    #   tensorboardx
+tensorboard-plugin-wit==1.8.0
+    # via tensorboard
+tensorboard==2.4.1
+    # via -r demos/requirements.txt
+tensorboardx==2.1
+    # via -r demos/requirements.txt
+threadpoolctl==2.1.0
+    # via scikit-learn
+tokenizers==0.10.0
+    # via -r demos/requirements.txt
+toml==0.10.2
+    # via pytest
+tqdm==4.56.0
+    # via -r demos/requirements.txt
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+urllib3==1.26.3
+    # via requests
+werkzeug==1.0.1
+    # via tensorboard
+wheel==0.36.2
+    # via tensorboard
+xmltodict==0.12.0
+    # via motmetrics
+zipp==3.4.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-demos.txt
+++ b/ci/requirements-demos.txt
@@ -2,28 +2,28 @@
 
 absl-py==0.11.0           # via tensorboard
 attrs==20.3.0             # via pytest
-cachetools==4.2.0         # via google-auth
+cachetools==4.2.1         # via google-auth
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 cycler==0.10.0            # via matplotlib
 flake8-import-order==0.18.1  # via motmetrics
 flake8==3.8.4             # via motmetrics
 google-auth-oauthlib==0.4.2  # via tensorboard
 google-auth==1.24.0       # via google-auth-oauthlib, tensorboard
-grpcio==1.34.0            # via tensorboard
+grpcio==1.35.0            # via tensorboard
 idna==2.10                # via requests
-importlib-metadata==3.3.0  # via flake8, markdown, pluggy, pytest
+importlib-metadata==3.4.0  # via flake8, markdown, pluggy, pytest
 iniconfig==1.1.1          # via pytest
-joblib==0.17.0            # via scikit-learn
+joblib==1.0.0             # via scikit-learn
 kiwisolver==1.3.1         # via matplotlib
 markdown==3.3.3           # via tensorboard
-matplotlib==3.3.3         # via -r demos/python_demos/requirements.txt
+matplotlib==3.3.4         # via -r demos/requirements.txt
 mccabe==0.6.1             # via flake8
-motmetrics==1.2.0         # via -r demos/python_demos/requirements.txt
-nibabel==3.2.1            # via -r demos/python_demos/requirements.txt
-numpy==1.19.3 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/python_demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
+motmetrics==1.2.0         # via -r demos/requirements.txt
+nibabel==3.2.1            # via -r demos/requirements.txt
+numpy==1.19.5 ; python_version >= "3.4"  # via -r ${INTEL_OPENVINO_DIR}/python/requirements.txt, -r demos/requirements.txt, matplotlib, motmetrics, nibabel, pandas, scikit-learn, scipy, tensorboard, tensorboardx
 oauthlib==3.1.0           # via requests-oauthlib
-packaging==20.8           # via nibabel, pytest
+packaging==20.9           # via nibabel, pytest
 pandas==1.1.5             # via motmetrics
 pillow==8.1.0             # via matplotlib
 pluggy==0.13.1            # via pytest
@@ -36,24 +36,24 @@ pycodestyle==2.6.0        # via flake8, flake8-import-order
 pyflakes==2.2.0           # via flake8
 pyparsing==2.4.7          # via matplotlib, packaging
 pytest-benchmark==3.2.3   # via motmetrics
-pytest==6.2.0             # via motmetrics, pytest-benchmark
+pytest==6.2.2             # via motmetrics, pytest-benchmark
 python-dateutil==2.8.1    # via matplotlib, pandas
-pytz==2020.4              # via pandas
+pytz==2021.1              # via pandas
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.25.0          # via requests-oauthlib, tensorboard
-rsa==4.6                  # via google-auth
-scikit-learn==0.23.2      # via -r demos/python_demos/requirements.txt
-scipy==1.5.4              # via -r demos/python_demos/requirements.txt, motmetrics, scikit-learn
+requests==2.25.1          # via requests-oauthlib, tensorboard
+rsa==4.7                  # via google-auth
+scikit-learn==0.24.1      # via -r demos/requirements.txt
+scipy==1.5.4              # via -r demos/requirements.txt, motmetrics, scikit-learn
 six==1.15.0               # via absl-py, google-auth, grpcio, protobuf, python-dateutil, tensorboard, tensorboardx
-tensorboard-plugin-wit==1.7.0  # via tensorboard
-tensorboard==2.4.0        # via -r demos/python_demos/requirements.txt
-tensorboardx==2.1         # via -r demos/python_demos/requirements.txt
+tensorboard-plugin-wit==1.8.0  # via tensorboard
+tensorboard==2.4.1        # via -r demos/requirements.txt
+tensorboardx==2.1         # via -r demos/requirements.txt
 threadpoolctl==2.1.0      # via scikit-learn
-tokenizers==0.9.4         # via -r demos/python_demos/requirements.txt
+tokenizers==0.10.0        # via -r demos/requirements.txt
 toml==0.10.2              # via pytest
-tqdm==4.54.1              # via -r demos/python_demos/requirements.txt
+tqdm==4.56.0              # via -r demos/requirements.txt
 typing-extensions==3.7.4.3  # via importlib-metadata
-urllib3==1.26.2           # via requests
+urllib3==1.26.3           # via requests
 werkzeug==1.0.1           # via tensorboard
 wheel==0.36.2             # via tensorboard
 xmltodict==0.12.0         # via motmetrics

--- a/ci/requirements-downloader.txt
+++ b/ci/requirements-downloader.txt
@@ -1,8 +1,8 @@
 # use update-requirements.py to update this file
 
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 idna==2.10                # via requests
-pyyaml==5.3.1             # via -r tools/downloader/requirements.in
-requests==2.25.0          # via -r tools/downloader/requirements.in
-urllib3==1.26.2           # via requests
+pyyaml==5.4.1             # via -r tools/downloader/requirements.in
+requests==2.25.1          # via -r tools/downloader/requirements.in
+urllib3==1.26.3           # via requests

--- a/ci/requirements-downloader.txt
+++ b/ci/requirements-downloader.txt
@@ -1,8 +1,14 @@
 # use update-requirements.py to update this file
 
-certifi==2020.12.5        # via requests
-chardet==4.0.0            # via requests
-idna==2.10                # via requests
-pyyaml==5.4.1             # via -r tools/downloader/requirements.in
-requests==2.25.1          # via -r tools/downloader/requirements.in
-urllib3==1.26.3           # via requests
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
+idna==2.10
+    # via requests
+pyyaml==5.4.1
+    # via -r tools/downloader/requirements.in
+requests==2.25.1
+    # via -r tools/downloader/requirements.in
+urllib3==1.26.3
+    # via requests

--- a/ci/requirements-quantization.txt
+++ b/ci/requirements-quantization.txt
@@ -1,54 +1,145 @@
 # use update-requirements.py to update this file
 
-addict==2.2.1                              # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-chainer==7.7.0                             # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-click==7.1.2                               # via nltk
-cycler==0.10.0                             # via matplotlib
-decorator==4.4.2                           # via networkx
-defusedxml==0.6.0                          # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
-editdistance==0.5.3                        # via -r tools/accuracy_checker/requirements.in
-fast-ctc-decode==0.2.5                     # via -r tools/accuracy_checker/requirements.in
-filelock==3.0.12                           # via chainer
-future==0.18.2                             # via hyperopt
-hyperopt==0.1.2                            # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-ideep4py==2.0.0.post3                      # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-imageio==2.9.0                             # via scikit-image
-joblib==1.0.0                              # via nltk, scikit-learn
-jstyleson==0.0.2                           # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-kiwisolver==1.3.1                          # via matplotlib
-matplotlib==3.3.4                          # via scikit-image
-networkx==2.5                              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt, hyperopt, scikit-image
-nibabel==3.2.1                             # via -r tools/accuracy_checker/requirements.in
-nltk==3.5                                  # via -r tools/accuracy_checker/requirements.in
-numpy==1.16.3                              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt, -r tools/accuracy_checker/requirements-core.in, chainer, hyperopt, imageio, matplotlib, nibabel, pandas, parasail, pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py), pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.9                            # via nibabel
-pandas==0.24.2                             # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
-parasail==1.2                              # via -r tools/accuracy_checker/requirements.in
-pillow==8.1.0                              # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
-protobuf==3.14.0                           # via chainer
-py-cpuinfo==7.0.0                          # via -r tools/accuracy_checker/requirements.in
-pydicom==2.1.2                             # via -r tools/accuracy_checker/requirements.in
-pymongo==3.11.2                            # via hyperopt
-pyparsing==2.4.7                           # via matplotlib, packaging
-python-dateutil==2.8.1                     # via matplotlib, pandas
-pytz==2021.1                               # via pandas
-pywavelets==1.1.1                          # via scikit-image
-pyyaml==5.4.1                              # via -r tools/accuracy_checker/requirements-core.in
-rawpy==0.16.0                              # via -r tools/accuracy_checker/requirements.in
-regex==2020.11.13                          # via nltk
-scikit-image==0.17.2                       # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.24.1                       # via -r tools/accuracy_checker/requirements.in
-scipy==1.2.1                               # via -r tools/accuracy_checker/requirements.in, hyperopt, pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py), scikit-image, scikit-learn
-sentencepiece==0.1.95                      # via -r tools/accuracy_checker/requirements.in
-shapely==1.7.1                             # via -r tools/accuracy_checker/requirements.in
-six==1.15.0                                # via chainer, hyperopt, protobuf, python-dateutil, test-generator
-test-generator==0.1.1                      # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
-threadpoolctl==2.1.0                       # via scikit-learn
-tifffile==2020.9.3                         # via scikit-image
-tokenizers==0.10.0                         # via -r tools/accuracy_checker/requirements.in
-tqdm==4.56.0                               # via -r tools/accuracy_checker/requirements.in, hyperopt, nltk
-typing-extensions==3.7.4.3                 # via chainer
-wheel==0.36.2                              # via parasail
+addict==2.2.1
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+chainer==7.7.0
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+click==7.1.2
+    # via nltk
+cycler==0.10.0
+    # via matplotlib
+decorator==4.4.2
+    # via networkx
+defusedxml==0.6.0
+    # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+editdistance==0.5.3
+    # via -r tools/accuracy_checker/requirements.in
+fast-ctc-decode==0.2.5
+    # via -r tools/accuracy_checker/requirements.in
+filelock==3.0.12
+    # via chainer
+future==0.18.2
+    # via hyperopt
+hyperopt==0.1.2
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+ideep4py==2.0.0.post3
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+imageio==2.9.0
+    # via scikit-image
+joblib==1.0.0
+    # via
+    #   nltk
+    #   scikit-learn
+jstyleson==0.0.2
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+kiwisolver==1.3.1
+    # via matplotlib
+matplotlib==3.3.4
+    # via scikit-image
+networkx==2.5
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+    #   hyperopt
+    #   scikit-image
+nibabel==3.2.1
+    # via -r tools/accuracy_checker/requirements.in
+nltk==3.5
+    # via -r tools/accuracy_checker/requirements.in
+numpy==1.16.3
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   chainer
+    #   hyperopt
+    #   imageio
+    #   matplotlib
+    #   nibabel
+    #   pandas
+    #   parasail
+    #   pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+    #   pywavelets
+    #   rawpy
+    #   scikit-image
+    #   scikit-learn
+    #   scipy
+    #   tifffile
+packaging==20.9
+    # via nibabel
+pandas==0.24.2
+    # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+parasail==1.2
+    # via -r tools/accuracy_checker/requirements.in
+pillow==8.1.0
+    # via
+    #   -r tools/accuracy_checker/requirements-core.in
+    #   imageio
+    #   matplotlib
+    #   scikit-image
+protobuf==3.14.0
+    # via chainer
+py-cpuinfo==7.0.0
+    # via -r tools/accuracy_checker/requirements.in
+pydicom==2.1.2
+    # via -r tools/accuracy_checker/requirements.in
+pymongo==3.11.2
+    # via hyperopt
+pyparsing==2.4.7
+    # via
+    #   matplotlib
+    #   packaging
+python-dateutil==2.8.1
+    # via
+    #   matplotlib
+    #   pandas
+pytz==2021.1
+    # via pandas
+pywavelets==1.1.1
+    # via scikit-image
+pyyaml==5.4.1
+    # via -r tools/accuracy_checker/requirements-core.in
+rawpy==0.16.0
+    # via -r tools/accuracy_checker/requirements.in
+regex==2020.11.13
+    # via nltk
+scikit-image==0.17.2
+    # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1
+    # via -r tools/accuracy_checker/requirements.in
+scipy==1.2.1
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   hyperopt
+    #   pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
+    #   scikit-image
+    #   scikit-learn
+sentencepiece==0.1.95
+    # via -r tools/accuracy_checker/requirements.in
+shapely==1.7.1
+    # via -r tools/accuracy_checker/requirements.in
+six==1.15.0
+    # via
+    #   chainer
+    #   hyperopt
+    #   protobuf
+    #   python-dateutil
+    #   test-generator
+test-generator==0.1.1
+    # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+threadpoolctl==2.1.0
+    # via scikit-learn
+tifffile==2020.9.3
+    # via scikit-image
+tokenizers==0.10.0
+    # via -r tools/accuracy_checker/requirements.in
+tqdm==4.56.0
+    # via
+    #   -r tools/accuracy_checker/requirements.in
+    #   hyperopt
+    #   nltk
+typing-extensions==3.7.4.3
+    # via chainer
+wheel==0.36.2
+    # via parasail
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/ci/requirements-quantization.txt
+++ b/ci/requirements-quantization.txt
@@ -16,12 +16,12 @@ imageio==2.9.0                             # via scikit-image
 joblib==1.0.0                              # via nltk, scikit-learn
 jstyleson==0.0.2                           # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
 kiwisolver==1.3.1                          # via matplotlib
-matplotlib==3.3.3                          # via scikit-image
+matplotlib==3.3.4                          # via scikit-image
 networkx==2.5                              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt, hyperopt, scikit-image
 nibabel==3.2.1                             # via -r tools/accuracy_checker/requirements.in
 nltk==3.5                                  # via -r tools/accuracy_checker/requirements.in
 numpy==1.16.3                              # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt, -r tools/accuracy_checker/requirements-core.in, chainer, hyperopt, imageio, matplotlib, nibabel, pandas, parasail, pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py), pywavelets, rawpy, scikit-image, scikit-learn, scipy, tifffile
-packaging==20.8                            # via nibabel
+packaging==20.9                            # via nibabel
 pandas==0.24.2                             # via pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py)
 parasail==1.2                              # via -r tools/accuracy_checker/requirements.in
 pillow==8.1.0                              # via -r tools/accuracy_checker/requirements-core.in, imageio, matplotlib, scikit-image
@@ -31,13 +31,13 @@ pydicom==2.1.2                             # via -r tools/accuracy_checker/requi
 pymongo==3.11.2                            # via hyperopt
 pyparsing==2.4.7                           # via matplotlib, packaging
 python-dateutil==2.8.1                     # via matplotlib, pandas
-pytz==2020.5                               # via pandas
+pytz==2021.1                               # via pandas
 pywavelets==1.1.1                          # via scikit-image
-pyyaml==5.3.1                              # via -r tools/accuracy_checker/requirements-core.in
+pyyaml==5.4.1                              # via -r tools/accuracy_checker/requirements-core.in
 rawpy==0.16.0                              # via -r tools/accuracy_checker/requirements.in
 regex==2020.11.13                          # via nltk
 scikit-image==0.17.2                       # via -r tools/accuracy_checker/requirements.in
-scikit-learn==0.24.0                       # via -r tools/accuracy_checker/requirements.in
+scikit-learn==0.24.1                       # via -r tools/accuracy_checker/requirements.in
 scipy==1.2.1                               # via -r tools/accuracy_checker/requirements.in, hyperopt, pot (${INTEL_OPENVINO_DIR}/deployment_tools/tools/post_training_optimization_toolkit/setup.py), scikit-image, scikit-learn
 sentencepiece==0.1.95                      # via -r tools/accuracy_checker/requirements.in
 shapely==1.7.1                             # via -r tools/accuracy_checker/requirements.in

--- a/ci/update-requirements.py
+++ b/ci/update-requirements.py
@@ -27,7 +27,8 @@ def fixup_req_file(req_path, path_placeholders):
     contents = req_path.read_text()
 
     for path, placeholder in path_placeholders:
-        contents = contents.replace('-r {}/'.format(path), '-r ${{{}}}/'.format(placeholder))
+        contents = contents.replace(f'-r {path}/', f'-r ${{{placeholder}}}/')
+        contents = contents.replace(f'({path}/', f'(${{{placeholder}}}/')
 
     contents = "# use {} to update this file\n\n".format(script_name) + contents
     req_path.write_text(contents)
@@ -73,7 +74,7 @@ def main():
         *(openvino_dir / f'deployment_tools/model_optimizer/requirements_{suffix}.txt'
             for suffix in ['caffe', 'mxnet', 'onnx', 'tf2']))
     pc('ci/requirements-demos.txt',
-        'demos/python_demos/requirements.txt', openvino_dir / 'python/requirements.txt')
+        'demos/requirements.txt', openvino_dir / 'python/requirements.txt')
     pc('ci/requirements-downloader.txt',
         'tools/downloader/requirements.in')
     pc('ci/requirements-quantization.txt',


### PR DESCRIPTION
The notable changes are:

* Updating PyYAML to 5.4.1, which fixes a long-standing security vulnerability (which we're not affected by, but still).
* Updating NumPy to 1.19.5, which works around the Windows bug that previously forced us to downgrade it to 1.19.3.

I've also regenerated the files with updated pip-compile, which formats it differently, but that's in a separate commit from version bumps.
