### PR TITLE
add parameters to greedy decoder to make it able run tr-0013

### DIFF
--- a/models/intel/text-recognition-0013/accuracy-check.yml
+++ b/models/intel/text-recognition-0013/accuracy-check.yml
@@ -4,8 +4,7 @@ models:
     launchers:
       - framework: dlsdk
         adapter:
-          type: beam_search_decoder
-          beam_size: 10
+          type: ctc_greedy_search_decoder
           logits_output: logits
           blank_label: 0
           custom_label_map:


### PR DESCRIPTION
This PR allows to use greedy search with text-recognition-0013 model. This does not affect accuracy, but speeds up measurement.
Currently, beam search with beam width=10 and greedy search produce the same result for text-recognition-0013.