### PR TITLE
Don't run the AC CI jobs on changes to the config files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,5 +31,6 @@
 /models/**/*.yml -omz.ci.job-for-change.documentation
 
 /tools/accuracy_checker/** omz.ci.job-for-change.ac
+/tools/accuracy_checker/configs/*.yml -omz.ci.job-for-change.ac
 /tools/downloader/** omz.ci.job-for-change.downloader
 /tools/**/*.md -omz.ci.job-for-change.ac -omz.ci.job-for-change.downloader


### PR DESCRIPTION
Previously, the AC jobs used to run yamllint on the configs, but now that is done by the trigger job as part of the basic checks, so there's no reason to run AC jobs when config files are changed anymore.