### PR TITLE
Add PYTHONPATH modification logic for running python demos on Windows

### DIFF
--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -159,8 +159,7 @@ def main():
 
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',
-            **PYTHONPATH),
-        }
+            **PYTHONPATH}
 
         for demo in demos_to_test:
             print('Testing {}...'.format(demo.subdirectory))

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -150,12 +150,9 @@ def main():
 
         num_failures = 0
         
-        pythonpath_args = (os.environ['PYTHONPATH'], args.demo_build_dir)
-        
-        if os.name == "nt":
-            PYTHONPATH = {'PYTHONPATH': "{};{};".format(*pythonpath_args)}
-        else:
-            PYTHONPATH = {'PYTHONPATH': "{}:{}/lib".format(*pythonpath_args)}
+        demo_build_subdir = "/lib" if os.pathsep == ":" else ""
+        pythonpath_args = (os.environ['PYTHONPATH'], os.pathsep, args.demo_build_dir, demo_build_subdir)
+        PYTHONPATH = {'PYTHONPATH': "{}{}{}{}".format(*pythonpath_args)}
 
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -151,10 +151,11 @@ def main():
 
         num_failures = 0
         
-        demo_build_subdir = "" if platform.system() == "Windows" else "/lib"
+        python_module_subdir = "" if platform.system() == "Windows" else "/lib"
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',
-            'PYTHONPATH': f"{os.environ['PYTHONPATH']}{os.pathsep}{args.demo_build_dir}{demo_build_subdir}"}
+            'PYTHONPATH': f"{os.environ['PYTHONPATH']}{os.pathsep}{args.demo_build_dir}{demo_build_subdir}",
+        }
 
         for demo in demos_to_test:
             print('Testing {}...'.format(demo.subdirectory))

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -154,7 +154,7 @@ def main():
         python_module_subdir = "" if platform.system() == "Windows" else "/lib"
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',
-            'PYTHONPATH': f"{os.environ['PYTHONPATH']}{os.pathsep}{args.demo_build_dir}{demo_build_subdir}",
+            'PYTHONPATH': f"{os.environ['PYTHONPATH']}{os.pathsep}{args.demo_build_dir}{python_module_subdir}",
         }
 
         for demo in demos_to_test:

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -149,10 +149,17 @@ def main():
         dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test)
 
         num_failures = 0
+        
+        pythonpath_args = (os.environ['PYTHONPATH'], args.demo_build_dir)
+        
+        if os.name == "nt":
+            PYTHONPATH = {'PYTHONPATH': "{};{};".format(*pythonpath_args)}
+        else:
+            PYTHONPATH = {'PYTHONPATH': "{}:{}/lib".format(*pythonpath_args)}
 
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',
-            'PYTHONPATH': "{}:{}/lib".format(os.environ['PYTHONPATH'], args.demo_build_dir),
+            **PYTHONPATH),
         }
 
         for demo in demos_to_test:

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -31,6 +31,7 @@ import contextlib
 import csv
 import json
 import os
+import platform
 import shlex
 import subprocess
 import sys
@@ -150,13 +151,10 @@ def main():
 
         num_failures = 0
         
-        demo_build_subdir = "/lib" if os.pathsep == ":" else ""
-        pythonpath_args = (os.environ['PYTHONPATH'], os.pathsep, args.demo_build_dir, demo_build_subdir)
-        PYTHONPATH = {'PYTHONPATH': "{}{}{}{}".format(*pythonpath_args)}
-
+        demo_build_subdir = "" if platform.system() == "Windows" else "/lib"
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',
-            **PYTHONPATH}
+            'PYTHONPATH': f"{os.environ['PYTHONPATH']}{os.pathsep}{args.demo_build_dir}{demo_build_subdir}"}
 
         for demo in demos_to_test:
             print('Testing {}...'.format(demo.subdirectory))

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -150,7 +150,7 @@ def main():
         dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test)
 
         num_failures = 0
-        
+
         python_module_subdir = "" if platform.system() == "Windows" else "/lib"
         demo_environment = {**os.environ,
             'PYTHONIOENCODING': 'utf-8',


### PR DESCRIPTION
Fixed incorrect PYTHONPATH modification with non-Windows delimiters on Windows.