### PR TITLE
Add CPU performance tuning 'KEY_CPU_THROUGHPUT_STREAMS' to multi_chan…

### DIFF
--- a/demos/multi_channel_common/cpp/graph.cpp
+++ b/demos/multi_channel_common/cpp/graph.cpp
@@ -48,7 +48,6 @@ void IEGraph::initNetwork(const std::string& deviceName) {
     if (deviceName.find("GPU") != std::string::npos) {
         ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS, InferenceEngine::PluginConfigParams::GPU_THROUGHPUT_AUTO}}, "GPU");
     }
-    }
     if (!cpuExtensionPath.empty()) {
         auto extension_ptr = InferenceEngine::make_so_pointer<InferenceEngine::IExtension>(cpuExtensionPath);
         ie.AddExtension(extension_ptr, "CPU");

--- a/demos/multi_channel_common/cpp/graph.cpp
+++ b/demos/multi_channel_common/cpp/graph.cpp
@@ -43,6 +43,7 @@ void IEGraph::initNetwork(const std::string& deviceName) {
 
     if (deviceName.find("CPU") != std::string::npos) {
         ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_BIND_THREAD, "NO"}}, "CPU");
+        ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,InferenceEngine::PluginConfigParams::CPU_THROUGHPUT_AUTO}},"CPU");
     }
     if (!cpuExtensionPath.empty()) {
         auto extension_ptr = InferenceEngine::make_so_pointer<InferenceEngine::IExtension>(cpuExtensionPath);

--- a/demos/multi_channel_common/cpp/graph.cpp
+++ b/demos/multi_channel_common/cpp/graph.cpp
@@ -43,7 +43,11 @@ void IEGraph::initNetwork(const std::string& deviceName) {
 
     if (deviceName.find("CPU") != std::string::npos) {
         ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_BIND_THREAD, "NO"}}, "CPU");
-        ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS,InferenceEngine::PluginConfigParams::CPU_THROUGHPUT_AUTO}},"CPU");
+        ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS, InferenceEngine::PluginConfigParams::CPU_THROUGHPUT_AUTO}}, "CPU");
+    }
+    if (deviceName.find("GPU") != std::string::npos) {
+        ie.SetConfig({{InferenceEngine::PluginConfigParams::KEY_GPU_THROUGHPUT_STREAMS, InferenceEngine::PluginConfigParams::GPU_THROUGHPUT_AUTO}}, "GPU");
+    }
     }
     if (!cpuExtensionPath.empty()) {
         auto extension_ptr = InferenceEngine::make_so_pointer<InferenceEngine::IExtension>(cpuExtensionPath);


### PR DESCRIPTION
Add CPU performance tuning 'KEY_CPU_THROUGHPUT_STREAMS' to multi_channel demo. 
As for multi_channel demo, the default stream is 1, which is latency-oriented, it's not optimized for multi_channel situation, which require the throughput-oriented situation.

In fact , multi_channel demo doesn't provide nstream/nthread parameters for users to tune, I'm not sure whether I should add these setting.