### PR TITLE
AC: remove deprecated np.float usage

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/centernet.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/centernet.py
@@ -67,8 +67,8 @@ class CTDETAdapter(Adapter):
         topk_scores = scores[np.arange(scores.shape[0])[:, None], topk_inds]
 
         topk_inds = topk_inds % (height * width)
-        topk_ys = (topk_inds / width).astype(np.int32).astype(np.float)
-        topk_xs = (topk_inds % width).astype(np.int32).astype(np.float)
+        topk_ys = (topk_inds / width).astype(np.int32).astype(float)
+        topk_xs = (topk_inds % width).astype(np.int32).astype(float)
 
         topk_scores = topk_scores.reshape((-1))
         topk_ind = np.argpartition(topk_scores, -K)[-K:]
@@ -143,7 +143,7 @@ class CTDETAdapter(Adapter):
 
             wh = self._tranpose_and_gather_feat(wh, inds)
             wh = wh.reshape((num_predictions, 2))
-            clses = clses.reshape((num_predictions, 1)).astype(np.float)
+            clses = clses.reshape((num_predictions, 1)).astype(float)
             scores = scores.reshape((num_predictions, 1))
             bboxes = np.concatenate((xs - wh[..., 0:1] / 2,
                                      ys - wh[..., 1:2] / 2,

--- a/tools/accuracy_checker/accuracy_checker/adapters/detection.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detection.py
@@ -210,7 +210,7 @@ class MTCNNPAdapter(Adapter):
 
     def _extract_predictions(self, outputs_list, meta):
         scales = [1] if not meta[0] or 'scales' not in meta[0] else meta[0]['scales']
-        total_boxes = np.zeros((0, 9), np.float)
+        total_boxes = np.zeros((0, 9), float)
         for idx, outputs in enumerate(outputs_list):
             scale = scales[idx]
             mapping = outputs[self.probability_out][0, 1, :, :]

--- a/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/retinaface.py
@@ -172,7 +172,7 @@ class RetinaFaceAdapter(Adapter):
         if boxes.shape[0] == 0:
             return np.zeros((0, box_deltas.shape[1]))
 
-        boxes = boxes.astype(np.float, copy=False)
+        boxes = boxes.astype(float, copy=False)
         widths = boxes[:, 2] - boxes[:, 0] + 1.0
         heights = boxes[:, 3] - boxes[:, 1] + 1.0
         ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)
@@ -267,7 +267,7 @@ class RetinaFaceAdapter(Adapter):
     def landmark_pred(boxes, landmark_deltas):
         if boxes.shape[0] == 0:
             return np.zeros((0, landmark_deltas.shape[1]))
-        boxes = boxes.astype(np.float, copy=False)
+        boxes = boxes.astype(float, copy=False)
         widths = boxes[:, 2] - boxes[:, 0] + 1.0
         heights = boxes[:, 3] - boxes[:, 1] + 1.0
         ctr_x = boxes[:, 0] + 0.5 * (widths - 1.0)

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/oar3d.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/oar3d.py
@@ -103,8 +103,8 @@ class OAR3DTilingConverter(DirectoryBasedAnnotationConverter):
 
         if not (mask_name.exists() and input_name.exists()):
 
-            inp = np.zeros([1, self.wD, self.wH, self.wW], dtype=np.float)
-            ref = np.zeros([self.wD, self.wH, self.wW, CLS], dtype=np.float)
+            inp = np.zeros([1, self.wD, self.wH, self.wW], dtype=float)
+            ref = np.zeros([self.wD, self.wH, self.wW, CLS], dtype=float)
             for d in range(self.wD):
                 for h in range(self.wH):
                     for w in range(self.wW):

--- a/tools/accuracy_checker/accuracy_checker/metrics/coco_metrics.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/coco_metrics.py
@@ -341,8 +341,8 @@ def compute_precision_recall(thresholds, matching_results):
     npig = np.count_nonzero(gt_ignored == 0)
     tps = np.logical_and(dtm, np.logical_not(dt_ignored))
     fps = np.logical_and(np.logical_not(dtm), np.logical_not(dt_ignored))
-    tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-    fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+    tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+    fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
     if npig == 0:
         return np.nan, np.nan
     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):


### PR DESCRIPTION
in numpy 1.20 np.float alias for builtin float is deprecated, remove this dtype usage in AC