### PR TITLE
Allow using PyTorch 1.8 for model conversion

### DIFF
--- a/models/public/rexnet-v1-x1.0/model.yml
+++ b/models/public/rexnet-v1-x1.0/model.yml
@@ -41,6 +41,11 @@ postprocessing:
     file: rexnetv1.py
     pattern: 'USE_MEMORY_EFFICIENT_SWISH = True'
     replacement: 'USE_MEMORY_EFFICIENT_SWISH = False'
+  # MO can't convert ONNX files with unknown-dimension Squeeze ops
+  - $type: regex_replace
+    file: rexnetv1.py
+    pattern: '\.squeeze\(\)'
+    replacement: '.squeeze(-1).squeeze(-1)'
 framework: pytorch
 conversion_to_onnx_args:
   - --model-path=$dl_dir

--- a/tools/downloader/requirements-pytorch.in
+++ b/tools/downloader/requirements-pytorch.in
@@ -7,6 +7,6 @@ scipy           # via torchvision
 # which might undo the effects of the first change. It's not yet been included in any
 # release at the time of writing, so whether it helps, remains to be seen.
 # For now, just cap the PyTorch version at 1.6.x.
-torch>=1.5,<1.7
-torchvision<0.8
+torch>=1.5,!=1.7.*
+torchvision
 yacs


### PR DESCRIPTION
Only one model currently doesn't work with it; apply a workaround for it.