### PR TITLE
demos: use defusedxml to parse XML

### DIFF
--- a/demos/multi_camera_multi_target_tracking_demo/python/run_evaluate.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/run_evaluate.py
@@ -15,9 +15,9 @@ import argparse
 import json
 import logging as log
 
+import defusedxml.ElementTree as etree
 import motmetrics as mm
 import numpy as np
-from xml.etree import ElementTree as etree
 from tqdm import tqdm
 
 from mc_tracker.sct import TrackedObj

--- a/demos/smart_classroom_demo/cpp/action_event_metrics.py
+++ b/demos/smart_classroom_demo/cpp/action_event_metrics.py
@@ -16,9 +16,9 @@ from argparse import ArgumentParser
 from collections import namedtuple
 from os.path import exists
 
+import defusedxml.ElementTree as etree
 import numpy as np
 from builtins import range
-from lxml import etree
 from tqdm import tqdm
 
 BBoxDesc = namedtuple('BBoxDesc', 'id, label, det_conf, xmin, ymin, xmax, ymax')


### PR DESCRIPTION
defusedxml prevents DoS due to malicious XML entities.

I don't think we need to add it to the requirements, because we only parse XML in supplementary scripts that likely won't be used by most users of the demos.