### PR TITLE
smart_classroom: allow running without dynamic batch

### DIFF
--- a/demos/smart_classroom_demo/cpp/src/cnn.cpp
+++ b/demos/smart_classroom_demo/cpp/src/cnn.cpp
@@ -39,7 +39,12 @@ void CnnDLSDKBase::Load() {
         output_blobs_names_.push_back(item.first);
     }
 
-    executable_network_ = config_.ie.LoadNetwork(cnnNetwork, config_.deviceName);
+    try {
+        executable_network_ = config_.ie.LoadNetwork(cnnNetwork, config_.deviceName);
+    } catch (const details::InferenceEngineException&) {  // face-recognition-mobilefacenet-arcface may not work with dynamic batch
+        cnnNetwork.setBatchSize(1);
+        executable_network_ = config_.ie.LoadNetwork(cnnNetwork, config_.deviceName, {{PluginConfigParams::KEY_DYN_BATCH_ENABLED, PluginConfigParams::NO}});
+    }
     infer_request_ = executable_network_.CreateInferRequest();
 }
 


### PR DESCRIPTION
This PR add safeguard check if model can be processed in dynamic batch. According to OpenVINO [documentation](https://docs.openvinotoolkit.org/latest/openvino_docs_IE_DG_DynamicBatching.html) dynamic batch feature not supported for models which have:
> layers that might arbitrary change tensor shape (such as Flatten, Permute, Reshape), layers specific to object detection topologies (ROIPooling, ProirBox, DetectionOutput), and custom layers