### PR TITLE
add pointers to demo location at demos README.md

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -3,7 +3,7 @@
 The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
 
 For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the following directory: `<INSTALL_DIR>/deployment_tools/open_model_zoo/demos`.
-For the open source version of OpenVINO™ toolkit, the demos are available in the Open Model Zoo repository in the `demos` directory.
+The demos can also be obtained from the Open Model Zoo [GitHub repository](https://github.com/openvinotoolkit/open_model_zoo/).
 C++, C++ G-API and Python versions are located in the `cpp`, `cpp_gapi` and `python` subdirectories respectively.
 
 The Open Model Zoo includes the following demos:

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,11 @@
 # Open Model Zoo Demos
 
-The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases
+The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
+
+For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the folder: `<INSTALL_DIR>\deployment_tools\open_model_zoo\demos`.
+For the open source version of OpenVINO™ toolkit, the demos are available in the Open Model Zoo repository in the `demos` directory.
+C++, C++ GAPI and Python versions are located in the `cpp`, `cpp_gapi` and `python` subfolders respectively.
+
 The Open Model Zoo includes the following demos:
 
 - [3D Human Pose Estimation Python\* Demo](./human_pose_estimation_3d_demo/python/README.md) - 3D human pose estimation demo.

--- a/demos/README.md
+++ b/demos/README.md
@@ -2,7 +2,7 @@
 
 The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
 
-For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the folder: `<INSTALL_DIR>\deployment_tools\open_model_zoo\demos`.
+For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the following directory: `<INSTALL_DIR>/deployment_tools/open_model_zoo/demos`.
 For the open source version of OpenVINO™ toolkit, the demos are available in the Open Model Zoo repository in the `demos` directory.
 C++, C++ GAPI and Python versions are located in the `cpp`, `cpp_gapi` and `python` subfolders respectively.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Open Model Zoo Demos
 
-The Open Model Zoo demo applications are console applications that demonstrate how you can use the Inference Engine in your applications to solve specific use-cases.
+The Open Model Zoo demo applications are console applications that provide robust application templates to help you implement specific deep learning scenarios. These applications involve increasingly complex processing pipelines that gather analysis data from several models that run inference simultaneously, such as detecting a person in a video stream along with detecting the person's physical attributes, such as age, gender, and emotional state
 
 For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the following directory: `<INSTALL_DIR>/deployment_tools/open_model_zoo/demos`.
 The demos can also be obtained from the Open Model Zoo [GitHub repository](https://github.com/openvinotoolkit/open_model_zoo/).

--- a/demos/README.md
+++ b/demos/README.md
@@ -4,7 +4,7 @@ The Open Model Zoo demo applications are console applications that demonstrate h
 
 For the Intel® Distribution of OpenVINO™ toolkit, the demos are available after installation in the following directory: `<INSTALL_DIR>/deployment_tools/open_model_zoo/demos`.
 For the open source version of OpenVINO™ toolkit, the demos are available in the Open Model Zoo repository in the `demos` directory.
-C++, C++ GAPI and Python versions are located in the `cpp`, `cpp_gapi` and `python` subfolders respectively.
+C++, C++ G-API and Python versions are located in the `cpp`, `cpp_gapi` and `python` subdirectories respectively.
 
 The Open Model Zoo includes the following demos:
 


### PR DESCRIPTION
The idea is to add the paths to demos (for both distribution package and repo) to the title page.