### PR TITLE
AC: minor issues fixes

### DIFF
--- a/models/public/face-recognition-mobilefacenet-arcface/accuracy-check.yml
+++ b/models/public/face-recognition-mobilefacenet-arcface/accuracy-check.yml
@@ -15,6 +15,7 @@ models:
 
         preprocessing:
           - type: bgr_to_rgb
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets
@@ -27,6 +28,9 @@ models:
 
     datasets:
       - name: lfw_bin
+
+        preprocessing:
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets

--- a/models/public/face-recognition-resnet100-arcface/accuracy-check.yml
+++ b/models/public/face-recognition-resnet100-arcface/accuracy-check.yml
@@ -15,6 +15,7 @@ models:
 
         preprocessing:
           - type: bgr_to_rgb
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets
@@ -27,6 +28,8 @@ models:
 
     datasets:
       - name: lfw_bin
+        preprocessing:
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets

--- a/models/public/face-recognition-resnet34-arcface/accuracy-check.yml
+++ b/models/public/face-recognition-resnet34-arcface/accuracy-check.yml
@@ -15,6 +15,7 @@ models:
 
         preprocessing:
           - type: bgr_to_rgb
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets
@@ -27,6 +28,9 @@ models:
 
     datasets:
       - name: lfw_bin
+
+        preprocessing:
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets

--- a/models/public/face-recognition-resnet50-arcface/accuracy-check.yml
+++ b/models/public/face-recognition-resnet50-arcface/accuracy-check.yml
@@ -15,6 +15,7 @@ models:
 
         preprocessing:
           - type: bgr_to_rgb
+          - type: auto_resize
 
         metrics:
           - type: pairwise_accuracy_subsets
@@ -27,6 +28,10 @@ models:
 
     datasets:
       - name: lfw_bin
+
+        preprocessing:
+          - type: auto_resize
+
 
         metrics:
           - type: pairwise_accuracy_subsets

--- a/models/public/facenet-20180408-102900/accuracy-check.yml
+++ b/models/public/facenet-20180408-102900/accuracy-check.yml
@@ -11,6 +11,7 @@ models:
       - name: lfw_mtcnn_align
 
         preprocessing:
+          - type: auto_resize
           - type: flip
             mode: vertical
             merge_with_original: True

--- a/tools/accuracy_checker/accuracy_checker/launcher/input_feeder.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/input_feeder.py
@@ -57,7 +57,7 @@ PRECISION_TO_DTYPE = {
     'I16': np.int16,  # signed short
     'I32': np.int32,  # signed int
     'I64': np.int64,  # signed long int
-    'STR': np.str,  # string
+    'STR': str,  # string
 }
 
 INPUT_TYPES_WITHOUT_VALUE = ['IMAGE_INFO', 'ORIG_IMAGE_INFO', 'IGNORE_INPUT', 'LSTM_INPUT']

--- a/tools/accuracy_checker/accuracy_checker/metrics/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/classification.py
@@ -35,6 +35,7 @@ except ImportError as import_error:
     confusion_matrix = UnsupportedPackage("sklearn.metric.confusion_matrix", import_error.msg)
     roc_auc_score = UnsupportedPackage("sklearn.metric.roc_auc_score", import_error.msg)
 
+
 class ClassificationAccuracy(PerImageEvaluationMetric):
     """
     Class for evaluating accuracy metric of classification models.
@@ -327,6 +328,7 @@ class MetthewsCorrelation(PerImageEvaluationMetric):
         self.fp = 0
         self.fn = 0
 
+
 class RocAucScore(PerImageEvaluationMetric):
     __provider__ = 'roc_auc_score'
     annotation_types = (ClassificationAnnotation, TextClassificationAnnotation)
@@ -352,6 +354,7 @@ class RocAucScore(PerImageEvaluationMetric):
         self.targets = []
         self.results = []
 
+
 class AcerScore(PerImageEvaluationMetric):
     __provider__ = 'acer_score'
     annotation_types = (ClassificationAnnotation, TextClassificationAnnotation)
@@ -360,6 +363,9 @@ class AcerScore(PerImageEvaluationMetric):
     def configure(self):
         if isinstance(confusion_matrix, UnsupportedPackage):
             confusion_matrix.raise_error(self.__provider__)
+        self.meta.update({
+            'target': 'higher-worse'
+        })
         self.reset()
 
     def update(self, annotation, prediction):


### PR DESCRIPTION
in numpy 1.19.5 np.str alias is deprecated and shown warning about it.
