### PR TITLE
Add a config describing which version of OpenVINO toolkit to use in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,8 @@
 /models/**/*.yml omz.package.component=tools
 /tools/**/* omz.package.component=tools
 
+/ci/dependencies.yml omz.ci.job-for-change.ac omz.ci.job-for-change.demos omz.ci.job-for-change.models
+
 /ci/requirements-ac.txt omz.ci.job-for-change.ac
 /ci/requirements-ac-test.txt omz.ci.job-for-change.ac
 /ci/requirements-conversion.txt omz.ci.job-for-change.demos omz.ci.job-for-change.models

--- a/ci/dependencies.yml
+++ b/ci/dependencies.yml
@@ -1,0 +1,2 @@
+openvino_linux: '2021.3.394'
+openvino_windows: '2021.3.394'


### PR DESCRIPTION
This will let us upgrade OpenVINO on CI by submitting a PR that edits the config, which will make it easy to test OMZ with new OpenVINO packages, as well as make synchronized project changes if necessary (e.g. changing the Python dependencies).

I used different Python keys for different OSes, because sometimes different builds are used as the final release for each OS. We might also want to use different pre-release builds for whatever reason.
