### PR TITLE
AC: allow setting device config if device unknown

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -723,11 +723,9 @@ class DLSDKLauncher(Launcher):
         else:
             for key, value in device_configuration.items():
                 if isinstance(value, dict):
-                    if key in ie.known_plugins:
-                        self.ie_core.set_config(value, key)
-                    else:
-                        warnings.warn('Option {key}: {value} will be skipped because device is '
-                                      'unknown'.format(key=key, value=value))
+                    if key not in ie.known_plugins:
+                        warnings.warn('{} device is unknown'.format(key))
+                    self.ie_core.set_config(value, key)
                 else:
                     warnings.warn('Option {key}: {value} will be skipped because device to which it should be '
                                   'applied is not specified or option is not a dict-like'.format(key=key, value=value))

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -724,7 +724,7 @@ class DLSDKLauncher(Launcher):
             for key, value in device_configuration.items():
                 if isinstance(value, dict):
                     if key not in ie.known_plugins:
-                        warnings.warn('{} device is unknown'.format(key))
+                        warnings.warn('{} device is unknown. Config loading may lead to error.'.format(key))
                     self.ie_core.set_config(value, key)
                 else:
                     warnings.warn('Option {key}: {value} will be skipped because device to which it should be '


### PR DESCRIPTION
some fresh devices is has not been listed in known plugins yet, but they should load configuration