### PR TITLE
Enable flake8-comprehensions warning C408

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,6 +39,3 @@ ignore=
     # ignored because putting a statement after a colon is harmless and
     # sometimes results in more compact code
     E701,E704,
-    # unnecessary <dict/list/tuple> call
-    # TODO: consider enabling this later
-    C408,

--- a/demos/speech_recognition_demo/python/utils/deep_speech_pipeline.py
+++ b/demos/speech_recognition_demo/python/utils/deep_speech_pipeline.py
@@ -17,34 +17,34 @@ from utils.ctcnumpy_beam_search_decoder import CtcnumpyBeamSearchDecoder
 
 
 PROFILES = {
-    'mds06x_en': dict(
-        alphabet = None,  # the default alphabet
+    'mds06x_en': {
+        'alphabet': None,  # the default alphabet
         # alpha: Language model weight
-        alpha = 0.75,
+        'alpha': 0.75,
         # beta: Word insertion bonus (ignored without LM)
-        beta = 1.85,
-        model_sampling_rate = 16000,
-        frame_window_size_seconds = 32e-3,
-        frame_stride_seconds = 20e-3,
-        mel_num = 40,
-        mel_fmin = 20.,
-        mel_fmax = 4000.,
-        num_mfcc_dct_coefs = 26,
-        num_context_frames = 19,
-    ),
-    'mds07x_en': dict(
-        alphabet = None,  # the default alphabet
-        alpha = 0.93128901720047,
-        beta = 1.1834137439727783,
-        model_sampling_rate = 16000,
-        frame_window_size_seconds = 32e-3,
-        frame_stride_seconds = 20e-3,
-        mel_num = 40,
-        mel_fmin = 20.,
-        mel_fmax = 8000.,
-        num_mfcc_dct_coefs = 26,
-        num_context_frames = 19,
-    ),
+        'beta': 1.85,
+        'model_sampling_rate': 16000,
+        'frame_window_size_seconds': 32e-3,
+        'frame_stride_seconds': 20e-3,
+        'mel_num': 40,
+        'mel_fmin': 20.,
+        'mel_fmax': 4000.,
+        'num_mfcc_dct_coefs': 26,
+        'num_context_frames': 19,
+    },
+    'mds07x_en': {
+        'alphabet': None,  # the default alphabet
+        'alpha': 0.93128901720047,
+        'beta': 1.1834137439727783,
+        'model_sampling_rate': 16000,
+        'frame_window_size_seconds': 32e-3,
+        'frame_stride_seconds': 20e-3,
+        'mel_num': 40,
+        'mel_fmin': 20.,
+        'mel_fmax': 8000.,
+        'num_mfcc_dct_coefs': 26,
+        'num_context_frames': 19,
+    },
 }
 PROFILES['mds08x_en'] = PROFILES['mds07x_en']
 


### PR DESCRIPTION
Fix the last remaining violations.

I would've preferred to turn the profiles in `speech_recognition_demo` into instances of `types.SimpleNamespace` (instead of changing the initialization syntax), but they have to be compatible with what `yaml.safe_load` returns, which is a dict.

Granted, it would be possible to convert the result of `yaml.safe_load` into a namespace, but then there would need to be error handling for the case that the keys are not strings; plus if the profile ever needs to contain nested dicts, those would need to be converted too. All in all, it's possible, but it looks like enough of a mess that I don't want to get into it. :-)