### PR TITLE
add vocabulary files reference to formula-recognition models and demo

### DIFF
--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -35,6 +35,8 @@ The demo application takes an input with the help of the `-i` argument. This cou
 * Path to a video (.avi, .mp4, etc)
 > This will trigger interactive mode, which would be explained in detail later.
 
+Vocabulary files are provided under corresponding model description folder.
+
 ### Non-interactive mode
 Non-interactive mode assumes that demo processes inputs sequentially.
 The demo workflow in non-interactive mode is the following:

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -35,7 +35,7 @@ The demo application takes an input with the help of the `-i` argument. This cou
 * Path to a video (.avi, .mp4, etc)
 > This will trigger interactive mode, which would be explained in detail later.
 
-Vocabulary files are provided under corresponding model description folder.
+Vocabulary files are provided under corresponding model configuration directory.
 
 ### Non-interactive mode
 Non-interactive mode assumes that demo processes inputs sequentially.

--- a/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
+++ b/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
@@ -6,7 +6,7 @@ This is an im2latex composite model that recognizes latex formulas.
 The model uses vocabulary file `vocab.json` to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 
-Vocabulary file is located under the model description folder, <omz_dir>/models/intel/formula-recognition-medium-scan-0001/vocab.json. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
+Vocabulary file is located under the model description folder, `<omz_dir>/models/intel/formula-recognition-medium-scan-0001/vocab.json`. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
+++ b/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
@@ -3,10 +3,10 @@
 ## Use Case and High-Level Description
 
 This is an im2latex composite model that recognizes latex formulas.
-The model uses [vocabulary file](../vocab.json) to predict sequence of latex tokens.
+The model uses vocabulary file `vocab.json` to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 
-Vocabulary file is located under the model description folder with name [vocab.json](../vocab.json). Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
+Vocabulary file is located under the model description folder, <omz_dir>/models/intel/formula-recognition-medium-scan-0001/vocab.json. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
+++ b/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
@@ -6,7 +6,7 @@ This is an im2latex composite model that recognizes latex formulas.
 The model uses vocabulary file `vocab.json` to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 
-Vocabulary file is located under the model description folder, `<omz_dir>/models/intel/formula-recognition-medium-scan-0001/vocab.json`. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
+Vocabulary file is located under corresponding model configuration directory, `<omz_dir>/models/intel/formula-recognition-medium-scan-0001/vocab.json`. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
+++ b/models/intel/formula-recognition-medium-scan-0001/description/formula-recognition-medium-scan-0001.md
@@ -3,10 +3,10 @@
 ## Use Case and High-Level Description
 
 This is an im2latex composite model that recognizes latex formulas.
-The model uses vocabulary file to predict sequence of latex tokens.
+The model uses [vocabulary file](../vocab.json) to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 
-Vocabulary file is distributed with the model. Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
+Vocabulary file is located under the model description folder with name [vocab.json](../vocab.json). Model can predict big and small letters, numbers, some greek letters, trigonometric functions (e.g. cos, sin, coth), logarithmic function, sqrt and superscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
@@ -8,7 +8,7 @@ The model is built on the resnext50 backbone with additional attention-based tex
 The model was trained on internal Intel's dataset containing images of handwritten polynomial equations.
 The equations consist of tokens from the corresponding to this model vocabulary file.
 
-Vocabulary file is located under the model description folder, <omz_dir>/models/intel/formula-recognition-polynomials-handwritten-0001/vocab.json. Model can predict letters, numbers and upperscript.
+Vocabulary file is located under the model description folder, `<omz_dir>/models/intel/formula-recognition-polynomials-handwritten-0001/vocab.json`. Model can predict letters, numbers and upperscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
@@ -8,7 +8,7 @@ The model is built on the resnext50 backbone with additional attention-based tex
 The model was trained on internal Intel's dataset containing images of handwritten polynomial equations.
 The equations consist of tokens from the corresponding to this model vocabulary file.
 
-Vocabulary file is located under the model description folder, `<omz_dir>/models/intel/formula-recognition-polynomials-handwritten-0001/vocab.json`. Model can predict letters, numbers and upperscript.
+Vocabulary file is located under corresponding model configuration directory, `<omz_dir>/models/intel/formula-recognition-polynomials-handwritten-0001/vocab.json`. Model can predict letters, numbers and upperscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
@@ -3,12 +3,12 @@
 ## Use Case and High-Level Description
 
 This is an im2latex composite model that recognizes latex formulas.
-The model uses [vocabulary file](../vocab.json) to predict sequence of latex tokens.
+The model uses vocabulary file `vocab.json` to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 The model was trained on internal Intel's dataset containing images of handwritten polynomial equations.
 The equations consist of tokens from the corresponding to this model vocabulary file.
 
-Vocabulary file is located under the model description folder with name [vocab.json](../vocab.json). Model can predict letters, numbers and upperscript.
+Vocabulary file is located under the model description folder, <omz_dir>/models/intel/formula-recognition-polynomials-handwritten-0001/vocab.json. Model can predict letters, numbers and upperscript.
 
 ## Example of the input data
 

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/description/formula-recognition-polynomials-handwritten-0001.md
@@ -3,12 +3,12 @@
 ## Use Case and High-Level Description
 
 This is an im2latex composite model that recognizes latex formulas.
-The model uses vocabulary file to predict sequence of latex tokens.
+The model uses [vocabulary file](../vocab.json) to predict sequence of latex tokens.
 The model is built on the resnext50 backbone with additional attention-based text recognition head.
 The model was trained on internal Intel's dataset containing images of handwritten polynomial equations.
 The equations consist of tokens from the corresponding to this model vocabulary file.
 
-Vocabulary file is distributed with the model. Model can predict letters, numbers and upperscript.
+Vocabulary file is located under the model description folder with name [vocab.json](../vocab.json). Model can predict letters, numbers and upperscript.
 
 ## Example of the input data
 


### PR DESCRIPTION
formula-recognition demo and models descriptions did not refer to where one can get required vocabulary file, although these are provided in Open Model Zoo. This PR intend to fix the issue by adding reference to required files in model description and mentioning this in demo readme