### PR TITLE
Add flake8-comprehensions checks to the basic checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@ exclude=
     models/public/mozilla-deepspeech-0.8.2/mds_convert_utils/memmapped_file_system_pb2.py,
 
 select=
+    # flake8-comprehensions issues
+    C4,
     # indentation problems
     E10,E11,
     # closing bracket does not match indentation of opening brackets line
@@ -37,3 +39,6 @@ ignore=
     # ignored because putting a statement after a colon is harmless and
     # sometimes results in more compact code
     E701,E704,
+    # unnecessary <dict/list/tuple> call
+    # TODO: consider enabling this later
+    C408,

--- a/ci/requirements-check-basics.in
+++ b/ci/requirements-check-basics.in
@@ -1,2 +1,3 @@
 flake8
+flake8-comprehensions
 yamllint

--- a/ci/requirements-check-basics.txt
+++ b/ci/requirements-check-basics.txt
@@ -1,9 +1,15 @@
 # use update-requirements.py to update this file
 
-flake8==3.9.0
+flake8-comprehensions==3.4.0
     # via -r ci/requirements-check-basics.in
+flake8==3.9.0
+    # via
+    #   -r ci/requirements-check-basics.in
+    #   flake8-comprehensions
 importlib-metadata==3.7.3
-    # via flake8
+    # via
+    #   flake8
+    #   flake8-comprehensions
 mccabe==0.6.1
     # via flake8
 mistune==2.0.0a6

--- a/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
+++ b/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
@@ -339,8 +339,8 @@ def main():
     result = res[out_name]
     batch, channels, out_d, out_h, out_w = result.shape
 
-    list_img = list()
-    list_seg_result = list()
+    list_img = []
+    list_seg_result = []
 
     logger.info("Processing of the received inference results is started")
     start_time = datetime.now()

--- a/demos/action_recognition_demo/python/action_recognition_demo/models.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/models.py
@@ -112,7 +112,7 @@ class IEModel:
 class DummyDecoder:
     def __init__(self, num_requests=2):
         self.num_requests = num_requests
-        self.requests = dict()
+        self.requests = {}
 
     @staticmethod
     def _average(model_input):

--- a/demos/bert_question_answering_demo/python/bert_question_answering_demo.py
+++ b/demos/bert_question_answering_demo/python/bert_question_answering_demo.py
@@ -126,7 +126,7 @@ def main():
         seq = min(c, int(np.ceil((len(c_tokens_id) + args.max_question_token_num) / 64) * 64))
         if seq < c:
             input_info = list(ie_encoder.inputs)
-            new_shapes = dict([])
+            new_shapes = {}
             for i in input_info:
                 n, c = ie_encoder.inputs[i].shape
                 new_shapes[i] = [n, seq]
@@ -143,8 +143,8 @@ def main():
                      " as (context length + max question length) exceeds the current (input) network sequence length")
 
     # check input and output names
-    input_names = list(i.strip() for i in args.input_names.split(','))
-    output_names = list(o.strip() for o in args.output_names.split(','))
+    input_names = [i.strip() for i in args.input_names.split(',')]
+    output_names = [o.strip() for o in args.output_names.split(',')]
     if ie_encoder.inputs.keys() != set(input_names) or ie_encoder.outputs.keys() != set(output_names):
         log.error("Input or Output names do not match")
         log.error("    The demo expects input->output names: {}->{}. "

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -104,7 +104,7 @@ class YOLO(Model):
     @staticmethod
     def _parse_yolo_region(predictions, input_size, params, threshold, multiple_labels=True):
         # ------------------------------------------ Extracting layer parameters ---------------------------------------
-        objects = list()
+        objects = []
         size_normalizer = input_size if params.isYoloV3 else params.sides
         bbox_size = params.coords + 1 + params.classes
         # ------------------------------------------- Parsing YOLO Region output ---------------------------------------
@@ -196,7 +196,7 @@ class YOLO(Model):
         return detections
 
     def postprocess(self, outputs, meta):
-        detections = list()
+        detections = []
 
         for layer_name, out_blob in outputs.items():
             layer_params = self.yolo_layer_params[layer_name]

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
@@ -147,7 +147,7 @@ def main():
 
     last_caption = None
     active_object_id = -1
-    tracker_labels_map = dict()
+    tracker_labels_map = {}
     tracker_labels = set()
 
     frames_processed = 0
@@ -200,7 +200,7 @@ def main():
                         cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
 
         if detections is not None:
-            tracker_labels = set(det.id for det in detections)
+            tracker_labels = {det.id for det in detections}
 
             for det in detections:
                 roi_color = (0, 255, 0) if active_object_id == det.id else (128, 128, 128)

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo/tracker.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo/tracker.py
@@ -181,7 +181,7 @@ class Tracker:  # pylint: disable=too-few-public-methods
         """Returns active detections"""
 
         if self._last_detections is None or len(self._last_detections) == 0:
-            return list(), dict()
+            return [], {}
 
         out_detections = []
         for det in self._last_detections:
@@ -196,10 +196,10 @@ class Tracker:  # pylint: disable=too-few-public-methods
             out_detections.sort(key=lambda x: x.conf, reverse=True)
             out_detections = out_detections[:max_num_detections]
 
-        matched_det_ids = set(det.id for det in out_detections) & labels_map.keys()
+        matched_det_ids = {det.id for det in out_detections} & labels_map.keys()
         unused_det_ids = sorted(set(range(max_num_detections)) - matched_det_ids)
 
-        out_labels_map = dict()
+        out_labels_map = {}
         for det in out_detections:
             if det.id in matched_det_ids:
                 out_labels_map[det.id] = labels_map[det.id]

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo/video_library.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo/video_library.py
@@ -50,7 +50,7 @@ class VideoLibrary:
     def parse_source_paths(input_dir, valid_names):
         """Returns the list of valid video sources"""
 
-        valid_names = set(n.lower() for n in valid_names)
+        valid_names = {n.lower() for n in valid_names}
         all_file_paths = [f for f in listdir(input_dir) if isfile(join(input_dir, f))]
         all_file_paths.sort()
 

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo/visualizer.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo/visualizer.py
@@ -30,7 +30,7 @@ class Visualizer:
         self._last_key = Value('i', -1, lock=True)
         self._need_stop = Value('i', False, lock=False)
         self._worker_process = None
-        self._tasks = dict()
+        self._tasks = {}
 
     def register_window(self, name):
         """Allocates resources for the new window"""

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo/model_utils.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo/model_utils.py
@@ -77,7 +77,7 @@ def mask_rcnn_postprocess(
     scores = scores[detections_filter]
     classes = classes[detections_filter]
     boxes = boxes[detections_filter]
-    masks = list(segm for segm, is_valid in zip(masks, detections_filter) if is_valid)
+    masks = [segm for segm, is_valid in zip(masks, detections_filter) if is_valid]
     return scores, classes, boxes, masks
 
 

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo/tracker.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo/tracker.py
@@ -77,11 +77,11 @@ class StaticIOUTracker(object):
 
         # Prune out too old tracks.
         alive = tuple(i for i, age in enumerate(self.age) if age < self.age_threshold)
-        self.history = list(self.history[i] for i in alive)
-        self.history_areas = list(self.history_areas[i] for i in alive)
-        self.history_classes = list(self.history_classes[i] for i in alive)
-        self.age = list(self.age[i] for i in alive)
-        self.ids = list(self.ids[i] for i in alive)
+        self.history = [self.history[i] for i in alive]
+        self.history_areas = [self.history_areas[i] for i in alive]
+        self.history_classes = [self.history_classes[i] for i in alive]
+        self.age = [self.age[i] for i in alive]
+        self.ids = [self.ids[i] for i in alive]
 
         # Save new tracks.
         for i, j in enumerate(assignment):

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo/visualizer.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo/visualizer.py
@@ -122,7 +122,7 @@ class Visualizer(object):
         presenter.drawGraphs(result)
 
         if self.show_masks and segms is not None:
-            segms = list(segm for segm, show in zip(segms, filter_mask) if show)
+            segms = [segm for segm, show in zip(segms, filter_mask) if show]
             result = self.overlay_masks(result, segms, classes, ids)
 
         if self.show_boxes:

--- a/demos/multi_camera_multi_target_tracking_demo/python/utils/segm_postprocess.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/utils/segm_postprocess.py
@@ -56,7 +56,7 @@ def postprocess(scores, classes, boxes, raw_cls_masks,
     classes = classes[confidence_filter]
     boxes = boxes[confidence_filter]
     if raw_cls_masks is not None:
-        raw_cls_masks = list(segm for segm, is_valid in zip(raw_cls_masks, confidence_filter) if is_valid)
+        raw_cls_masks = [segm for segm, is_valid in zip(raw_cls_masks, confidence_filter) if is_valid]
 
     if len(scores) == 0:
         return no_detections

--- a/demos/tests/args.py
+++ b/demos/tests/args.py
@@ -61,7 +61,7 @@ class DataPatternArg:
         seq = [Path(data.resolve(context))
             for data in context.data_sequences[self.sequence_name]]
 
-        assert len(set(data.suffix for data in seq)) == 1, "all images in the sequence must have the same extension"
+        assert len({data.suffix for data in seq}) == 1, "all images in the sequence must have the same extension"
         assert '%' not in seq[0].suffix
 
         name_format = 'input-%04d' + seq[0].suffix

--- a/demos/text_spotting_demo/python/text_spotting_demo/tracker.py
+++ b/demos/text_spotting_demo/python/text_spotting_demo/tracker.py
@@ -77,11 +77,11 @@ class StaticIOUTracker(object):
 
         # Prune out too old tracks.
         alive = tuple(i for i, age in enumerate(self.age) if age < self.age_threshold)
-        self.history = list(self.history[i] for i in alive)
-        self.history_areas = list(self.history_areas[i] for i in alive)
-        self.history_classes = list(self.history_classes[i] for i in alive)
-        self.age = list(self.age[i] for i in alive)
-        self.ids = list(self.ids[i] for i in alive)
+        self.history = [self.history[i] for i in alive]
+        self.history_areas = [self.history_areas[i] for i in alive]
+        self.history_classes = [self.history_classes[i] for i in alive]
+        self.age = [self.age[i] for i in alive]
+        self.ids = [self.ids[i] for i in alive]
 
         # Save new tracks.
         for i, j in enumerate(assignment):

--- a/tools/accuracy_checker/accuracy_checker/adapters/text_recognition.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/text_recognition.py
@@ -107,7 +107,7 @@ class BeamSearchDecoder(Adapter):
         times, symbols = probabilities.shape
         # Initialize the beam with the empty sequence, a probability of 1 for ending in blank
         # and zero for ending in non-blank (in log space).
-        beam = [(tuple(), (0.0, -np.inf))]
+        beam = [((), (0.0, -np.inf))]
 
         for time in range(times):
             # A default dictionary to store the next step candidates.

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/image_retrieval.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/image_retrieval.py
@@ -49,7 +49,7 @@ class ImageRetrievalConverter(BaseFormatConverter):
 
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
         content_errors = None if not check_content else []
-        gallery = list()
+        gallery = []
         gallery_ids = set()
         if progress_callback:
             num_iteration = len(read_txt(self.gallery_annotation_file)) + len(read_txt(self.queries_annotation_file))
@@ -67,7 +67,7 @@ class ImageRetrievalConverter(BaseFormatConverter):
             if progress_callback and line_id % progress_interval == 0:
                 progress_callback(line_id * 100 / num_iteration)
 
-        queries = list()
+        queries = []
         queries_ids = set()
         for line_id, line in enumerate(read_txt(self.queries_annotation_file)):
             identifier, image_id = line.split()

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/ms_asl_continuous.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/ms_asl_continuous.py
@@ -119,7 +119,7 @@ class MSASLContiniousConverter(BaseFormatConverter):
 
             annotations.append(ClassificationAnnotation(identifier, record.label))
 
-        return ConverterReturn(annotations, dict(), content_errors)
+        return ConverterReturn(annotations, {}, content_errors)
 
     @staticmethod
     def load_annotations(ann_file):

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/pascal_voc.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/pascal_voc.py
@@ -28,7 +28,7 @@ _VOC_CLASSES_DETECTION = (
     'sheep', 'sofa', 'train', 'tvmonitor'
 )
 
-_VOC_CLASSES_SEGMENTATION = tuple(['__background__']) + _VOC_CLASSES_DETECTION
+_VOC_CLASSES_SEGMENTATION = ('__background__',) + _VOC_CLASSES_DETECTION
 _SEGMENTATION_COLORS = ((
     (0, 0, 0), (128, 0, 0), (0, 128, 0), (128, 128, 0),
     (0, 0, 128), (128, 0, 128), (0, 128, 128), (128, 128, 128),

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/squad_bidaf.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/squad_bidaf.py
@@ -102,9 +102,9 @@ class SQUADConverterBiDAF(BaseFormatConverter):
                     tokens.extend(re.split("([{}])".format("".join(additional_separators)), token))
             else:
                 tokens = nltk_tokens
-            assert not any([t == '<NULL>' for t in tokens])
-            assert not any([' ' in t for t in tokens])
-            assert not any(['\t' in t for t in tokens])
+            assert not any(t == '<NULL>' for t in tokens)
+            assert not any(' ' in t for t in tokens)
+            assert not any('\t' in t for t in tokens)
             return tokens
 
         words = tokenize(text, is_context)

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/squad_emb.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/squad_emb.py
@@ -136,7 +136,7 @@ class SQUADConverterEMB(BaseFormatConverter):
         self.lower_case = self.get_value_from_config('lower_case')
         vocab_file = str(self.get_value_from_config('vocab_file'))
         with open(vocab_file, "r", encoding="utf-8") as r:
-            self.vocab = dict((t.rstrip("\n"), i) for i, t in enumerate(r.readlines()))
+            self.vocab = {t.rstrip("\n"): i for i, t in enumerate(r.readlines())}
 
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
 

--- a/tools/accuracy_checker/accuracy_checker/config/config_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_reader.py
@@ -124,7 +124,7 @@ class ConfigReader:
     @staticmethod
     def process_config(config, mode='models', arguments=None):
         if arguments is None:
-            arguments = dict()
+            arguments = {}
         ConfigReader._merge_paths_with_prefixes(arguments, config, mode)
         ConfigReader._provide_cmd_arguments(arguments, config, mode)
         ConfigReader._filter_launchers(config, arguments, mode)

--- a/tools/accuracy_checker/accuracy_checker/config/config_validator.py
+++ b/tools/accuracy_checker/accuracy_checker/config/config_validator.py
@@ -138,7 +138,7 @@ class ConfigValidator(BaseValidator):
                 self.fields[key].validate(entry[key], fetch_only=fetch_only, validation_scheme=field_valid_scheme)
             )
 
-        required_fields = set(name for name, value in self.fields.items() if value.required())
+        required_fields = {name for name, value in self.fields.items() if value.required()}
         missing_arguments = required_fields.difference(entry)
 
         if missing_arguments:

--- a/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/model_evaluator.py
@@ -361,7 +361,7 @@ class ModelEvaluator(BaseEvaluator):
 
             batch_input, batch_meta = self._get_batch_input(batch_annotation, batch_input)
             self.launcher.predict_async(infer_requests_pool[ir_id], batch_input, batch_meta,
-                                        context=tuple([batch_id, batch_input_ids, batch_annotation]))
+                                        context=(batch_id, batch_input_ids, batch_annotation))
             queued_irs.append(ir_id)
 
         return free_irs, queued_irs

--- a/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
+++ b/tools/accuracy_checker/accuracy_checker/evaluators/quantization_model_evaluator.py
@@ -321,7 +321,7 @@ class ModelEvaluator:
 
             batch_input, batch_meta = self._get_batch_input(batch_inputs, batch_annotation)
             self.launcher.predict_async(infer_requests_pool[ir_id], batch_input, batch_meta,
-                                        context=tuple([batch_id, batch_input_ids, batch_annotation, batch_identifiers]))
+                                        context=(batch_id, batch_input_ids, batch_annotation, batch_identifiers))
             queued_irs.append(ir_id)
 
         return free_irs, queued_irs

--- a/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/dlsdk_launcher.py
@@ -156,7 +156,7 @@ class DLSDKLauncher(Launcher):
         self.disable_resize_to_input = False
         self._do_reshape = False
         self._use_set_blob = False
-        self._output_layouts = dict()
+        self._output_layouts = {}
         self.preprocessor = preprocessor
 
         if not delayed_model_loading:
@@ -772,7 +772,7 @@ class DLSDKLauncher(Launcher):
                 output_tuple = string_to_tuple(output_string, casting_type=None)
                 if len(output_tuple) == 1:
                     return output_string
-                return tuple([output_tuple[0], int(output_tuple[1])])
+                return (output_tuple[0], int(output_tuple[1]))
             preprocessed_outputs = [output_preprocessing(output) for output in outputs]
             self.network.add_outputs(preprocessed_outputs)
         if input_shapes is not None:
@@ -861,7 +861,7 @@ class DLSDKLauncher(Launcher):
             if len(data_shape) == 1:
                 return np.transpose([data])
             if len(data_shape) > 2:
-                if all([dim == 1 for dim in layer_shape]) and all([dim == 1 for dim in data_shape]):
+                if all(dim == 1 for dim in layer_shape) and all(dim == 1 for dim in data_shape):
                     return np.resize(data, layer_shape)
                 if len(np.squeeze(np.zeros(layer_shape))) == len(np.squeeze(np.zeros(data_shape))):
                     return np.resize(data, layer_shape)

--- a/tools/accuracy_checker/accuracy_checker/launcher/opencv_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/opencv_launcher.py
@@ -169,7 +169,7 @@ class OpenCVLauncher(Launcher):
             raise ConfigError('inputs should be provided in config')
 
         def parse_shape_value(shape):
-            return tuple([1, *[int(elem) for elem in get_or_parse_value(shape, ())]])
+            return (1, *map(int, get_or_parse_value(shape, ())))
 
         return OrderedDict([(elem.get('name'), parse_shape_value(elem.get('shape'))) for elem in inputs])
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/tf_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/tf_launcher.py
@@ -92,7 +92,7 @@ class TFLauncher(Launcher):
                 self._outputs_tensors.append(tensor)
 
         self.device = '/{}:0'.format(self.get_value_from_config('device').lower())
-        self._output_layouts = dict()
+        self._output_layouts = {}
         self._lstm_inputs = None
         if '_list_lstm_inputs' in self.config:
             self._configure_lstm_inputs()
@@ -111,7 +111,7 @@ class TFLauncher(Launcher):
             if len(data_shape) == 1:
                 return np.transpose([data])
             if len(data_shape) > 2:
-                if all([dim == 1 for dim in layer_shape]) and all([dim == 1 for dim in data_shape]):
+                if all(dim == 1 for dim in layer_shape) and all(dim == 1 for dim in data_shape):
                     return np.resize(data, layer_shape)
                 if len(np.squeeze(np.zeros(layer_shape))) == len(np.squeeze(np.zeros(data_shape))):
                     return np.resize(data, layer_shape)

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/extend_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/extend_segmentation_mask.py
@@ -69,7 +69,7 @@ class ExtendSegmentationMask(Postprocessor):
         return annotation, prediction
 
     def process_image_with_metadata(self, annotation, prediction, image_metadata=None):
-        if all([annotation_ is None for annotation_ in annotation]):
+        if all(annotation_ is None for annotation_ in annotation):
             return annotation, self._deprocess_prediction(prediction, image_metadata)
         return self.process_image(annotation, prediction)
 

--- a/tools/accuracy_checker/accuracy_checker/postprocessor/postprocessor.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/postprocessor.py
@@ -254,7 +254,7 @@ class PostprocessorWithSpecificTargets(Postprocessor):
         return target_annotations, target_predictions
 
     def _choose_targets_using_apply_to(self, annotations, predictions):
-        if all([annotation is None for annotation in annotations]):
+        if all(annotation is None for annotation in annotations):
             apply_to = ApplyToOption.PREDICTION
             self._deprocess_predictions = True
         else:

--- a/tools/accuracy_checker/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/accuracy_checker/utils.py
@@ -95,7 +95,7 @@ def string_to_tuple(string, casting_type=float):
     processed = processed.replace(')', '')
     processed = processed.split(',')
 
-    return tuple([casting_type(entry) for entry in processed]) if casting_type else tuple(processed)
+    return tuple(map(casting_type, processed)) if casting_type else tuple(processed)
 
 
 def string_to_list(string):
@@ -104,7 +104,7 @@ def string_to_list(string):
     processed = processed.replace(']', '')
     processed = processed.split(',')
 
-    return list(entry for entry in processed)
+    return processed
 
 
 def validate_print_interval(value, min_value=0, max_value=None):
@@ -561,7 +561,7 @@ class MatlabDataReader():
             'miUTF16': {'n': 17, 'fmt': 's'},
             'miUTF32': {'n': 18, 'fmt': 's'}
         }
-        self.inv_etypes = dict((v['n'], k) for k, v in self.etypes.items())
+        self.inv_etypes = {v['n']: k for k, v in self.etypes.items()}
         self.mclasses = {
             'mxCELL_CLASS': 1,
             'mxSTRUCT_CLASS': 2,
@@ -594,7 +594,7 @@ class MatlabDataReader():
             'mxINT64_CLASS': 'miINT64',
             'mxUINT64_CLASS': 'miUINT64'
         }
-        self.inv_mclasses = dict((v, k) for k, v in self.mclasses.items())
+        self.inv_mclasses = {v: k for k, v in self.mclasses.items()}
         self.compressed_numeric = ['miINT32', 'miUINT16', 'miINT16', 'miUINT8']
 
     def read_var_header(self, fd, endian):
@@ -709,12 +709,12 @@ class MatlabDataReader():
             return data
         rowcount = header['dims'][0]
         colcount = header['dims'][1]
-        array = [list(data[c * rowcount + r] for c in range(colcount))
+        array = [[data[c * rowcount + r] for c in range(colcount)]
                  for r in range(rowcount)]
         return self._squeeze(array)
 
     def _read_cell_array(self, fd, endian, header):
-        array = [list() for i in range(header['dims'][0])]
+        array = [[] for i in range(header['dims'][0])]
         for row in range(header['dims'][0]):
             for _col in range(header['dims'][1]):
                 vheader, next_pos, fd_var = self.read_var_header(fd, endian)

--- a/tools/accuracy_checker/pylint_checkers.py
+++ b/tools/accuracy_checker/pylint_checkers.py
@@ -120,7 +120,7 @@ class BadFunctionChecker(BaseChecker):
     )
 
     def visit_call(self, node):
-        bad_functions = set(f.strip() for f in self.config.bad_functions.split(','))
+        bad_functions = {f.strip() for f in self.config.bad_functions.split(',')}
         if self._function_name(node) in bad_functions:
             self.add_message('bad-function-call', node=node)
 

--- a/tools/downloader/converter.py
+++ b/tools/downloader/converter.py
@@ -143,12 +143,12 @@ def main():
 
         model_format = model.framework
 
-        template_variables = dict(
-            config_dir=common.MODEL_ROOT / model.subdirectory,
-            conv_dir=output_dir / model.subdirectory,
-            dl_dir=args.download_dir / model.subdirectory,
-            mo_dir=mo_path.parent,
-        )
+        template_variables = {
+            'config_dir': common.MODEL_ROOT / model.subdirectory,
+            'conv_dir': output_dir / model.subdirectory,
+            'dl_dir': args.download_dir / model.subdirectory,
+            'mo_dir': mo_path.parent,
+        }
 
         if model.conversion_to_onnx_args:
             if not convert_to_onnx(reporter, model, output_dir, args, template_variables):


### PR DESCRIPTION
Fix any issues that were found.

Note about `C408`: there are a lot of instances of `dict()` being used instead of `dict` literals, and I haven't refactored them all yet (also, I think in some cases it's better to replace those `dict`s with `SimpleNamespaces`, which is a non-trivial change), so I decided to leave enabling that warning for a future PR.