### PR TITLE
Add a script to do quick documentation checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,8 +34,7 @@
 /demos/** omz.ci.job-for-change.demos
 /demos/**/*.md -omz.ci.job-for-change.demos
 
-/models/** omz.ci.job-for-change.documentation
-/models/**/*.yml -omz.ci.job-for-change.documentation
+/models/**/*.md omz.ci.job-for-change.documentation
 
 /tools/accuracy_checker/** omz.ci.job-for-change.ac
 /tools/accuracy_checker/configs/*.yml -omz.ci.job-for-change.ac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ Add `README.md` file, which describes demo usage. Update [demos' README.md](demo
 
 ## Accuracy Validation
 
-Accuracy validation can be performed by the [Accuracy Checker](./tools/accuracy_checker) tool. This tool can use either IE to run a converted model, or an original framework to run an original model. Accuracy Checker supports lots of datasets, metrics and preprocessing options, which simplifies validation if a task is supported by the tool. You only need to create a configuration file that contains necessary parameters for accuracy validation (specify a dataset and annotation, pre- and post-processing parameters, accuracy metrics to compute and so on) of converted model. For details, refer to [Testing new models](./tools/accuracy_checker#testing-new-models).
+Accuracy validation can be performed by the [Accuracy Checker](./tools/accuracy_checker/README.md) tool. This tool can use either IE to run a converted model, or an original framework to run an original model. Accuracy Checker supports lots of datasets, metrics and preprocessing options, which simplifies validation if a task is supported by the tool. You only need to create a configuration file that contains necessary parameters for accuracy validation (specify a dataset and annotation, pre- and post-processing parameters, accuracy metrics to compute and so on) of converted model. For details, refer to [Testing new models](./tools/accuracy_checker/README.md#testing-new-models).
 
 If a model uses a dataset which is not supported by the Accuracy Checker, you also must provide the license and the link to it and mention it in the PR description.
 

--- a/ci/check-basics.py
+++ b/ci/check-basics.py
@@ -145,6 +145,10 @@ def main():
     if subprocess.run([sys.executable, '-m', 'flake8', '--config=.flake8'], cwd=OMZ_ROOT).returncode != 0:
         all_passed = False
 
+    print('running documentation checks...', flush=True)
+    if subprocess.run([sys.executable, '--', str(OMZ_ROOT / 'ci/check-documentation.py')]).returncode != 0:
+        all_passed = False
+
     sys.exit(0 if all_passed else 1)
 
 

--- a/ci/check-documentation.py
+++ b/ci/check-documentation.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+"""
+This script is like check-basics.py, but specific to the documentation.
+It's split off into a separate script, so that it can be easily run on its own.
+"""
+
+import sys
+import urllib.parse
+import urllib.request
+
+from pathlib import Path
+
+OMZ_ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.append(str(OMZ_ROOT / 'ci/lib'))
+
+import omzdocs
+
+def find_md_files():
+    thirdparty_dir = OMZ_ROOT / 'demos' / 'thirdparty'
+
+    for path in OMZ_ROOT.glob('**/*.md'):
+        if thirdparty_dir in path.parents: continue
+        yield path
+
+def main():
+    all_passed = True
+
+    def complain(message):
+        nonlocal all_passed
+        all_passed = False
+        print(message, file=sys.stderr)
+
+    for md_path in sorted(find_md_files()):
+        md_path_rel = md_path.relative_to(OMZ_ROOT)
+
+        doc_page = omzdocs.DocumentationPage(md_path.read_text(encoding='UTF-8'))
+
+        # check local link validity
+
+        for url in sorted([ref.url for ref in doc_page.external_references()]):
+            try:
+                components = urllib.parse.urlparse(url)
+            except ValueError:
+                complain(f'{md_path_rel}: invalid URL reference {url!r}')
+                continue
+
+            if components.scheme: # non-local URLs
+                continue
+
+            if components.netloc or components.path.startswith('/'):
+                complain(f'{md_path_rel}: non-relative local URL reference "{url}"')
+                continue
+
+            if not components.path: # self-link
+                continue
+
+            target_path = (md_path.parent / urllib.request.url2pathname(components.path)).resolve()
+
+            if OMZ_ROOT not in target_path.parents:
+                complain(f'{md_path_rel}: URL reference "{url}" points outside the OMZ directory')
+                continue
+
+            if not target_path.is_file():
+                complain(f'{md_path_rel}: URL reference "{url}" target'
+                    ' does not exist or is not a file')
+                continue
+
+
+    sys.exit(0 if all_passed else 1)
+
+if __name__ == '__main__':
+    main()

--- a/ci/lib/omzdocs.py
+++ b/ci/lib/omzdocs.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+
+import mistune
+
+_parse_markdown = mistune.create_markdown(renderer=mistune.AstRenderer())
+
+def _get_all_ast_nodes(ast_nodes):
+    for node in ast_nodes:
+        yield node
+        if 'children' in node:
+            # workaround for https://github.com/lepture/mistune/issues/269
+            if isinstance(node['children'], str):
+                yield {'type': 'text', 'text': node['children']}
+            else:
+                yield from _get_all_ast_nodes(node['children'])
+
+def _get_text_from_ast(ast_nodes):
+    def get_text_from_node(node):
+        if node['type'] != 'text':
+            raise RuntimeError(f'unsupported node type: {node["type"]}')
+        return node['text']
+
+    return ''.join(map(get_text_from_node, ast_nodes))
+
+ExternalReference = collections.namedtuple('ExternalReference', ['type', 'url'])
+
+class DocumentationPage:
+    def __init__(self, markdown_text):
+        self._ast = ast = _parse_markdown(markdown_text)
+
+        self._title = None
+        if ast and ast[0]['type'] == 'heading' and ast[0]['level'] == 1:
+            self._title = _get_text_from_ast(ast[0]['children'])
+
+    @property
+    def title(self):
+        return self._title
+
+    def external_references(self):
+        for node in _get_all_ast_nodes(self._ast):
+            if node['type'] == 'image':
+                yield ExternalReference('image', node['src'])
+            elif node['type'] == 'link':
+                yield ExternalReference('link', node['link'])

--- a/ci/lib/omzdocs.py
+++ b/ci/lib/omzdocs.py
@@ -30,9 +30,11 @@ def _get_all_ast_nodes(ast_nodes):
 
 def _get_text_from_ast(ast_nodes):
     def get_text_from_node(node):
-        if node['type'] != 'text':
-            raise RuntimeError(f'unsupported node type: {node["type"]}')
-        return node['text']
+        if node['type'] == 'text':
+            return node['text']
+        elif node['type'] == 'link':
+            return _get_text_from_ast(node['children'])
+        raise RuntimeError(f'unsupported node type: {node["type"]}')
 
     return ''.join(map(get_text_from_node, ast_nodes))
 


### PR DESCRIPTION
Currently it's just checking local links, but later on we could add checks on the indexes, page title checks, etc.

The script is lightweight enough to be run for every pull request, so do that.

See commit messages for more details.