### PR TITLE
AC: fix setting metric meta if several results required different

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/metrics/regression.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/regression.py
@@ -573,6 +573,7 @@ class PeakSignalToNoiseRatio(BaseRegressionMetric):
     def __init__(self, *args, **kwargs):
         super().__init__(self._psnr_differ, *args, **kwargs)
         self.meta['target'] = 'higher-better'
+        self.meta['target_per_value'] = {'mean': 'higher-better', 'std': 'higher-worse'}
 
     def configure(self):
         super().configure()
@@ -668,6 +669,7 @@ class StructuralSimilarity(BaseRegressionMetric):
     def __init__(self, *args, **kwargs):
         super().__init__(_ssim, *args, **kwargs)
         self.meta['target'] = 'higher-better'
+        self.meta['target_per_value'] = {'mean': 'higher-better', 'std': 'higher-worse'}
 
 
 class PercentageCorrectKeypoints(PerImageEvaluationMetric):

--- a/tools/accuracy_checker/accuracy_checker/presenters.py
+++ b/tools/accuracy_checker/accuracy_checker/presenters.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from collections import namedtuple
+from copy import deepcopy
 import numpy as np
 
 from .utils import Color, color_format
@@ -130,7 +131,15 @@ class VectorPrintPresenter(BasePresenter):
             mean_value = np.mean(value)
             value = np.append(value, mean_value)
             meta['names'] = value_names
-        per_value_meta = [meta for _ in value_names]
+        per_value_meta = []
+        target_per_value = meta.pop('target_per_value', {})
+        target = meta.pop('target', 'higher-better')
+        for v_name in value_names:
+            orig_name = v_name.split('@')[-1]
+            target_for_value = target_per_value.get(orig_name, target)
+            meta_for_value = deepcopy(meta)
+            meta_for_value['target'] = target_for_value
+            per_value_meta.append(meta_for_value)
         results = []
         for idx, value_item in enumerate(value):
             results.append(


### PR DESCRIPTION
PSNR & SSM metrics have differen target directions for different components (mean - higher-better, std - higher-worse), implemented mechanism which allow provide target info for results independently 