### PR TITLE
YOLO* model validation fix

### DIFF
--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -46,8 +46,10 @@ models:
             apply_to: prediction
             min_confidence: 0.001
             remove_filtered: true
-          - type: diou_nms
+          - type: nms
             overlap: 0.5
+            diou: True
+            nms_per_class: True
           - type: clip_boxes
             apply_to: prediction
         metrics:
@@ -98,8 +100,10 @@ models:
             apply_to: prediction
             min_confidence: 0.001
             remove_filtered: true
-          - type: diou_nms
+          - type: nms
             overlap: 0.5
+            diou: True
+            nms_per_class: True
           - type: clip_boxes
             apply_to: prediction
         metrics:

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -32,12 +32,12 @@ models:
       - name: ms_coco_detection_80_class_without_background
         im_reader: pillow
         preprocessing:
-          - type: normalization
-            std: 255.0
           - type: resize
             size: 608
             aspect_ratio_scale: fit_to_window
             use_pillow: True
+          - type: normalization
+            std: 255.0
           - type: padding
             pad_type: center
         postprocessing:

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -80,8 +80,12 @@ models:
         preprocessing:
           - type: resize
             size: 608
+            aspect_ratio_scale: fit_to_window
+            use_pillow: True
+          - type: padding
+            pad_type: center
         postprocessing:
-          - type: resize_prediction_boxes
+          - type: letterbox_postprocessing_resize
           - type: filter
             apply_to: prediction
             min_confidence: 0.001

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -30,12 +30,13 @@ models:
           - conv2d_109/BiasAdd
     datasets:
       - name: ms_coco_detection_80_class_without_background
-        im_reader: pillow
+        reader: pillow_imread
         preprocessing:
           - type: resize
             size: 608
             aspect_ratio_scale: fit_to_window
             use_pillow: True
+            interpolation: BICUBIC
           - type: normalization
             std: 255.0
           - type: padding
@@ -85,13 +86,14 @@ models:
             - conv2d_109/BiasAdd/Add
     datasets:
       - name: ms_coco_detection_80_class_without_background
-        im_reader: pillow
+        reader: pillow_imread
         preprocessing:
           - type: rgb_to_bgr
           - type: resize
             size: 608
             aspect_ratio_scale: fit_to_window
             use_pillow: True
+            interpolation: BICUBIC
           - type: padding
             pad_type: center
         postprocessing:

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -15,6 +15,7 @@ models:
           output_format: HWB
           do_reshape: True
           cells: [76, 38, 19]
+          scales: [1.2, 1.1, 1.05]
           outputs:
             - conv2d_93/BiasAdd
             - conv2d_101/BiasAdd
@@ -29,14 +30,18 @@ models:
           - conv2d_109/BiasAdd
     datasets:
       - name: ms_coco_detection_80_class_without_background
+        im_reader: pillow
         preprocessing:
-          - type: bgr_to_rgb
           - type: normalization
             std: 255.0
           - type: resize
             size: 608
+            aspect_ratio_scale: fit_to_window
+            use_pillow: True
+          - type: padding
+            pad_type: center
         postprocessing:
-          - type: resize_prediction_boxes
+          - type: letterbox_postprocessing_resize
           - type: filter
             apply_to: prediction
             min_confidence: 0.001
@@ -71,13 +76,16 @@ models:
           threshold: 0.001
           anchor_masks: [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
           raw_output: True
+          scales: [1.2, 1.1, 1.05]
           outputs:
             - conv2d_93/BiasAdd/Add
             - conv2d_101/BiasAdd/Add
             - conv2d_109/BiasAdd/Add
     datasets:
       - name: ms_coco_detection_80_class_without_background
+        im_reader: pillow
         preprocessing:
+          - type: rgb_to_bgr
           - type: resize
             size: 608
             aspect_ratio_scale: fit_to_window

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -48,7 +48,7 @@ models:
             min_confidence: 0.001
             remove_filtered: true
           - type: nms
-            overlap: 0.5
+            overlap: 0.4
             diou: True
             nms_per_class: True
           - type: clip_boxes
@@ -103,7 +103,7 @@ models:
             min_confidence: 0.001
             remove_filtered: true
           - type: nms
-            overlap: 0.5
+            overlap: 0.4
             diou: True
             nms_per_class: True
           - type: clip_boxes

--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -59,6 +59,7 @@ AccuracyChecker supports following set of adapters:
   * `do_reshape` - forces reshape output tensor to [B,Cy,Cx] or [Cy,Cx,B] format, depending on `output_format` value ([B,Cy,Cx] by default). You may need to specify `cells` value.
   * `transpose` - transpose output tensor to specified format (optional).
   * `multi_labels` - allows multiple labels for single box (optional, default `False`)
+  * `scales` - sets scales for grid sensivity elimination (used for YOLO v4 model). Optional, none by default.
 * `yolo_v3_onnx` - converting output of ONNX Yolo V3 model to `DetectionPrediction`.
   * `boxes_out` - the name of layer with bounding boxes
   * `scores_out` - the name of output layer with detection scores for each class and box pair.

--- a/tools/accuracy_checker/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/adapters/README.md
@@ -58,6 +58,7 @@ AccuracyChecker supports following set of adapters:
   * `cells` - sets grid size for each layer, according `outputs` filed. Works only with `do_reshape=True` or when output tensor dimensions not equal 3.
   * `do_reshape` - forces reshape output tensor to [B,Cy,Cx] or [Cy,Cx,B] format, depending on `output_format` value ([B,Cy,Cx] by default). You may need to specify `cells` value.
   * `transpose` - transpose output tensor to specified format (optional).
+  * `multi_labels` - allows multiple labels for single box (optional, default `False`)
 * `yolo_v3_onnx` - converting output of ONNX Yolo V3 model to `DetectionPrediction`.
   * `boxes_out` - the name of layer with bounding boxes
   * `scores_out` - the name of output layer with detection scores for each class and box pair.

--- a/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/yolo.py
@@ -42,8 +42,8 @@ class YoloOutputProcessor:
         if anchors is None:
             anchors = [1, 1]
         if self.scale:
-            x = self.coord_correct(bbox.x) * scale - (scale - 1.0) / 2
-            y = self.coord_correct(bbox.y) * scale - (scale - 1.0) / 2
+            x = self.coord_correct(bbox.x) * self.scale - (self.scale - 1.0) / 2
+            y = self.coord_correct(bbox.y) * self.scale - (self.scale - 1.0) / 2
             x = (x + i) / self.x_normalizer
             y = (y + j) / self.y_normalizer
         else:
@@ -451,7 +451,7 @@ class YoloV3Adapter(Adapter):
                 self.processor.y_normalizer = cells
 
                 if self.scales:
-                    self.processor.scale = scales[layer_id]
+                    self.processor.scale = self.scales[layer_id]
 
                 labels, scores, x_mins, y_mins, x_maxs, y_maxs = parse_output(p, cells, num, box_size, anchors,
                                                                               self.processor, self.threshold,

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -34,6 +34,7 @@ Accuracy Checker supports following set of postprocessors:
   * `use_min_area` - boolean value to determine whether to use minimum area of two bounding boxes as base area to calculate overlap.
   * `per_class_nms` - enables supression only within class (`False` by default)
   * `diou` - uses distance-IoU non-maximum supression (`False` by default)
+  * `diou_pow` - sets degree for distance-IOU expression (`1` by default)
 * `soft_nms` - soft non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
   * `keep_top_k`  - the maximal number of detections which should be kept.
   * `sigma` - sigma-value for updated detection score calculation.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -28,7 +28,7 @@ Accuracy Checker supports following set of postprocessors:
    - the preprocessing steps contains only one operation changing input image size, and the operation is `resize`
    - the preprocessing steps contains only two operations changing input image size, and the operations are `resize` and then `padding`.
    * `rescale` if this option enabled, rescaling boxes on input size will be performed before applying postprocessing (Optional, default `False`).
-* `resize_prediction_boxes` - resizing normalized detection prediction boxes according to image with the letterbox resizing. Supported representations: `DetectionAnotation`, `DetectionPrediction`. Works only when the preprocessing steps contains only two operations changing - `resize` and then `padding` with `center` padding type.
+* `letterbox_postprocessing_resize` - resizing normalized detection prediction boxes according to image with the letterbox resizing. Supported representations: `DetectionAnotation`, `DetectionPrediction`. Works only when the preprocessing steps contains only two operations changing - `resize` and then `padding` with `center` padding type.
 * `nms` - non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
   * `overlap` - overlap threshold for merging detections.
   * `use_min_area` - boolean value to determine whether to use minimum area of two bounding boxes as base area to calculate overlap.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -32,8 +32,8 @@ Accuracy Checker supports following set of postprocessors:
 * `nms` - non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
   * `overlap` - overlap threshold for merging detections.
   * `use_min_area` - boolean value to determine whether to use minimum area of two bounding boxes as base area to calculate overlap.
-* `diou_nms` - distance-IoU non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
-  * `overlap` - overlap threshold for merging detections.
+  * `per_class_nms` - enables supression only within class (`False` by default)
+  * `diou` - uses distance-IoU non-maximum supression (`False` by default)
 * `soft_nms` - soft non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
   * `keep_top_k`  - the maximal number of detections which should be kept.
   * `sigma` - sigma-value for updated detection score calculation.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/README.md
@@ -28,6 +28,7 @@ Accuracy Checker supports following set of postprocessors:
    - the preprocessing steps contains only one operation changing input image size, and the operation is `resize`
    - the preprocessing steps contains only two operations changing input image size, and the operations are `resize` and then `padding`.
    * `rescale` if this option enabled, rescaling boxes on input size will be performed before applying postprocessing (Optional, default `False`).
+* `resize_prediction_boxes` - resizing normalized detection prediction boxes according to image with the letterbox resizing. Supported representations: `DetectionAnotation`, `DetectionPrediction`. Works only when the preprocessing steps contains only two operations changing - `resize` and then `padding` with `center` padding type.
 * `nms` - non-maximum suppression. Supported representations: `DetectionAnotation`, `DetectionPrediction`, `ActionDetectionAnnotation`, `ActionDetectionPrediction`.
   * `overlap` - overlap threshold for merging detections.
   * `use_min_area` - boolean value to determine whether to use minimum area of two bounding boxes as base area to calculate overlap.

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
@@ -60,6 +60,7 @@ from .argmax_segmentation_mask import ArgMaxSegmentationMask
 from .normalize_salient_map import SalientMapNormalizer
 from .min_max_normalization import MinMaxRegressionNormalization
 from .crop_image import CropImage, CornerCropImage
+from .letterbox_postrocessing_resize import LetterboxPostprocessingResize
 
 
 __all__ = [
@@ -81,6 +82,7 @@ __all__ = [
     'DIoUNMS',
     'ResizePredictionBoxes',
     'FRCNNPostprocessingBboxResize',
+    'LetterboxPostprocessingResize',
     'CorrectYoloV2Boxes',
     'NormalizeBoxes',
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/__init__.py
@@ -29,7 +29,7 @@ from .filter import (
 
 from .cast_to_int import CastToInt
 from .clip_boxes import ClipBoxes
-from .nms import NMS, SoftNMS, DIoUNMS
+from .nms import NMS, SoftNMS
 from .resize_prediction_boxes import ResizePredictionBoxes
 from .faster_rcnn_postprocessing_resize import FRCNNPostprocessingBboxResize
 from .correct_yolo_v2_boxes import CorrectYoloV2Boxes
@@ -79,7 +79,6 @@ __all__ = [
     'ClipBoxes',
     'NMS',
     'SoftNMS',
-    'DIoUNMS',
     'ResizePredictionBoxes',
     'FRCNNPostprocessingBboxResize',
     'LetterboxPostprocessingResize',

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
@@ -42,7 +42,6 @@ class LetterboxPostprocessingResize(Postprocessor):
             assert op_name2 == "padding", (
                 "Unknown case: two geometric operations, the second with name '{}'".format(op_name2))
             pad = op_props2['pad']
-            assert (pad[0] == 0 and pad[2] == 0) or (pad[1] == 0 and pad[3] == 0), "Unknown case: padding is not center"
 
             offset_x = pad[1] / op_props2['pref_width']
             offset_y = pad[2] / op_props2['pref_height']

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
@@ -13,8 +13,6 @@ limitations under the License.
 
 from ..representation import DetectionPrediction, DetectionAnnotation
 from ..postprocessor.postprocessor import Postprocessor
-from ..utils import get_size_from_config
-from ..config import NumberField, BoolField
 
 
 class LetterboxPostprocessingResize(Postprocessor):

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/letterbox_postrocessing_resize.py
@@ -1,0 +1,63 @@
+"""
+Copyright (c) 2021 Intel Corporation
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..representation import DetectionPrediction, DetectionAnnotation
+from ..postprocessor.postprocessor import Postprocessor
+from ..utils import get_size_from_config
+from ..config import NumberField, BoolField
+
+
+class LetterboxPostprocessingResize(Postprocessor):
+    __provider__ = 'letterbox_postprocessing_resize'
+
+    prediction_types = (DetectionPrediction, )
+    annotation_types = (DetectionAnnotation, )
+
+    def process_image(self, annotations, predictions):
+        raise RuntimeError("Since `process_image_with_metadata` is overriden, this method MUST NOT be called")
+
+    def process_image_with_metadata(self, annotations, predictions, image_metadata=None):
+        assert image_metadata and 'geometric_operations' in image_metadata, (
+            "Postprocessing step `faster_rcnn_postprocessing_resize` cannot work without "
+            "metadata with `geometric_operations` field")
+
+        assert image_metadata and 'geometric_operations' in image_metadata
+        geometric_operations = image_metadata['geometric_operations']  # should be list of GeometricOperationMetadata
+
+        if len(geometric_operations) == 2:
+            op_name1, op_props1 = geometric_operations[0]
+            op_name2, op_props2 = geometric_operations[1]
+            assert op_name1 == "resize", (
+                "Unknown case: two geometric operations, the first with name '{}'".format(op_name1))
+            assert op_name2 == "padding", (
+                "Unknown case: two geometric operations, the second with name '{}'".format(op_name2))
+            pad = op_props2['pad']
+            assert (pad[0] == 0 and pad[2] == 0) or (pad[1] == 0 and pad[3] == 0), "Unknown case: padding is not center"
+
+            offset_x = pad[1] / op_props2['pref_width']
+            offset_y = pad[2] / op_props2['pref_height']
+            scale_x = op_props2['pref_width'] / op_props2['width'] * op_props1['original_width']
+            scale_y = op_props2['pref_height'] / op_props2['height'] * op_props1['original_height']
+
+        else:
+            raise RuntimeError(
+                "Unknown case: ""len(image_metadata['geometric_operations']) = {}".format(len(geometric_operations))
+            )
+
+        for prediction in predictions:
+            prediction.x_mins = (prediction.x_mins - offset_x) * scale_x
+            prediction.x_maxs = (prediction.x_maxs - offset_x) * scale_x
+            prediction.y_mins = (prediction.y_mins - offset_y) * scale_y
+            prediction.y_maxs = (prediction.y_maxs - offset_y) * scale_y
+
+        return annotations, predictions

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/nms.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/nms.py
@@ -71,6 +71,10 @@ class NMS(Postprocessor):
             'nms_per_class': BoolField(
                 optional=True, default=False,
                 description="Use nms for each class separately"
+            ),
+            'diou': BoolField(
+                optional=True, default=False,
+                description="Use DIOU NMS"
             )
         })
         return parameters
@@ -80,7 +84,8 @@ class NMS(Postprocessor):
         self.include_boundaries = self.get_value_from_config('include_boundaries')
         self.keep_top_k = self.get_value_from_config('keep_top_k')
         self.use_min_area = self.get_value_from_config('use_min_area')
-        self.nms_per_class = True
+        self.nms_per_class = self.get_value_from_config('nms_per_class')
+        self.diou = self.get_value_from_config('diou')
 
     def process_image(self, annotations, predictions):
         for prediction in predictions:
@@ -96,13 +101,13 @@ class NMS(Postprocessor):
                         prediction.x_mins[indexes], prediction.y_mins[indexes],
                         prediction.x_maxs[indexes], prediction.y_maxs[indexes],
                         scores[indexes],
-                        self.overlap, self.include_boundaries, self.keep_top_k, self.use_min_area
+                        self.overlap, self.include_boundaries, self.keep_top_k, self.use_min_area, self.diou
                     )
                     keep.extend(indexes[keep_per_class])
             else:
                 keep = self.nms(
                     prediction.x_mins, prediction.y_mins, prediction.x_maxs, prediction.y_maxs, scores,
-                    self.overlap, self.include_boundaries, self.keep_top_k, self.use_min_area
+                    self.overlap, self.include_boundaries, self.keep_top_k, self.use_min_area, self.diou
                 )
 
             prediction.remove([box for box in range(len(prediction.x_mins)) if box not in keep])
@@ -110,7 +115,8 @@ class NMS(Postprocessor):
         return annotations, predictions
 
     @staticmethod
-    def nms(x1, y1, x2, y2, scores, thresh, include_boundaries=True, keep_top_k=None, use_min_area=False):
+    def nms(x1, y1, x2, y2, scores, thresh, include_boundaries=True, keep_top_k=None,
+            use_min_area=False, use_diou=False):
         """
         Pure Python NMS baseline.
         """
@@ -148,6 +154,15 @@ class NMS(Postprocessor):
                 out=np.zeros_like(intersection, dtype=float),
                 where=base_area != 0
             )
+            if use_diou:
+                cw = np.maximum(x2[i], x2[order[1:]]) - np.minimum(x1[i], x1[order[1:]])
+                ch = np.maximum(y2[i], y2[order[1:]]) - np.minimum(y1[i], y1[order[1:]])
+                c_area = cw ** 2 + ch ** 2 + 1e-16
+                d_1 = ((x2[order[1:]] + x1[order[1:]]) - (x2[i] + x1[i])) ** 2 / 4
+                d_2 = ((y2[order[1:]] + y1[order[1:]]) - (y2[i] + y1[i])) ** 2 / 4
+                d_area = d_1 + d_2
+
+                overlap = overlap - pow(d_area / c_area, 0.6)
             order = order[np.where(overlap <= thresh)[0] + 1] # pylint: disable=W0143
 
         return keep
@@ -251,85 +266,3 @@ class SoftNMS(Postprocessor):
             scores *= np.exp(np.negative(np.square(iou_values) / self.sigma))
 
         return np.array(out_ids, dtype=np.int32), np.array(out_scores, dtype=np.float32)
-
-class DIoUNMS(Postprocessor):
-    __provider__ = 'diou_nms'
-
-    prediction_types = (DetectionPrediction, ActionDetectionPrediction)
-    annotation_types = (DetectionAnnotation, ActionDetectionPrediction)
-
-    @classmethod
-    def parameters(cls):
-        parameters = super().parameters()
-        parameters.update({
-            'overlap': NumberField(
-                min_value=0, max_value=1, optional=True, default=0.5,
-                description="Overlap threshold for merging detections."
-            ),
-            'include_boundaries': BoolField(
-                optional=True, default=True, description="Shows if boundaries are included."
-            ),
-            'keep_top_k': NumberField(min_value=0, optional=True, description="Keep top K.")
-        })
-        return parameters
-
-    def configure(self):
-        self.overlap = self.get_value_from_config('overlap')
-        self.include_boundaries = self.get_value_from_config('include_boundaries')
-        self.keep_top_k = self.get_value_from_config('keep_top_k')
-
-    def process_image(self, annotations, predictions):
-        for prediction in predictions:
-            scores = get_scores(prediction)
-            keep = self.diou_nms(
-                prediction.x_mins, prediction.y_mins, prediction.x_maxs, prediction.y_maxs, scores,
-                self.overlap, self.include_boundaries, self.keep_top_k
-            )
-            prediction.remove([box for box in range(len(prediction.x_mins)) if box not in keep])
-
-        return annotations, predictions
-
-    @staticmethod
-    def diou_nms(x1, y1, x2, y2, scores, thresh, include_boundaries=True, keep_top_k=None, use_min_area=False):
-
-        b = 1 if include_boundaries else 0
-
-        areas = (x2 - x1 + b) * (y2 - y1 + b)
-        order = scores.argsort()[::-1]
-
-        if keep_top_k:
-            order = order[:keep_top_k]
-
-        keep = []
-
-        while order.size > 0:
-            i = order[0]
-            keep.append(i)
-
-            xx1 = np.maximum(x1[i], x1[order[1:]])
-            yy1 = np.maximum(y1[i], y1[order[1:]])
-            xx2 = np.minimum(x2[i], x2[order[1:]])
-            yy2 = np.minimum(y2[i], y2[order[1:]])
-
-            w = np.maximum(0.0, xx2 - xx1 + b)
-            h = np.maximum(0.0, yy2 - yy1 + b)
-            intersection = w * h
-
-            cw = np.maximum(x2[i], x2[order[1:]]) - np.minimum(x1[i], x1[order[1:]])
-            ch = np.maximum(y2[i], y2[order[1:]]) - np.minimum(y1[i], y1[order[1:]])
-            c_area = cw**2 + ch**2 + 1e-16
-            d_1 = ((x2[order[1:]] + x1[order[1:]]) - (x2[i] + x1[i]))**2 / 4
-            d_2 = ((y2[order[1:]] + y1[order[1:]]) - (y2[i] + y1[i]))**2 / 4
-            d_area = d_1 + d_2
-
-            base_area = (areas[i] + areas[order[1:]] - intersection)
-
-            overlap = np.divide(
-                intersection,
-                base_area,
-                out=np.zeros_like(intersection, dtype=float),
-                where=base_area != 0
-            ) - pow(d_area / c_area, 0.6)
-            order = order[np.where(overlap <= thresh)[0] + 1] # pylint: disable=W0143
-
-        return keep


### PR DESCRIPTION
What's new:

- Updated `yolo_v3` adapder:
    - added `scales` parameter for setting scales - grid sensivity eliminators (presented in V4 model)
    - added `multi_label` parameter allowing multiple labels for same box
- The `letterbox_postprocessing_resize` - resizer for boxes, uses then initial image has letterbox resize (`keep_aspect_ratio` in `resize` and `center` in `padding`)
- The `nms` and `diou_nms` are united under `nms` type. The `diou_nms` parameter enables DIoU-NMS
- Added `nms_per_class` parameter allowing suppresion within sinlge class
- Updated config for `yolo-v4-tf` model (aligning validation with initial [repo](https://github.com/david8862/keras-YOLOv3-model-set)
- [ ] Updated accuracy metrics for `yolo-v4-tf` model