### PR TITLE
AC requirements: remove parasail version restriction

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -29,7 +29,7 @@ nltk
 editdistance
 
 # DNA sequence matching
-parasail<=1.2
+parasail
 fast-ctc-decode
 
 # raw image formats processing


### PR DESCRIPTION
in the previous release, we fix parasail version due to issue with installation on windows. Now this issue resolved with new parasail version, so I remove this restriction