### PR TITLE
object_detection_demo.py: add import of ONNX models

### DIFF
--- a/demos/common/python/models/__init__.py
+++ b/demos/common/python/models/__init__.py
@@ -25,7 +25,7 @@ from .retinaface import RetinaFace
 from .segmentation import SegmentationModel, SalientObjectDetectionModel
 from .ssd import SSD
 from .ultra_lightweight_face_detection import UltraLightweightFaceDetection
-from .utils import DetectionWithLandmarks
+from .utils import DetectionWithLandmarks, InputTransform
 from .yolo import YOLO, YoloV4
 
 __all__ = [
@@ -35,6 +35,7 @@ __all__ = [
     'Deblurring',
     'FaceBoxes',
     'HpeAssociativeEmbedding',
+    'InputTransform',
     'OpenPose',
     'RetinaFace',
     'SalientObjectDetectionModel',

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -58,8 +58,8 @@ class CenterNet(Model):
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
-        if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.scaleshift(resized_image)
+        if self.is_onnx_format:
+            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -51,7 +51,7 @@ class CenterNet(Model):
         scale = max(height, width)
         trans_input = self.get_affine_transform(center, scale, 0, [self.w, self.h])
         resized_image = cv2.warpAffine(image, trans_input, (self.w, self.h), flags=cv2.INTER_LINEAR)
-        resized_image = self.input_transform.apply(resized_image)
+        resized_image = self.input_transform(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,9 +23,8 @@ from .utils import Detection, load_labels
 
 
 class CenterNet(Model):
-    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values,
-                 labels=None, threshold=0.3):
-        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
+    def __init__(self, ie, model_path, input_transform, labels=None, threshold=0.3):
+        super().__init__(ie, model_path, input_transform)
 
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         assert len(self.net.outputs) == 3, "Expected 3 output blobs"
@@ -52,14 +51,12 @@ class CenterNet(Model):
         scale = max(height, width)
         trans_input = self.get_affine_transform(center, scale, 0, [self.w, self.h])
         resized_image = cv2.warpAffine(image, trans_input, (self.w, self.h), flags=cv2.INTER_LINEAR)
-        if self.is_onnx_format and self.reverse_input_channels:
+        if self.input_transform.reverse_input_channels:
             resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
 
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        if self.is_onnx_format:
-            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -59,7 +59,7 @@ class CenterNet(Model):
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
         if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.normalize(resized_image)
+            resized_image = self.scaleshift(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -51,10 +51,7 @@ class CenterNet(Model):
         scale = max(height, width)
         trans_input = self.get_affine_transform(center, scale, 0, [self.w, self.h])
         resized_image = cv2.warpAffine(image, trans_input, (self.w, self.h), flags=cv2.INTER_LINEAR)
-        if self.input_transform.reverse_input_channels:
-            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
-        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
-
+        resized_image = self.input_transform.apply(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,8 +23,9 @@ from .utils import Detection, load_labels
 
 
 class CenterNet(Model):
-    def __init__(self, ie, model_path, labels=None, threshold=0.3):
-        super().__init__(ie, model_path)
+    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values,
+                 labels=None, threshold=0.3):
+        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
 
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         assert len(self.net.outputs) == 3, "Expected 3 output blobs"
@@ -51,7 +52,14 @@ class CenterNet(Model):
         scale = max(height, width)
         trans_input = self.get_affine_transform(center, scale, 0, [self.w, self.h])
         resized_image = cv2.warpAffine(image, trans_input, (self.w, self.h), flags=cv2.INTER_LINEAR)
-        resized_image = np.transpose(resized_image, (2, 0, 1))
+        if self.is_onnx_format and self.reverse_input_channels:
+            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+
+        resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
+        resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
+
+        if self.is_onnx_format and self.mean_values is not None:
+            resized_image = self.normalize(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -15,7 +15,6 @@
 """
 import itertools
 import math
-import cv2
 import numpy as np
 
 from .model import Model

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -65,7 +65,7 @@ class FaceBoxes(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        resized_image = self.input_transform.apply(resized_image)
+        resized_image = self.input_transform(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -73,7 +73,7 @@ class FaceBoxes(Model):
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
         if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.normalize(resized_image)
+            resized_image = self.scaleshift(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -72,8 +72,8 @@ class FaceBoxes(Model):
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
-        if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.scaleshift(resized_image)
+        if self.is_onnx_format:
+            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -23,8 +23,8 @@ from .utils import Detection, resize_image, nms
 
 
 class FaceBoxes(Model):
-    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values, threshold=0.5):
-        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
+    def __init__(self, ie, model_path, input_transform, threshold=0.5):
+        super().__init__(ie, model_path, input_transform)
 
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         self.image_blob_name = next(iter(self.net.input_info))
@@ -66,14 +66,12 @@ class FaceBoxes(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        if self.is_onnx_format and self.reverse_input_channels:
+        if self.input_transform.reverse_input_channels:
             resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
 
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        if self.is_onnx_format:
-            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -66,10 +66,7 @@ class FaceBoxes(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        if self.input_transform.reverse_input_channels:
-            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
-        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
-
+        resized_image = self.input_transform.apply(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -15,14 +15,19 @@
 """
 
 import logging
-
+import numpy as np
 
 class Model:
-    def __init__(self, ie, model_path):
+    def __init__(self, ie, model_path, reverse_input_channels=None, mean_values=None, scale_values=None):
         self.logger = logging.getLogger()
         self.logger.info('Reading network from IR...')
         self.net = ie.read_network(model_path, model_path.with_suffix('.bin'))
         self.set_batch_size(1)
+
+        self.is_onnx_format = model_path.suffix == '.onnx'
+        self.reverse_input_channels = reverse_input_channels
+        self.mean_values = np.array(mean_values) if mean_values else None
+        self.scale_values = np.array(scale_values) if scale_values else np.array([1, 1, 1])
 
     def preprocess(self, inputs):
         meta = {}
@@ -37,3 +42,9 @@ class Model:
             new_shape = [batch] + self.net.input_info[input_layer].input_data.shape[1:]
             shapes.update({input_layer: new_shape})
         self.net.reshape(shapes)
+
+    def normalize(self, inputs):
+        normalized_inputs = np.zeros(inputs.shape, dtype=np.float32)
+        for i in range(inputs.shape[1]):
+            normalized_inputs[:,i,:,:] = (inputs[:,i,:,:] - self.mean_values[i]) / self.scale_values[i]
+        return normalized_inputs

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -18,7 +18,7 @@ import logging
 
 
 class Model:
-    def __init__(self, ie, model_path, input_transform=None, mean_values=None, scale_values=None):
+    def __init__(self, ie, model_path, input_transform=None):
         self.logger = logging.getLogger()
         self.logger.info('Reading network from IR...')
         self.net = ie.read_network(model_path)

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -22,15 +22,12 @@ class Model:
         self.logger = logging.getLogger()
         self.logger.info('Reading network from IR...')
         self.is_onnx_format = model_path.suffix == '.onnx'
-        if self.is_onnx_format:
-            self.net = ie.read_network(model_path)
-        else:
-            self.net = ie.read_network(model_path, model_path.with_suffix('.bin'))
+        self.net = ie.read_network(model_path)
         self.set_batch_size(1)
 
         self.reverse_input_channels = reverse_input_channels
-        self.mean_values = np.array(mean_values, dtype=np.float32) if mean_values else None
-        self.scale_values = np.array(scale_values, dtype=np.float32) if scale_values else None
+        self.mean_values = np.array(mean_values, dtype=np.float32) if mean_values else np.zeros(3)
+        self.scale_values = np.array(scale_values, dtype=np.float32) if scale_values else np.ones(3)
 
     def preprocess(self, inputs):
         meta = {}
@@ -45,8 +42,3 @@ class Model:
             new_shape = [batch] + self.net.input_info[input_layer].input_data.shape[1:]
             shapes.update({input_layer: new_shape})
         self.net.reshape(shapes)
-
-    def scaleshift(self, inputs):
-        if self.scale_values is None:
-            return inputs - self.mean_values[:, None, None]
-        return (inputs - self.mean_values[:, None, None]) / self.scale_values[:, None, None]

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -46,5 +46,5 @@ class Model:
     def normalize(self, inputs):
         normalized_inputs = np.zeros(inputs.shape, dtype=np.float32)
         for i in range(inputs.shape[1]):
-            normalized_inputs[:,i,:,:] = (inputs[:,i,:,:] - self.mean_values[i]) / self.scale_values[i]
+            normalized_inputs[:, i, :, :] = (inputs[:, i, :, :] - self.mean_values[i]) / self.scale_values[i]
         return normalized_inputs

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -26,8 +26,8 @@ class Model:
         self.set_batch_size(1)
 
         self.reverse_input_channels = reverse_input_channels
-        self.mean_values = np.array(mean_values, dtype=np.float32) if mean_values else np.zeros(3)
-        self.scale_values = np.array(scale_values, dtype=np.float32) if scale_values else np.ones(3)
+        self.mean_values = np.array(mean_values, dtype=np.float32)
+        self.scale_values = np.array(scale_values, dtype=np.float32)
 
     def preprocess(self, inputs):
         meta = {}

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -15,19 +15,15 @@
 """
 
 import logging
-import numpy as np
+
 
 class Model:
-    def __init__(self, ie, model_path, reverse_input_channels=None, mean_values=None, scale_values=None):
+    def __init__(self, ie, model_path, input_transform=None, mean_values=None, scale_values=None):
         self.logger = logging.getLogger()
         self.logger.info('Reading network from IR...')
-        self.is_onnx_format = model_path.suffix == '.onnx'
         self.net = ie.read_network(model_path)
         self.set_batch_size(1)
-
-        self.reverse_input_channels = reverse_input_channels
-        self.mean_values = np.array(mean_values, dtype=np.float32)
-        self.scale_values = np.array(scale_values, dtype=np.float32)
+        self.input_transform = input_transform
 
     def preprocess(self, inputs):
         meta = {}

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -84,10 +84,7 @@ class SSD(Model):
         if h != self.h or w != self.w:
             resized_image = np.pad(resized_image, ((0, self.h - h), (0, self.w - w), (0, 0)),
                                    mode='constant', constant_values=0)
-        if self.input_transform.reverse_input_channels:
-            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
-        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
-
+        resized_image = self.input_transform.apply(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -13,7 +13,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import cv2
 import numpy as np
 
 from .model import Model

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -21,9 +21,8 @@ from .utils import Detection, resize_image, load_labels
 
 
 class SSD(Model):
-    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values,
-                 labels=None, keep_aspect_ratio_resize=False):
-        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
+    def __init__(self, ie, model_path, input_transform, labels=None, keep_aspect_ratio_resize=False):
+        super().__init__(ie, model_path, input_transform)
 
         self.keep_aspect_ratio_resize = keep_aspect_ratio_resize
         if isinstance(labels, (list, tuple)):
@@ -85,14 +84,12 @@ class SSD(Model):
         if h != self.h or w != self.w:
             resized_image = np.pad(resized_image, ((0, self.h - h), (0, self.w - w), (0, 0)),
                                    mode='constant', constant_values=0)
-        if self.is_onnx_format and self.reverse_input_channels:
+        if self.input_transform.reverse_input_channels:
             resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
 
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        if self.is_onnx_format:
-            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         if self.image_info_blob_name:

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -83,7 +83,7 @@ class SSD(Model):
         if h != self.h or w != self.w:
             resized_image = np.pad(resized_image, ((0, self.h - h), (0, self.w - w), (0, 0)),
                                    mode='constant', constant_values=0)
-        resized_image = self.input_transform.apply(resized_image)
+        resized_image = self.input_transform(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -92,7 +92,7 @@ class SSD(Model):
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
         if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.normalize(resized_image)
+            resized_image = self.scaleshift(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         if self.image_info_blob_name:

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -91,8 +91,8 @@ class SSD(Model):
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
-        if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.scaleshift(resized_image)
+        if self.is_onnx_format:
+            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         if self.image_info_blob_name:

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -65,8 +65,8 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
-        if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.scaleshift(resized_image)
+        if self.is_onnx_format:
+            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -21,8 +21,8 @@ from .utils import Detection, resize_image, nms
 
 
 class UltraLightweightFaceDetection(Model):
-    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values, threshold=0.5):
-        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
+    def __init__(self, ie, model_path, input_transform, threshold=0.5):
+        super().__init__(ie, model_path, input_transform)
 
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         self.image_blob_name = next(iter(self.net.input_info))
@@ -59,14 +59,12 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        if self.is_onnx_format and self.reverse_input_channels:
+        if self.input_transform.reverse_input_channels:
             resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
 
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        if self.is_onnx_format:
-            resized_image = (resized_image - self.mean_values[:, None, None]) / self.scale_values[:, None, None]
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -13,7 +13,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
-import cv2
 import numpy as np
 
 from .model import Model

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 """
+import cv2
 import numpy as np
 
 from .model import Model
@@ -20,8 +21,8 @@ from .utils import Detection, resize_image, nms
 
 
 class UltraLightweightFaceDetection(Model):
-    def __init__(self, ie, model_path, threshold=0.5):
-        super().__init__(ie, model_path)
+    def __init__(self, ie, model_path, reverse_input_channels, mean_values, scale_values, threshold=0.5):
+        super().__init__(ie, model_path, reverse_input_channels, mean_values, scale_values)
 
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         self.image_blob_name = next(iter(self.net.input_info))
@@ -58,8 +59,14 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
+        if self.is_onnx_format and self.reverse_input_channels:
+            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
+
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
+
+        if self.is_onnx_format and self.mean_values is not None:
+            resized_image = self.normalize(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -58,7 +58,7 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        resized_image = self.input_transform.apply(resized_image)
+        resized_image = self.input_transform(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -66,7 +66,7 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 
         if self.is_onnx_format and self.mean_values is not None:
-            resized_image = self.normalize(resized_image)
+            resized_image = self.scaleshift(resized_image)
 
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -59,10 +59,7 @@ class UltraLightweightFaceDetection(Model):
         resized_image = resize_image(image, (self.w, self.h))
         meta = {'original_shape': image.shape,
                 'resized_shape': resized_image.shape}
-        if self.input_transform.reverse_input_channels:
-            resized_image = cv2.cvtColor(resized_image, cv2.COLOR_BGR2RGB)
-        resized_image = (resized_image - self.input_transform.mean_values) / self.input_transform.scale_values
-
+        resized_image = self.input_transform.apply(resized_image)
         resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
         resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
 

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -48,6 +48,15 @@ class InputTransform:
         self.mean_values = np.array(mean_values, dtype=np.float32)
         self.scale_values = np.array(scale_values, dtype=np.float32)
 
+    def is_trivial(self):
+        return np.array_equal(self.mean_values, [0., 0., 0.]) and \
+               np.array_equal(self.scale_values, [1., 1., 1.]) and \
+               not self.reverse_input_channels
+
+    def apply(self, inputs):
+        if self.reverse_input_channels:
+            inputs = cv2.cvtColor(inputs, cv2.COLOR_BGR2RGB)
+        return (inputs - self.mean_values) / self.scale_values
 
 def load_labels(label_file):
     with open(label_file, 'r') as f:

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -51,7 +51,7 @@ class InputTransform:
                           np.array_equal(self.scale_values, [1., 1., 1.]) and \
                           not self.reverse_input_channels
 
-    def apply(self, inputs):
+    def __call__(self, inputs):
         if self.is_trivial:
             return inputs
         if self.reverse_input_channels:

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -47,13 +47,13 @@ class InputTransform:
         self.reverse_input_channels = reverse_input_channels
         self.mean_values = np.array(mean_values, dtype=np.float32)
         self.scale_values = np.array(scale_values, dtype=np.float32)
-
-    def is_trivial(self):
-        return np.array_equal(self.mean_values, [0., 0., 0.]) and \
-               np.array_equal(self.scale_values, [1., 1., 1.]) and \
-               not self.reverse_input_channels
+        self.is_trivial = np.array_equal(self.mean_values, [0., 0., 0.]) and \
+                          np.array_equal(self.scale_values, [1., 1., 1.]) and \
+                          not self.reverse_input_channels
 
     def apply(self, inputs):
+        if self.is_trivial:
+            return inputs
         if self.reverse_input_channels:
             inputs = cv2.cvtColor(inputs, cv2.COLOR_BGR2RGB)
         return (inputs - self.mean_values) / self.scale_values

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -44,12 +44,10 @@ class DetectionWithLandmarks(Detection):
 
 class InputTransform:
     def __init__(self, reverse_input_channels, mean_values, scale_values):
+        self.is_trivial = not (reverse_input_channels or mean_values or scale_values)
         self.reverse_input_channels = reverse_input_channels
-        self.mean_values = np.array(mean_values, dtype=np.float32)
-        self.scale_values = np.array(scale_values, dtype=np.float32)
-        self.is_trivial = np.array_equal(self.mean_values, [0., 0., 0.]) and \
-                          np.array_equal(self.scale_values, [1., 1., 1.]) and \
-                          not self.reverse_input_channels
+        self.mean_values = np.array(mean_values, dtype=np.float32) if mean_values else np.array([0., 0., 0.])
+        self.scale_values = np.array(scale_values, dtype=np.float32) if scale_values else np.array([1., 1., 1.])
 
     def __call__(self, inputs):
         if self.is_trivial:

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -42,6 +42,13 @@ class DetectionWithLandmarks(Detection):
             self.landmarks.append((x, y))
 
 
+class InputTransform:
+    def __init__(self, reverse_input_channels, mean_values, scale_values):
+        self.reverse_input_channels = reverse_input_channels
+        self.mean_values = np.array(mean_values, dtype=np.float32)
+        self.scale_values = np.array(scale_values, dtype=np.float32)
+
+
 def load_labels(label_file):
     with open(label_file, 'r') as f:
         labels_map = [x.strip() for x in f]

--- a/demos/object_detection_demo/python/README.md
+++ b/demos/object_detection_demo/python/README.md
@@ -60,6 +60,9 @@ usage: object_detection_demo.py [-h] -m MODEL -at
                                 [-nthreads NUM_THREADS] [--loop] [-o OUTPUT]
                                 [-limit OUTPUT_LIMIT] [--no_show]
                                 [-u UTILIZATION_MONITORS] [-r]
+                                [--reverse_input_channels REVERSE_CHANNELS]
+                                [--mean_values MEAN_VALUES]
+                                [--scale_values SCALE_VALUES]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -111,6 +114,18 @@ Input/output options:
   --no_show             Optional. Don't show output.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
+
+Onnx format options:
+  --reverse_input_channels REVERSE_CHANNELS
+                        Optional. Switch the input channels order from
+                        BGR to RGB for onnx model.
+  --mean_values MEAN_VALUES
+                        Optional. Normalize input by subtracting the mean values
+                        per channel for onnx model. Example: 255 255 255
+  --scale_values SCALE_VALUES
+                        Optional. Divide input by scale values per channel
+                        for onnx model. Division is applied after mean values
+                        subtraction. Example: 255 255 255
 
 Debug options:
   -r, --raw_output_message

--- a/demos/object_detection_demo/python/README.md
+++ b/demos/object_detection_demo/python/README.md
@@ -115,17 +115,17 @@ Input/output options:
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
 
-Onnx format options:
+Input transform options:
   --reverse_input_channels REVERSE_CHANNELS
                         Optional. Switch the input channels order from
-                        BGR to RGB for onnx model.
+                        BGR to RGB.
   --mean_values MEAN_VALUES
-                        Optional. Normalize input by subtracting the mean values
-                        per channel for onnx model. Example: 255 255 255
+                        Optional. Normalize input by subtracting the mean
+                        values per channel. Example: 255 255 255
   --scale_values SCALE_VALUES
                         Optional. Divide input by scale values per channel
-                        for onnx model. Division is applied after mean values
-                        subtraction. Example: 255 255 255
+                        Division is applied after mean values subtraction.
+                        Example: 255 255 255
 
 Debug options:
   -r, --raw_output_message

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -95,10 +95,10 @@ def build_argparser():
     onnx_args.add_argument('--reverse_input_channels', default=False, action='store_true',
                          help='Optional. Switch the input channels order from '
                               'BGR to RGB for onnx model.')
-    onnx_args.add_argument('--mean_values', default=None, type=float, nargs=3,
+    onnx_args.add_argument('--mean_values', default=(0.0, 0.0, 0.0), type=float, nargs=3,
                          help='Optional. Normalize input by subtracting the mean values '
                               'per channel for onnx model. Example: 255 255 255')
-    onnx_args.add_argument('--scale_values', default=None, type=float, nargs=3,
+    onnx_args.add_argument('--scale_values', default=(1.0, 1.0, 1.0), type=float, nargs=3,
                          help='Optional. Divide input by scale values per channel for onnx model. '
                               'Division is applied after mean values '
                               'subtraction. Example: 255 255 255')

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -95,10 +95,10 @@ def build_argparser():
     input_transform_args.add_argument('--reverse_input_channels', default=False, action='store_true',
                                       help='Optional. Switch the input channels order from '
                                            'BGR to RGB.')
-    input_transform_args.add_argument('--mean_values', default=(0.0, 0.0, 0.0), type=float, nargs=3,
+    input_transform_args.add_argument('--mean_values', default=None, type=float, nargs=3,
                                       help='Optional. Normalize input by subtracting the mean '
                                            'values per channel. Example: 255 255 255')
-    input_transform_args.add_argument('--scale_values', default=(1.0, 1.0, 1.0), type=float, nargs=3,
+    input_transform_args.add_argument('--scale_values', default=None, type=float, nargs=3,
                                       help='Optional. Divide input by scale values per channel. '
                                            'Division is applied after mean values subtraction. '
                                            'Example: 255 255 255')

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -153,7 +153,7 @@ class ColorPalette:
 def get_model(ie, args):
     input_transform = models.InputTransform(args.reverse_input_channels, args.mean_values, args.scale_values)
     common_args = (ie, args.model, input_transform)
-    if args.architecture_type in ('ctpn', 'yolo', 'yolov4', 'retinaface') and not input_transform.is_trivial():
+    if args.architecture_type in ('ctpn', 'yolo', 'yolov4', 'retinaface') and not input_transform.is_trivial:
         raise ValueError("{} model doesn't support input transforms.".format(args.architecture_type))
 
     if args.architecture_type == 'ssd':

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -151,7 +151,15 @@ class ColorPalette:
 
 
 def get_model(ie, args):
-    common_args = (ie, args.model, args.reverse_input_channels, args.mean_values, args.scale_values)
+    if args.architecture_type in ('ctpn', 'yolo', 'yolov4', 'retinaface') and \
+       (
+           args.reverse_input_channels or
+           not np.array_equal(args.mean_values, [0., 0., 0.]) or
+           not np.array_equal(args.scale_values, [1., 1., 1.])
+       ):
+        raise ValueError("{} model doesn't support input transforms.".format(args.architecture_type))
+    input_transform = models.InputTransform(args.reverse_input_channels, args.mean_values, args.scale_values)
+    common_args = (ie, args.model, input_transform)
     if args.architecture_type == 'ssd':
         return models.SSD(*common_args, labels=args.labels, keep_aspect_ratio_resize=args.keep_aspect_ratio)
     elif args.architecture_type == 'ctpn':


### PR DESCRIPTION
Add support of models in ONNX format for object_detection_demo.py:
- ctdet_coco_dlav0_384
- ctdet_coco_dlav0_512
- faceboxes-pytorch
- ssd-resnet34-1200-onnx
- ultra-lightweight-face-detection-rfb-320
- ultra-lightweight-face-detection-slim-320

The info about mean_values, scale_values and reverse_input_channels is located in `model.yml` for each model.
 