### PR TITLE
Fix broken link in run_tests.py description

### DIFF
--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -22,8 +22,7 @@ For the tests to work, the test data directory must contain:
   https://drive.google.com/open?id=1A2IU8Sgea1h3fYLpYtFb2v7NYdMjvEhU);
 * a "ILSVRC2012_img_val" subdirectory with the ILSVRC2012 dataset;
 * a "Image_Retrieval" subdirectory with image retrieval dataset (images, videos) (see https://github.com/19900531/test)
-  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/
-089de2f/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
+  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/089de2f/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
 * a "msasl" subdirectory with the MS-ASL dataset (https://www.microsoft.com/en-us/research/project/ms-asl/)
 """
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -22,7 +22,7 @@ For the tests to work, the test data directory must contain:
   https://drive.google.com/open?id=1A2IU8Sgea1h3fYLpYtFb2v7NYdMjvEhU);
 * a "ILSVRC2012_img_val" subdirectory with the ILSVRC2012 dataset;
 * a "Image_Retrieval" subdirectory with image retrieval dataset (images, videos) (see https://github.com/19900531/test)
-  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/develop/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
+  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/develop/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
 * a "msasl" subdirectory with the MS-ASL dataset (https://www.microsoft.com/en-us/research/project/ms-asl/)
 """
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -22,7 +22,8 @@ For the tests to work, the test data directory must contain:
   https://drive.google.com/open?id=1A2IU8Sgea1h3fYLpYtFb2v7NYdMjvEhU);
 * a "ILSVRC2012_img_val" subdirectory with the ILSVRC2012 dataset;
 * a "Image_Retrieval" subdirectory with image retrieval dataset (images, videos) (see https://github.com/19900531/test)
-  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/develop/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
+  and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/
+089de2f/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
 * a "msasl" subdirectory with the MS-ASL dataset (https://www.microsoft.com/en-us/research/project/ms-asl/)
 """
 


### PR DESCRIPTION
The broken link to Image_Retrieval's list of images (gallery.txt) was replaced by new one.
The file was moved in [this](https://github.com/openvinotoolkit/training_extensions/commit/089de2f24667329a58e8560ed4e01ef203e99def) commit.