### PR TITLE
demos: replace some dicts with namespaces

### DIFF
--- a/demos/formula_recognition_demo/python/formula_recognition_demo.py
+++ b/demos/formula_recognition_demo/python/formula_recognition_demo.py
@@ -159,8 +159,8 @@ def non_interactive_demo(model, args):
     renderer = create_renderer()
     show_window = not args.no_show
     for rec in tqdm(model.images_list):
-        log.info("Starting inference for %s", rec['img_name'])
-        image = rec['img']
+        log.info("Starting inference for %s", rec.img_name)
+        image = rec.img
         distribution, targets = model.infer_sync(image)
         prob = calculate_probability(distribution)
         log.info("Confidence score is %s", prob)
@@ -168,9 +168,9 @@ def non_interactive_demo(model, args):
             phrase = model.vocab.construct_phrase(targets)
             if args.output_file:
                 with open(args.output_file, 'a') as output_file:
-                    output_file.write(rec['img_name'] + '\t' + phrase + '\n')
+                    output_file.write(rec.img_name + '\t' + phrase + '\n')
             else:
-                print("\n\tImage name: {}\n\tFormula: {}\n".format(rec['img_name'], phrase))
+                print("\n\tImage name: {}\n\tFormula: {}\n".format(rec.img_name, phrase))
                 if renderer is not None:
                     rendered_formula, _ = renderer.render(phrase)
                     if rendered_formula is not None and show_window:

--- a/demos/formula_recognition_demo/python/utils.py
+++ b/demos/formula_recognition_demo/python/utils.py
@@ -22,6 +22,7 @@ import subprocess
 import tempfile
 from enum import Enum
 from multiprocessing.pool import ThreadPool
+from types import SimpleNamespace as namespace
 
 import cv2 as cv
 import numpy as np
@@ -187,7 +188,7 @@ class Model:
             assert image_raw is not None, "Error reading image {}".format(filenm)
             image = preprocess_image(
                 PREPROCESSING[self.args.preprocessing_type], image_raw, target_shape)
-            record = dict(img_name=filenm, img=image, formula=None)
+            record = namespace(img_name=filenm, img=image)
             self.images_list.append(record)
 
     def check_model_dimensions(self):

--- a/demos/multi_camera_multi_target_tracking_demo/python/configs/person.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/configs/person.py
@@ -1,20 +1,22 @@
+from types import SimpleNamespace as namespace
+
 random_seed = 100
 
-obj_det = dict(
+obj_det = namespace(
     trg_classes=(1,)
 )
 
-obj_segm = dict(
+obj_segm = namespace(
     trg_classes=(1,)
 )
 
-mct_config = dict(
+mct_config = namespace(
     time_window=20,
     global_match_thresh=0.2,
     bbox_min_aspect_ratio=1.2
 )
 
-sct_config = dict(
+sct_config = namespace(
     time_window=10,
     continue_time_thresh=2,
     track_clear_thresh=3000,
@@ -30,19 +32,19 @@ sct_config = dict(
     rectify_thresh=0.1
 )
 
-normalizer_config = dict(
+normalizer_config = namespace(
     enabled=False,
     clip_limit=.5,
     tile_size=8
 )
 
-visualization_config = dict(
+visualization_config = namespace(
     show_all_detections=True,
     max_window_size=(1920, 1080),
     stack_frames='vertical'
 )
 
-analyzer = dict(
+analyzer = namespace(
     enable=False,
     show_distances=True,
     save_distances='',
@@ -52,8 +54,8 @@ analyzer = dict(
     crop_size=(32, 64)
 )
 
-embeddings = dict(
+embeddings = namespace(
     save_path='',
-    use_images=True,  # Use it with `analyzer['enable'] = True` to save crops of objects
+    use_images=True,  # Use it with `analyzer.enable = True` to save crops of objects
     step=0  # Equal to subdirectory for `save_path`
 )

--- a/demos/multi_camera_multi_target_tracking_demo/python/configs/vehicle.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/configs/vehicle.py
@@ -1,20 +1,22 @@
+from types import SimpleNamespace as namespace
+
 random_seed = 100
 
-obj_det = dict(
+obj_det = namespace(
     trg_classes=(1,)
 )
 
-obj_segm = dict(
+obj_segm = namespace(
     trg_classes=(3, 6, 8)
 )
 
-mct_config = dict(
+mct_config = namespace(
     time_window=5,
     global_match_thresh=0.2,
     bbox_min_aspect_ratio=0.1
 )
 
-sct_config = dict(
+sct_config = namespace(
     time_window=4,
     continue_time_thresh=3,
     track_clear_thresh=3000,
@@ -30,19 +32,19 @@ sct_config = dict(
     rectify_thresh=0.1
 )
 
-normalizer_config = dict(
+normalizer_config = namespace(
     enabled=False,
     clip_limit=.5,
     tile_size=8
 )
 
-visualization_config = dict(
+visualization_config = namespace(
     show_all_detections=True,
     max_window_size=(1920, 1080),
     stack_frames='vertical'
 )
 
-analyzer = dict(
+analyzer = namespace(
     enable=False,
     show_distances=True,
     save_distances='',
@@ -52,8 +54,8 @@ analyzer = dict(
     crop_size=(32, 64)
 )
 
-embeddings = dict(
+embeddings = namespace(
     save_path='',
-    use_images=True,  # Use it with `analyzer['enable'] = True` to save crops of objects
+    use_images=True,  # Use it with `analyzer.enable = True` to save crops of objects
     step=0  # Equal to subdirectory for `save_path`
 )

--- a/demos/multi_camera_multi_target_tracking_demo/python/mc_tracker/mct.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/mc_tracker/mct.py
@@ -21,7 +21,7 @@ from .sct import SingleCameraTracker, clusters_distance, THE_BIGGEST_DISTANCE
 
 class MultiCameraTracker:
     def __init__(self, num_sources, reid_model,
-                 sct_config={},
+                 sct_config,
                  time_window=20,
                  global_match_thresh=0.35,
                  bbox_min_aspect_ratio=1.2,
@@ -41,7 +41,8 @@ class MultiCameraTracker:
         for i in range(num_sources):
             self.scts.append(SingleCameraTracker(i, self._get_next_global_id,
                                                  self._release_global_id,
-                                                 reid_model, visual_analyze=visual_analyze, **sct_config))
+                                                 reid_model, visual_analyze=visual_analyze,
+                                                 **vars(sct_config)))
 
     def process(self, frames, all_detections, masks=None):
         assert len(frames) == len(all_detections) == len(self.scts)

--- a/demos/multi_camera_multi_target_tracking_demo/python/mc_tracker/sct.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/mc_tracker/sct.py
@@ -259,8 +259,8 @@ class SingleCameraTracker:
         self.analyzer = None
         self.current_detections = None
 
-        if visual_analyze is not None and 'enable' in visual_analyze and visual_analyze['enable']:
-            self.analyzer = Analyzer(self.id, **visual_analyze)
+        if visual_analyze is not None and visual_analyze.enable:
+            self.analyzer = Analyzer(self.id, **vars(visual_analyze))
 
     def process(self, frame, detections, mask=None):
         reid_features = [None]*len(detections)

--- a/demos/multi_camera_multi_target_tracking_demo/python/utils/misc.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/utils/misc.py
@@ -16,6 +16,7 @@ import logging as log
 import os.path as osp
 import sys
 from importlib import import_module
+from types import SimpleNamespace as namespace
 
 
 class AverageEstimator(object):
@@ -66,13 +67,12 @@ def read_py_config(filename):
     sys.path.insert(0, config_dir)
     mod = import_module(module_name)
     sys.path.pop(0)
-    cfg_dict = {
+
+    return namespace(**{
         name: value
         for name, value in mod.__dict__.items()
         if not name.startswith('__')
-    }
-
-    return cfg_dict
+    })
 
 
 def check_pressed_keys(key):

--- a/demos/speech_recognition_demo/python/speech_recognition_demo.py
+++ b/demos/speech_recognition_demo/python/speech_recognition_demo.py
@@ -101,8 +101,8 @@ def main():
     for candidate in transcription:
         print(
             "{}\t{}".format(
-                candidate['conf'],
-                candidate['text'],
+                candidate.conf,
+                candidate.text,
             )
         )
 

--- a/demos/speech_recognition_demo/python/utils/ctcnumpy_beam_search_decoder.py
+++ b/demos/speech_recognition_demo/python/utils/ctcnumpy_beam_search_decoder.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+
+from types import SimpleNamespace as namespace
+
 import numpy as np
 
 import ctcdecode_numpy
@@ -37,7 +40,7 @@ class CtcnumpyBeamSearchDecoder:
         output, scores, timesteps, out_seq_len = self.decoder_state.decode(probs[np.newaxis])
         assert out_seq_len.shape[0] == 1
         beam_results = [
-            dict(
+            namespace(
                 conf=scores[0, res_idx],
                 text=self.alphabet.decode(output[0, res_idx, :out_seq_len[0, res_idx]]),
                 ts=list(timesteps[0, res_idx]),

--- a/demos/whiteboard_inpainting_demo/python/utils/network_wrappers.py
+++ b/demos/whiteboard_inpainting_demo/python/utils/network_wrappers.py
@@ -14,6 +14,8 @@
 import cv2
 import numpy as np
 
+from types import SimpleNamespace as namespace
+
 from .ie_tools import IEModel
 from .segm_postprocess import postprocess
 
@@ -57,8 +59,10 @@ class MaskRCNN(IEModel):
         processed_image = processed_image.astype('float32').transpose(2, 0, 1)
         height, width = processed_image.shape[1], processed_image.shape[2]
         im_info = np.array([height, width, 1.0], dtype='float32') if self.segmentoly_type else None
-        meta=dict(original_size=frame.shape[:2],
-                  processed_size=processed_image.shape[1:3])
+        meta=namespace(
+            original_size=frame.shape[:2],
+            processed_size=processed_image.shape[1:3],
+        )
         return processed_image, im_info, meta
 
     def forward(self, im_data, im_info):
@@ -97,10 +101,10 @@ class MaskRCNN(IEModel):
 
             boxes, classes, scores, _, masks = self.forward(im_data, im_info)
             scores, classes, boxes, masks = postprocess(scores, classes, boxes, masks,
-                                                        im_h=meta['original_size'][0],
-                                                        im_w=meta['original_size'][1],
-                                                        im_scale_y=meta['processed_size'][0] / meta['original_size'][0],
-                                                        im_scale_x=meta['processed_size'][1] / meta['original_size'][1],
+                                                        im_h=meta.original_size[0],
+                                                        im_w=meta.original_size[1],
+                                                        im_scale_y=meta.processed_size[0] / meta.original_size[0],
+                                                        im_scale_x=meta.processed_size[1] / meta.original_size[1],
                                                         full_image_masks=True, encode_masks=False,
                                                         confidence_threshold=self.confidence,
                                                         segmentoly_postprocess=self.segmentoly_type)

--- a/models/public/mozilla-deepspeech-0.8.2/mds_convert_utils/parse_openfst.py
+++ b/models/public/mozilla-deepspeech-0.8.2/mds_convert_utils/parse_openfst.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+
+from types import SimpleNamespace as namespace
+
 from .struct_utils import parse_format, align_pos
 
 
@@ -22,7 +25,7 @@ def parse_header(data, pos=0):
     if fst_type != b'const' or arc_type != b'standard' or version != 1:
         raise ValueError("Cannot parse OpenFst TRIE: this version of format is not supported")
 
-    return dict(
+    return namespace(
         magic=magic, fst_type=fst_type, arc_type=arc_type, version=version,
         flags=flags, properties=properties,
         start_state=start_state, num_states=num_states, num_arcs=num_arcs,
@@ -44,15 +47,15 @@ def parse_openfst(data, pos=0, base_offset=0):
 
     pos = align_pos(pos, align=16, base_offset=base_offset)
     states = []
-    for state_idx in range(header['num_states']):  # pylint: disable=unused-variable
+    for state_idx in range(header.num_states):  # pylint: disable=unused-variable
         state, pos = parse_state(data, pos)
         states.append(state)
 
     pos = align_pos(pos, align=16, base_offset=base_offset)
     arcs = []
-    for arc_idx in range(header['num_arcs']):  # pylint: disable=unused-variable
+    for arc_idx in range(header.num_arcs):  # pylint: disable=unused-variable
         arc, pos = parse_arc(data, pos)
         arcs.append(arc)
 
-    fst = dict(meta=header, states=states, arcs=arcs)
+    fst = namespace(meta=header, states=states, arcs=arcs)
     return fst, pos

--- a/models/public/mozilla-deepspeech-0.8.2/mds_convert_utils/parse_trie_v6.py
+++ b/models/public/mozilla-deepspeech-0.8.2/mds_convert_utils/parse_trie_v6.py
@@ -40,7 +40,7 @@ def trie_v6_extract_vocabulary(data, alphabet=None, base_offset=0, max_num_words
         alphabet = DEFAULT_ALPHABET
     fst, _ = parse_trie_v6(data, pos=0, base_offset=base_offset)
     vocabulary = traverse_fst(fst, alphabet, max_num_words=max_num_words)
-    return vocabulary, fst['meta']
+    return vocabulary, fst.meta
 
 
 def parse_trie_v6(data, pos=0, base_offset=0):
@@ -52,15 +52,16 @@ def parse_trie_v6(data, pos=0, base_offset=0):
     if is_utf8_mode:
         raise ValueError("UTF-8 mode language model: UTF-8 mode was not tested, stopping")
     fst, pos = parse_openfst(data, pos, base_offset=base_offset)
-    fst['meta'].update(alpha=alpha, beta=beta)
+    fst.meta.alpha = alpha
+    fst.meta.beta = beta
     return fst, pos
 
 
 def traverse_fst(fst, alphabet, max_num_words):
-    graph = states_arcs_to_arc_dict(fst['states'], fst['arcs'])
+    graph = states_arcs_to_arc_dict(fst.states, fst.arcs)
     vocabulary = []
 
-    init_state = fst['meta']['start_state']
+    init_state = fst.meta.start_state
     cur_prefix = []
     def process_words(state, prefix):
         out_arcs = graph[state].items()

--- a/models/public/mozilla-deepspeech-0.8.2/scorer_to_kenlm.py
+++ b/models/public/mozilla-deepspeech-0.8.2/scorer_to_kenlm.py
@@ -33,8 +33,8 @@ def main():
 
     # pylint: disable=bad-function-call
     print('# Language model parameters:')
-    print('lm_alpha:', metadata['alpha'])
-    print('lm_beta:', metadata['beta'])
+    print('lm_alpha:', metadata.alpha)
+    print('lm_beta:', metadata.beta)
     if vocab_offset is not None:
         print('lm_vocabulary_offset:', vocab_offset)
     # pylint: enable=bad-function-call


### PR DESCRIPTION
When the keys of a dictionary are identifier-like strings that are known ahead of time, I find `types.SimpleNamespace` to be better suited for the job than `dict`. The attribute access syntax feels more natural than indexing syntax, and the `repr` of namespace instances is more readable than that of `dict`s. Namespaces can also be replaced with more specific types (e.g. dataclasses) to improve type safety in the future, without changing the code that accesses the attributes.

Note that I import the type as `namespace`, because that's the name it uses in the `repr`.