### PR TITLE
Add resizer to ocv_common

### DIFF
--- a/demos/common/cpp/models/include/models/detection_model.h
+++ b/demos/common/cpp/models/include/models/detection_model.h
@@ -16,6 +16,7 @@
 #pragma once
 #include "models/model_base.h"
 #include "opencv2/core.hpp"
+#include "utils/ocv_common.hpp"
 
 class DetectionModel : public ModelBase {
 public:
@@ -41,6 +42,6 @@ protected:
 
     size_t netInputHeight = 0;
     size_t netInputWidth = 0;
-
+    Resizer* imgResizer = nullptr;
     std::string getLabelName(int labelID) { return (size_t)labelID < labels.size() ? labels[labelID] : std::string("Label #") + std::to_string(labelID); }
 };

--- a/demos/common/cpp/models/include/models/detection_model.h
+++ b/demos/common/cpp/models/include/models/detection_model.h
@@ -42,6 +42,6 @@ protected:
 
     size_t netInputHeight = 0;
     size_t netInputWidth = 0;
-    Resizer* imgResizer = nullptr;
+    std::unique_ptr<Resizer> imgResizer = nullptr;
     std::string getLabelName(int labelID) { return (size_t)labelID < labels.size() ? labels[labelID] : std::string("Label #") + std::to_string(labelID); }
 };

--- a/demos/common/cpp/models/include/models/detection_model_centernet.h
+++ b/demos/common/cpp/models/include/models/detection_model_centernet.h
@@ -32,8 +32,6 @@ public:
 
     ModelCenterNet(const std::string& modelFileName, float confidenceThreshold,
         const std::vector<std::string>& labels = std::vector<std::string>());
-    std::shared_ptr<InternalModelData> preprocess(
-        const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:

--- a/demos/common/cpp/models/include/models/detection_model_retinaface.h
+++ b/demos/common/cpp/models/include/models/detection_model_retinaface.h
@@ -44,8 +44,6 @@ public:
     /// @param labels - array of labels for every class. If this array is empty or contains less elements
     /// than actual classes number, default "Label #N" will be shown for missing items.
     ModelRetinaFace(const std::string& model_name, float confidenceThreshold, bool useAutoResize, float boxIOUThreshold);
-    std::shared_ptr<InternalModelData> preprocess(const InputData& inputData,
-        InferenceEngine::InferRequest::Ptr& request) override;
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:

--- a/demos/common/cpp/models/include/models/detection_model_retinaface.h
+++ b/demos/common/cpp/models/include/models/detection_model_retinaface.h
@@ -44,6 +44,8 @@ public:
     /// @param labels - array of labels for every class. If this array is empty or contains less elements
     /// than actual classes number, default "Label #N" will be shown for missing items.
     ModelRetinaFace(const std::string& model_name, float confidenceThreshold, bool useAutoResize, float boxIOUThreshold);
+    std::shared_ptr<InternalModelData> preprocess(const InputData& inputData,
+        InferenceEngine::InferRequest::Ptr& request) override;
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:

--- a/demos/common/cpp/models/src/detection_model.cpp
+++ b/demos/common/cpp/models/src/detection_model.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<InternalModelData> DetectionModel::preprocess(const InputData& i
     }
     /* Resize and copy data from the image to the input blob */
     Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
-    matU8ToBlob<uint8_t>(img, frameBlob);
+    matU8ToBlob<uint8_t>(imgResizer->resize(img), frameBlob);
     return std::make_shared<InternalImageModelData>(img.cols, img.rows);
 }
 

--- a/demos/common/cpp/models/src/detection_model_centernet.cpp
+++ b/demos/common/cpp/models/src/detection_model_centernet.cpp
@@ -218,8 +218,8 @@ void transform(std::vector<ModelCenterNet::BBox>& bboxes, const InferenceEngine:
         ModelCenterNet::BBox newbb;
 
         newbb.left = trans.at<float>(0, 0) *  b.left + trans.at<float>(0, 1) *  b.top + trans.at<float>(0, 2);
-        newbb.top = trans.at<float>(1, 0)* b.left + trans.at<float>(1, 1) * b.top + trans.at<float>(1, 2);
-        newbb.right = trans.at<float>(0, 0)* b.right + trans.at<float>(0, 1) * b.bottom + trans.at<float>(0, 2);
+        newbb.top = trans.at<float>(1, 0) * b.left + trans.at<float>(1, 1) * b.top + trans.at<float>(1, 2);
+        newbb.right = trans.at<float>(0, 0) * b.right + trans.at<float>(0, 1) * b.bottom + trans.at<float>(0, 2);
         newbb.bottom = trans.at<float>(1, 0) *  b.right + trans.at<float>(1, 1) *  b.bottom + trans.at<float>(1, 2);
 
         b = newbb;

--- a/demos/common/cpp/models/src/detection_model_ssd.cpp
+++ b/demos/common/cpp/models/src/detection_model_ssd.cpp
@@ -103,6 +103,7 @@ void ModelSSD::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) {
             const TensorDesc& inputDesc = inputInfoItem.second->getTensorDesc();
             netInputHeight = getTensorHeight(inputDesc);
             netInputWidth = getTensorWidth(inputDesc);
+            imgResizer.reset(new StretchResizer(netInputWidth, netInputWidth));
         }
         else if (inputInfoItem.second->getTensorDesc().getDims().size() == 2) {  // 2nd input contains image info
             inputsNames.resize(2);

--- a/demos/common/cpp/models/src/detection_model_yolo.cpp
+++ b/demos/common/cpp/models/src/detection_model_yolo.cpp
@@ -52,7 +52,7 @@ void ModelYolo3::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) {
     const TensorDesc& inputDesc = inputInfo.begin()->second->getTensorDesc();
     netInputHeight = getTensorHeight(inputDesc);
     netInputWidth = getTensorWidth(inputDesc);
-
+    imgResizer.reset(new StretchResizer(netInputWidth, netInputWidth));
     // --------------------------- Prepare output blobs -----------------------------------------------------
     slog::info << "Checking that the outputs are as the demo expects" << slog::endl;
     OutputsDataMap outputInfo(cnnNetwork.getOutputsInfo());

--- a/demos/common/cpp/utils/include/utils/nms.hpp
+++ b/demos/common/cpp/utils/include/utils/nms.hpp
@@ -19,6 +19,18 @@
 #include "opencv2/core.hpp"
 #include <vector>
 
+template <typename T>
+struct BBox {
+    T left;
+    T top;
+    T right;
+    T bottom;
+
+    T getWidth() const { return (right - left) + 1.0f; }
+    T getHeight() const { return (bottom - top) + 1.0f; }
+    float getXCenter() const { return left + (getWidth() - 1.0f) / 2.0f; }
+    float getYCenter() const { return top + (getHeight() - 1.0f) / 2.0f; }
+};
 
 template <typename Anchor>
 std::vector<int> nms(const std::vector<Anchor>& boxes, const std::vector<float>& scores,

--- a/demos/common/cpp/utils/include/utils/nms.hpp
+++ b/demos/common/cpp/utils/include/utils/nms.hpp
@@ -19,19 +19,6 @@
 #include "opencv2/core.hpp"
 #include <vector>
 
-template <typename T>
-struct BBox {
-    T left;
-    T top;
-    T right;
-    T bottom;
-
-    T getWidth() const { return (right - left) + 1.0f; }
-    T getHeight() const { return (bottom - top) + 1.0f; }
-    float getXCenter() const { return left + (getWidth() - 1.0f) / 2.0f; }
-    float getYCenter() const { return top + (getHeight() - 1.0f) / 2.0f; }
-};
-
 template <typename Anchor>
 std::vector<int> nms(const std::vector<Anchor>& boxes, const std::vector<float>& scores,
                      const float thresh, bool includeBoundaries=false) {

--- a/demos/common/cpp/utils/include/utils/ocv_common.hpp
+++ b/demos/common/cpp/utils/include/utils/ocv_common.hpp
@@ -100,11 +100,11 @@ void matU8ToBlob(const cv::Mat& origImage, InferenceEngine::Blob::Ptr& blob, int
     InferenceEngine::LockedMemory<void> blobMapped = InferenceEngine::as<InferenceEngine::MemoryBlob>(blob)->wmap();
     T* blobData = blobMapped.as<T*>();
 
-     cv::Mat resizedImage(origImage);
-     if (static_cast<int>(width) != origImage.size().width ||
-             static_cast<int>(height) != origImage.size().height) {
-         cv::resize(origImage, resizedImage, cv::Size(width, height));
-     }
+    cv::Mat resizedImage(origImage);
+    if (static_cast<int>(width) != origImage.size().width ||
+            static_cast<int>(height) != origImage.size().height) {
+        cv::resize(origImage, resizedImage, cv::Size(width, height));
+    }
 
     int batchOffset = batchIndex * width * height * channels;
 

--- a/demos/common/cpp/utils/include/utils/ocv_common.hpp
+++ b/demos/common/cpp/utils/include/utils/ocv_common.hpp
@@ -37,7 +37,7 @@ public:
         origH = img.size().height;
         scaleX = static_cast<float>(origW) / dstW;
         scaleY = static_cast<float>(origH) / dstH;
-        
+
         cv::Mat resizedImage(img);
         if (dstW != origW ||dstH != origH) {
             cv::resize(img, resizedImage, cv::Size(dstW, dstH), 0., 0., interType);


### PR DESCRIPTION
Some models in object_detection_demo requires letterbox resize for input to produce correct results on image (ex. retinaface), this PR provides it. Also it would be nice to have function which scale bounding box coordinates back to origin image, it implemented in the same class.
- [ ] Update centernet model class

- [ ] Update ssd model class

- [ ] Update yolo model class