### PR TITLE
AC: ignore non image inputs in normalization

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
@@ -95,7 +95,7 @@ Accuracy Checker supports following set of preprocessors:
 * `point_alignment` - aligning keypoints stored in annotation metadata.
   * `draw_points` - allows visualize points.
   * `normalize` - allows to use normalization for keypoints.
-  * `dst_width` and `dst_height` are destination width and height for keypoints resizing respectively. You can also use `size` instead in case when destination sizes are equal.*
+  * `dst_width` and `dst_height` are destination width and height for keypoints resizing respectively. You can also use `size` instead in case when destination sizes are equal.
 * `corner_crop` - Corner crop of the image.
   * `dst_width` and `dst_height` are destination width and height
   * `corner_type` is type of the corner crop. Options are:

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/README.md
@@ -45,6 +45,7 @@ Accuracy Checker supports following set of preprocessors:
   * `std` specifies values, on which pixels will be divided.
      You can specify one value for all channels or list of comma separated channel-wise values.
      These parameters support work with precomputed values of frequently used datasets (e.g. `cifar10` or `imagenet`).
+  * `images_only` - prevent usage normalization for non-image inputs in multi input mode (Optional, default `False`).
 * `resize3d` - resizing 3d image (e.g. MRI scans) to new size:
   * `size` in format `(H,W,D)`. All values will be interpolated with 1st-order spline.
 * `crop_brats`  -  performing crop of 3d images (e.g. MRI scans) by cropping all non-zero voxels. Also sets bounding boxes for `segmentation_prediction_resample` preprocessor (see [Postprocessors](../postprocessor/README.md))
@@ -94,7 +95,7 @@ Accuracy Checker supports following set of preprocessors:
 * `point_alignment` - aligning keypoints stored in annotation metadata.
   * `draw_points` - allows visualize points.
   * `normalize` - allows to use normalization for keypoints.
-  * `dst_width` and `dst_height` are destination width and height for keypoints resizing respectively. You can also use `size` instead in case when destination sizes are equal.
+  * `dst_width` and `dst_height` are destination width and height for keypoints resizing respectively. You can also use `size` instead in case when destination sizes are equal.*
 * `corner_crop` - Corner crop of the image.
   * `dst_width` and `dst_height` are destination width and height
   * `corner_type` is type of the corner crop. Options are:

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/normalization.py
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/normalization.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import numpy as np
 
-from ..config import NormalizationArgsField, ConfigError
+from ..config import NormalizationArgsField, ConfigError, BoolField
 from ..preprocessor import Preprocessor
 
 
@@ -49,6 +49,9 @@ class Normalize(Preprocessor):
                             "channels or list of comma separated channel-wise values.",
                 precomputed_args=Normalize.PRECOMPUTED_STDS,
                 allow_zeros=False
+            ),
+            'images_only': BoolField(
+                optional=True, default=False, description='in multi input mode, process only images.'
             )
         })
         return parameters
@@ -56,11 +59,17 @@ class Normalize(Preprocessor):
     def configure(self):
         self.mean = self.get_value_from_config('mean')
         self.std = self.get_value_from_config('std')
+        self.images_only = self.get_value_from_config('images_only')
         if not self.mean and not self.std:
             raise ConfigError('mean or std value should be provided')
 
     def process(self, image, annotation_meta=None):
         def process_data(data, mean, std):
+            if (
+                self.images_only and len(data.shape) not in [2, 3] or
+                (len(data.shape) == 3 and data.shape[-1] not in [1, 3, 4])
+            ):
+                return data
             if self.mean:
                 data = data - mean
             if self.std:

--- a/tools/accuracy_checker/accuracy_checker/preprocessor/normalization.py
+++ b/tools/accuracy_checker/accuracy_checker/preprocessor/normalization.py
@@ -66,8 +66,8 @@ class Normalize(Preprocessor):
     def process(self, image, annotation_meta=None):
         def process_data(data, mean, std):
             if (
-                self.images_only and len(data.shape) not in [2, 3] or
-                (len(data.shape) == 3 and data.shape[-1] not in [1, 3, 4])
+                    self.images_only and len(data.shape) not in [2, 3] or
+                    (len(data.shape) == 3 and data.shape[-1] not in [1, 3, 4])
             ):
                 return data
             if self.mean:


### PR DESCRIPTION
by default normalization applied to all model inputs, however not all of them may require normalization. Prevent usage normalization parameters for non image inputs in case, when user explicitly set it