### PR TITLE
AC: fixed lpcnet evaluator

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/lpcnet_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/custom_evaluators/lpcnet_evaluator.py
@@ -77,7 +77,7 @@ class SequentialModel:
             'decoder': self.decoder,
         }
 
-    def predict(self, identifiers, input_data, input_meta, callback=None):
+    def predict(self, identifiers, input_data, input_meta, input_names=None, callback=None):
         assert len(identifiers) == 1
         encoder_output, feats, chunk_size = self.encoder.predict(input_data[0])
         if callback:


### PR DESCRIPTION
Fixed number of arguments for predict method of sequential model to avoid TypeError: predict() got multiple values for argument 'callback'