### PR TITLE
AC: use defusedxml to read XML files instead of ET/lxml

### DIFF
--- a/ci/requirements-ac-test.txt
+++ b/ci/requirements-ac-test.txt
@@ -10,6 +10,8 @@ cycler==0.10.0
     # via matplotlib
 decorator==4.4.2
     # via networkx
+defusedxml==0.7.1
+    # via -r tools/accuracy_checker/requirements-core.in
 editdistance==0.5.3
     # via -r tools/accuracy_checker/requirements.in
 fast-ctc-decode==0.2.5

--- a/ci/requirements-ac.txt
+++ b/ci/requirements-ac.txt
@@ -6,6 +6,8 @@ cycler==0.10.0
     # via matplotlib
 decorator==4.4.2
     # via networkx
+defusedxml==0.7.1
+    # via -r tools/accuracy_checker/requirements-core.in
 editdistance==0.5.3
     # via -r tools/accuracy_checker/requirements.in
 fast-ctc-decode==0.2.5

--- a/ci/requirements-quantization.txt
+++ b/ci/requirements-quantization.txt
@@ -11,7 +11,9 @@ cycler==0.10.0
 decorator==4.4.2
     # via networkx
 defusedxml==0.6.0
-    # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+    # via
+    #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_kaldi.txt
+    #   -r tools/accuracy_checker/requirements-core.in
 editdistance==0.5.3
     # via -r tools/accuracy_checker/requirements.in
 fast-ctc-decode==0.2.5

--- a/tools/accuracy_checker/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/accuracy_checker/utils.py
@@ -31,13 +31,9 @@ from warnings import warn
 from collections.abc import MutableSet, Sequence
 from io import BytesIO
 
+import defusedxml.ElementTree as et
 import numpy as np
 import yaml
-
-try:
-    import lxml.etree as et
-except ImportError:
-    import xml.etree.cElementTree as et
 
 try:
     from shapely.geometry.polygon import Polygon

--- a/tools/accuracy_checker/requirements-core.in
+++ b/tools/accuracy_checker/requirements-core.in
@@ -1,4 +1,5 @@
 # core components
+defusedxml
 numpy>=1.16.3
 PyYAML
 pillow>=8.1


### PR DESCRIPTION
This solves several problems:

* it removes the use of the deprecated `cElementTree` module;
* it prevents developers from accidentally using lxml-specific features (AC doesn't require lxml, so that's unreliable);
* it prevents DoS on malicious input (`ElementTree` is vulnerable to entity expansion attacks).