### PR TITLE
ci: add a check for unknown HTML elements in the documentation

### DIFF
--- a/ci/lib/omzdocs.py
+++ b/ci/lib/omzdocs.py
@@ -58,3 +58,8 @@ class DocumentationPage:
                 yield ExternalReference('image', node['src'])
             elif node['type'] == 'link':
                 yield ExternalReference('link', node['link'])
+
+    def html_fragments(self):
+        for node in _get_all_ast_nodes(self._ast):
+            if node['type'] == 'inline_html':
+                yield node['text']


### PR DESCRIPTION
I have previously fixed errors where people would accidentally add text that was interpreted as HTML syntax even though it was not intended to be (see af9d6d02). This check helps to prevent such errors in the future.

We can't prevent all errors, because we can't prohibit raw HTML entirely, as some constructs aren't expressible in native Markdown (e.g. `<sup>`). But we can check that any HTML elements that are used are known by Doxygen (which is used to build OpenVINO documentation), which will at least prevent some errors.

Technically, we could also prohibit some elements that _are_ known by Doxygen, but for which there are native Markdown equivalents (e.g. `<code>`). I've not done that, because I don't want to figure out the exact list right now. Maybe later.