### PR TITLE
align cpp/python object_detection_demo 

### DIFF
--- a/demos/common/cpp/models/include/models/detection_model_yolo.h
+++ b/demos/common/cpp/models/include/models/detection_model_yolo.h
@@ -48,11 +48,11 @@ public:
     /// @param useAdvancedPostprocessing - if true, an advanced algorithm for filtering/postprocessing will be used
     /// (with better processing of multiple crossing objects). Otherwise, classic algorithm will be used.
     /// @param boxIOUThreshold - threshold to treat separate output regions as one object for filtering
-    /// during postprocessing (only one of them should stay). The default value is 0.4
+    /// during postprocessing (only one of them should stay). The default value is 0.5
     /// @param labels - array of labels for every class. If this array is empty or contains less elements
     /// than actual classes number, default "Label #N" will be shown for missing items.
     ModelYolo3(const std::string& modelFileName, float confidenceThreshold, bool useAutoResize,
-        bool useAdvancedPostprocessing = false, float boxIOUThreshold = 0.4, const std::vector<std::string>& labels = std::vector<std::string>());
+        bool useAdvancedPostprocessing = true, float boxIOUThreshold = 0.5, const std::vector<std::string>& labels = std::vector<std::string>());
 
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 

--- a/demos/object_detection_demo/cpp/main.cpp
+++ b/demos/object_detection_demo/cpp/main.cpp
@@ -83,14 +83,14 @@ DEFINE_string(c, "", custom_cldnn_message);
 DEFINE_string(l, "", custom_cpu_library_message);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_double(t, 0.5, thresh_output_message);
-DEFINE_double(iou_t, 0.4, iou_thresh_output_message);
+DEFINE_double(iou_t, 0.5, iou_thresh_output_message);
 DEFINE_bool(auto_resize, false, input_resizable_message);
 DEFINE_uint32(nireq, 0, nireq_message);
 DEFINE_uint32(nthreads, 0, num_threads_message);
 DEFINE_string(nstreams, "", num_streams_message);
 DEFINE_bool(no_show, false, no_show_processed_video);
 DEFINE_string(u, "", utilization_monitors_message);
-DEFINE_bool(yolo_af, false, yolo_af_message);
+DEFINE_bool(yolo_af, true, yolo_af_message);
 
 /**
 * \brief This function shows a help message


### PR DESCRIPTION
align default params between cpp/python object_detection_demo for yolo-v3 case