### PR TITLE
Encode mask as uint8 to prevent scaling in resize

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/postprocessor/encode_segmentation_mask.py
+++ b/tools/accuracy_checker/accuracy_checker/postprocessor/encode_segmentation_mask.py
@@ -52,7 +52,7 @@ class EncodeSegMask(PostprocessorWithSpecificTargets):
                 encoded_mask[np.where(
                     np.all(mask == color, axis=-1) if num_channels >= 3 else mask == color
                 )[:2]] = label
-            annotation_.mask = encoded_mask.astype(np.int8)
+            annotation_.mask = encoded_mask.astype(np.uint8)
 
         if not self._deprocess_predictions:
             for prediction_ in prediction:
@@ -69,7 +69,7 @@ class EncodeSegMask(PostprocessorWithSpecificTargets):
 
                 updated_mask[saved_mask >= len(prediction_to_gt_label)] = 255
 
-                prediction_.mask = updated_mask.astype(np.int8)
+                prediction_.mask = updated_mask.astype(np.uint8)
         self._deprocess_predictions = False
 
         return annotation, prediction


### PR DESCRIPTION
Currently the EncodeSegMask postprocessor encodes masks as int8
datatype. If one adds a ResizeSegmentationMask postprocessor to the
pipeline, unintended scaling to [0, 255] is caused.

This can be prevented by encoding as uint8 in the EncodeSegMask
postprocessor, since the scaling is not performed for such datatype
elements in the ResizeSegmentationMask postprocessor.