### PR TITLE
demos: make sure input data lives during inference

### DIFF
--- a/demos/common/cpp/models/include/models/internal_model_data.h
+++ b/demos/common/cpp/models/include/models/internal_model_data.h
@@ -37,12 +37,16 @@ struct InternalImageModelData : public InternalModelData {
     int inputImgHeight;
 };
 
-struct InternalScaleData : public InternalModelData {
-    InternalScaleData(float scaleX, float scaleY) {
-        x = scaleX;
-        y = scaleY;
-    }
+struct InternalImageMatModelData : public InternalImageModelData {
+    InternalImageMatModelData(const cv::Mat& mat) : InternalImageModelData(mat.cols, mat.rows), mat(mat) {}
+
+    cv::Mat mat;
+};
+
+struct InternalScaleMatData : public InternalModelData {
+    InternalScaleMatData(float scaleX, float scaleY, cv::Mat&& mat) : x(scaleX), y(scaleY), mat(std::move(mat)) {}
 
     float x;
     float y;
+    cv::Mat mat;
 };

--- a/demos/common/cpp/models/src/detection_model.cpp
+++ b/demos/common/cpp/models/src/detection_model.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<InternalModelData> DetectionModel::preprocess(const InputData& i
     if (useAutoResize) {
         /* Just set input blob containing read image. Resize and layout conversionx will be done automatically */
         request->SetBlob(inputsNames[0], wrapMat2Blob(img));
-        /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+        /* IE::Blob::Ptr from wrapMat2Blob() doesn't own data. Save the image to avoid deallocation before inference */
         return std::make_shared<InternalImageMatModelData>(img);
     }
     /* Resize and copy data from the image to the input blob */

--- a/demos/common/cpp/models/src/detection_model.cpp
+++ b/demos/common/cpp/models/src/detection_model.cpp
@@ -33,14 +33,13 @@ std::shared_ptr<InternalModelData> DetectionModel::preprocess(const InputData& i
     if (useAutoResize) {
         /* Just set input blob containing read image. Resize and layout conversionx will be done automatically */
         request->SetBlob(inputsNames[0], wrapMat2Blob(img));
+        /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+        return std::make_shared<InternalImageMatModelData>(img);
     }
-    else {
-        /* Resize and copy data from the image to the input blob */
-        Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
-        matU8ToBlob<uint8_t>(img, frameBlob);
-    }
-
-    return std::shared_ptr<InternalModelData>(new InternalImageModelData(img.cols, img.rows));
+    /* Resize and copy data from the image to the input blob */
+    Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
+    matU8ToBlob<uint8_t>(img, frameBlob);
+    return std::make_shared<InternalImageModelData>(img.cols, img.rows);
 }
 
 std::vector<std::string> DetectionModel::loadLabels(const std::string& labelFilename) {

--- a/demos/common/cpp/models/src/hpe_model_associative_embedding.cpp
+++ b/demos/common/cpp/models/src/hpe_model_associative_embedding.cpp
@@ -113,7 +113,7 @@ std::shared_ptr<InternalModelData> HpeAssociativeEmbedding::preprocess(const Inp
     cv::copyMakeBorder(resizedImage, paddedImage, 0, bottom, 0, right,
                        cv::BORDER_CONSTANT, meanPixel);
     request->SetBlob(inputsNames[0], wrapMat2Blob(paddedImage));
-    /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+    /* IE::Blob::Ptr from wrapMat2Blob() doesn't own data. Save the image to avoid deallocation before inference */
     return std::make_shared<InternalScaleMatData>(image.cols / static_cast<float>(w), image.rows / static_cast<float>(h), std::move(paddedImage));
 }
 

--- a/demos/common/cpp/models/src/hpe_model_openpose.cpp
+++ b/demos/common/cpp/models/src/hpe_model_openpose.cpp
@@ -110,7 +110,7 @@ std::shared_ptr<InternalModelData> HPEOpenPose::preprocess(const InputData& inpu
     cv::copyMakeBorder(resizedImage, paddedImage, 0, bottom, 0, right,
                        cv::BORDER_CONSTANT, meanPixel);
     request->SetBlob(inputsNames[0], wrapMat2Blob(paddedImage));
-    /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+    /* IE::Blob::Ptr from wrapMat2Blob() doesn't own data. Save the image to avoid deallocation before inference */
     return std::make_shared<InternalScaleMatData>(image.cols / static_cast<float>(w), image.rows / static_cast<float>(h), std::move(paddedImage));
 }
 

--- a/demos/common/cpp/models/src/hpe_model_openpose.cpp
+++ b/demos/common/cpp/models/src/hpe_model_openpose.cpp
@@ -110,8 +110,8 @@ std::shared_ptr<InternalModelData> HPEOpenPose::preprocess(const InputData& inpu
     cv::copyMakeBorder(resizedImage, paddedImage, 0, bottom, 0, right,
                        cv::BORDER_CONSTANT, meanPixel);
     request->SetBlob(inputsNames[0], wrapMat2Blob(paddedImage));
-    return std::shared_ptr<InternalModelData>(new InternalScaleData(image.cols / static_cast<float>(w),
-                                                                    image.rows / static_cast<float>(h)));
+    /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+    return std::make_shared<InternalScaleMatData>(image.cols / static_cast<float>(w), image.rows / static_cast<float>(h), std::move(paddedImage));
 }
 
 std::unique_ptr<ResultBase> HPEOpenPose::postprocess(InferenceResult& infResult) {
@@ -143,7 +143,7 @@ std::unique_ptr<ResultBase> HPEOpenPose::postprocess(InferenceResult& infResult)
 
     std::vector<HumanPose> poses = extractPoses(heatMaps, pafs);
 
-    const auto& scale = infResult.internalModelData->asRef<InternalScaleData>();
+    const auto& scale = infResult.internalModelData->asRef<InternalScaleMatData>();
     float scaleX = stride / upsampleRatio * scale.x;
     float scaleY = stride / upsampleRatio * scale.y;
     for (auto& pose : poses) {

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -79,14 +79,13 @@ std::shared_ptr<InternalModelData> SegmentationModel::preprocess(const InputData
     if (useAutoResize) {
         /* Just set input blob containing read image. Resize and layout conversionx will be done automatically */
         request->SetBlob(inputsNames[0], wrapMat2Blob(img));
+        /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+        return std::make_shared<InternalImageMatModelData>(img);
     }
-    else {
-        /* Resize and copy data from the image to the input blob */
-        Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
-        matU8ToBlob<uint8_t>(img, frameBlob);
-    }
-
-    return std::shared_ptr<InternalModelData>(new InternalImageModelData(img.cols, img.rows));
+    /* Resize and copy data from the image to the input blob */
+    Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
+    matU8ToBlob<uint8_t>(img, frameBlob);
+    return std::make_shared<InternalImageModelData>(img.cols, img.rows);
 }
 
 std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infResult) {

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<InternalModelData> SegmentationModel::preprocess(const InputData
     if (useAutoResize) {
         /* Just set input blob containing read image. Resize and layout conversionx will be done automatically */
         request->SetBlob(inputsNames[0], wrapMat2Blob(img));
-        /* IE::Blob::Ptr from wrapMat2Blob() doesn't onwn data. Save the image to avoid deallocation before inference */
+        /* IE::Blob::Ptr from wrapMat2Blob() doesn't own data. Save the image to avoid deallocation before inference */
         return std::make_shared<InternalImageMatModelData>(img);
     }
     /* Resize and copy data from the image to the input blob */


### PR DESCRIPTION
Only human_pose_estimation crashed because it pads an image which
creates new Mat and other demos keep unchanged data in `ImageMetaData`.