### PR TITLE
speech_recognition_demo: avoid yaml.load

### DIFF
--- a/demos/speech_recognition_demo/python/speech_recognition_demo.py
+++ b/demos/speech_recognition_demo/python/speech_recognition_demo.py
@@ -50,7 +50,7 @@ def get_profile(profile_name):
     if profile_name in PROFILES:
         return PROFILES[profile_name]
     with open(profile_name, 'rt') as f:
-        profile = yaml.load(f)
+        profile = yaml.safe_load(f)
     return profile
 
 


### PR DESCRIPTION
Use `safe_load`, which can't construct arbitrary Python objects.