### PR TITLE
Added VOC2007 dataset, changed VOC2012 to VOC2007 for public models

### DIFF
--- a/data/dataset_definitions.yml
+++ b/data/dataset_definitions.yml
@@ -1250,3 +1250,24 @@ datasets:
       converter: librispeech
       data_dir: librispeech/test/LibriSpeech/test-clean.npy
       use_numpy: true
+
+  - name: VOC2007_detection
+    data_source: VOCdevkit/VOC2007/JPEGImages
+    annotation_conversion:
+      converter: voc_detection
+      annotations_dir: VOCdevkit/VOC2007/Annotations
+      images_dir: VOCdevkit/VOC2007/JPEGImages
+      imageset_file: VOCdevkit/VOC2007/ImageSets/Main/test.txt
+    annotation: voc07.pickle
+    dataset_meta: voc07.json
+
+  - name: VOC2007_detection_no_bkgr
+    data_source: VOCdevkit/VOC2007/JPEGImages
+    annotation_conversion:
+      converter: voc_detection
+      annotations_dir: VOCdevkit/VOC2007/Annotations
+      images_dir: VOCdevkit/VOC2007/JPEGImages
+      imageset_file: VOCdevkit/VOC2007/ImageSets/Main/test.txt
+      has_background: False
+    annotation: voc07_without_bkgr.pickle
+    dataset_meta: voc07_without_bkgr.json

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -114,6 +114,30 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
     * `SegmentationClass` - directory containing the VOC2012 segmentation masks
 
 ### Datasets in dataset_definitions.yml
-* `VOC2012` used for evaluation models on VOC2012 dataset for object detection task. Background label + label map with 20 object categories are used. (model examples: [`mobilenet-ssd`](../models/public/mobilenet-ssd/mobilenet-ssd.md), [`ssd300`](../models/public/ssd300/ssd300.md))
+* `VOC2012` used for evaluation models on VOC2012 dataset for object detection task. Background label + label map with 20 object categories are used.
 * `VOC2012_without_background` used for evaluation models on VOC2012 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [`yolo-v2-ava-0001`](../models/intel/yolo-v2-ava-0001/description/yolo-v2-ava-0001.md), [`yolo-v2-tiny-ava-0001`](../models/intel/yolo-v2-tiny-ava-0001/description/yolo-v2-tiny-ava-0001.md))
 * `VOC2012_Segmentation` used for evaluation models on VOC2012 dataset for segmentation tasks. Background label + label map with 20 object categories are used.(model examples: [`deeplabv3`](../models/public/deeplabv3/deeplabv3.md))
+
+## [Visual Object Classes Challenge 2007 (VOC2007)](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/)
+
+### How download dataset
+
+To download VOC2007 dataset, you need to follow the steps below:
+1. Go to the [VOC2007](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/) website
+2. Go to the [`Development Kit`](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/#devkit) section
+3. Select [`Download the training/validation data`](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar) and download archive
+4. Unpack archive
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `VOCdevkit/VOC2007` - directory containing annotations, images and image sets files directories
+    * `Annotations` - directory containing the VOC2007 annotation files
+    * `JPEGImages` - directory containing the VOC2007 images
+    * `ImageSets` - directory containing the VOC2007 text files specifying lists of images for different tasks
+        * `Main/test.txt` - image sets file for detection tasks
+
+### Datasets in dataset_definitions.yml
+* `VOC2007_detection` used for evaluation models on VOC2007 dataset for object detection task. Background label + label map with 20 object categories are used. (model examples: [`mobilenet-ssd`](../models/public/mobilenet-ssd/mobilenet-ssd.md), [`ssd300`](../models/public/ssd300/ssd300.md))
+* `VOC2007_detection_no_bkgr` used for evaluation models on VOC2007 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [`yolo-v1-tiny-tf`](../models/public/yolo-v1-tiny-tf/yolo-v1-tiny-tf.md))

--- a/models/public/index.md
+++ b/models/public/index.md
@@ -133,9 +133,9 @@ SSD-based and provide reasonable accuracy/performance trade-offs.
 | Pelee                                | Caffe\*                  | [pelee-coco](./pelee-coco/pelee-coco.md) | 21.9761% | 1.290 | 5.98 |
 | RetinaNet with Resnet 50             | TensorFlow\*             | [retinanet-tf](./retinanet-tf/retinanet-tf.md) | 33.15% | 238.9469 | 64.9706 |
 | R-FCN with Resnet-101                | TensorFlow\*             | [rfcn-resnet101-coco-tf](./rfcn-resnet101-coco-tf/rfcn-resnet101-coco-tf.md) | 28.40%/45.02% | 53.462 | 171.85 |
-| SSD 300                              | Caffe\*                  | [ssd300](./ssd300/ssd300.md)  | 85.0791% | 62.815 | 26.285 |
-| SSD 512                              | Caffe\*                  | [ssd512](./ssd512/ssd512.md) | 90.3845% | 180.611 | 27.189 |
-| SSD with MobileNet                   | Caffe\* <br>TensorFlow\* | [mobilenet-ssd](./mobilenet-ssd/mobilenet-ssd.md) <br>[ssd_mobilenet_v1_coco](./ssd_mobilenet_v1_coco/ssd_mobilenet_v1_coco.md) | 79.8377%<br>23.32%| 2.316~2.494 | 5.783~6.807 |
+| SSD 300                              | Caffe\*                  | [ssd300](./ssd300/ssd300.md)  | 87.09% | 62.815 | 26.285 |
+| SSD 512                              | Caffe\*                  | [ssd512](./ssd512/ssd512.md) | 91.07% | 180.611 | 27.189 |
+| SSD with MobileNet                   | Caffe\* <br>TensorFlow\* | [mobilenet-ssd](./mobilenet-ssd/mobilenet-ssd.md) <br>[ssd_mobilenet_v1_coco](./ssd_mobilenet_v1_coco/ssd_mobilenet_v1_coco.md) | 67.00%<br>23.32%| 2.316~2.494 | 5.783~6.807 |
 | SSD with MobileNet FPN               | TensorFlow\*             | [ssd_mobilenet_v1_fpn_coco](./ssd_mobilenet_v1_fpn_coco/ssd_mobilenet_v1_fpn_coco.md) | 35.5453% | 123.309 | 36.188 |
 | SSD with MobileNet V2                | TensorFlow\*             | [ssd_mobilenet_v2_coco](./ssd_mobilenet_v2_coco/ssd_mobilenet_v2_coco.md) | 24.9452% | 3.775 | 16.818 |
 | SSD lite with MobileNet V2           | TensorFlow\*             | [ssdlite_mobilenet_v2](./ssdlite_mobilenet_v2/ssdlite_mobilenet_v2.md) | 24.2946% | 1.525 | 4.475 |
@@ -146,7 +146,7 @@ SSD-based and provide reasonable accuracy/performance trade-offs.
 | RetinaFace-Anti-Cov                  | MXNet\*                  | [retinaface-anti-cov](./retinaface-anti-cov/retinaface-anti-cov.md)  | 77.1531% | 2.7781 | 0.5955 |
 | Ultra Lightweight Face Detection RFB 320| PyTorch\*             | [ultra-lightweight-face-detection-rfb-320](./ultra-lightweight-face-detection-rfb-320/ultra-lightweight-face-detection-rfb-320.md)|84.78% | 0.2106 | 0.3004 |
 | Ultra Lightweight Face Detection slim 320| PyTorch\*            | [ultra-lightweight-face-detection-slim-320](./ultra-lightweight-face-detection-slim-320/ultra-lightweight-face-detection-slim-320.md)|83.32% | 0.1724 | 0.2844 |
-| YOLO v1 Tiny                         | TensorFlow.js\*          | [yolo-v1-tiny-tf](./yolo-v1-tiny-tf/yolo-v1-tiny-tf.md) | 72.1716% | 6.9883	 |	15.8587 |
+| YOLO v1 Tiny                         | TensorFlow.js\*          | [yolo-v1-tiny-tf](./yolo-v1-tiny-tf/yolo-v1-tiny-tf.md) | 54.79% | 6.9883	 |	15.8587 |
 | YOLO v2 Tiny                         | Keras\*                  | [yolo-v2-tiny-tf](./yolo-v2-tiny-tf/yolo-v2-tiny-tf.md) | 27.3443%/29.1184%| 5.4236	 |	11.2295 |
 | YOLO v2                              | Keras\*                  | [yolo-v2-tf](./yolo-v2-tf/yolo-v2-tf.md) | 53.1453%/56.483% | 63.0301	 |	50.9526 |
 | YOLO v3                              | Keras\*                  | [yolo-v3-tf](./yolo-v3-tf/yolo-v3-tf.md) | 62.2759%/67.7221% | 65.9843	 |	61.9221 |

--- a/models/public/mobilenet-ssd/accuracy-check.yml
+++ b/models/public/mobilenet-ssd/accuracy-check.yml
@@ -6,7 +6,7 @@ models:
         weights: mobilenet-ssd.caffemodel
         adapter: ssd
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 300
@@ -15,6 +15,11 @@ models:
             std:  127.5
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar
 
   - name: mobilenet-ssd
     launchers:
@@ -22,9 +27,14 @@ models:
         adapter: ssd
 
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 300
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar

--- a/models/public/mobilenet-ssd/mobilenet-ssd.md
+++ b/models/public/mobilenet-ssd/mobilenet-ssd.md
@@ -19,9 +19,11 @@ The model output is a typical vector containing the tracked object data, as prev
 
 ## Accuracy
 
+The accuracy results were obtained on test data from VOC2007 dataset.
+
 | Metric | Value |
 | ------ | ----- |
-|  mAP | 79.8377% |
+|  mAP   | 67.00% |
 
 See [the original repository](https://github.com/chuanqi305/MobileNet-SSD).
 

--- a/models/public/ssd300/accuracy-check.yml
+++ b/models/public/ssd300/accuracy-check.yml
@@ -6,7 +6,7 @@ models:
         weights: models/VGGNet/VOC0712Plus/SSD_300x300_ft/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel
         adapter: ssd
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 300
@@ -14,6 +14,12 @@ models:
             mean: 104, 117, 123
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar
+
 
   - name: ssd300
     launchers:
@@ -21,9 +27,14 @@ models:
         adapter: ssd
 
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 300
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar

--- a/models/public/ssd300/ssd300.md
+++ b/models/public/ssd300/ssd300.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `ssd300` model is the Caffe\* framework implementation of [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) algorithm with 300x300 input resolution and `VGG-16` backbone. The network intended to perform visual object detection. This model is pretrained on VOC2007 + VOC2012 + COCO dataset and is able to detect 20 [PASCAL VOC2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) object classes:
+The `ssd300` model is the Caffe\* framework implementation of [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) algorithm with 300x300 input resolution and `VGG-16` backbone. The network intended to perform visual object detection. This model is pretrained on VOC2007 + VOC2012 + COCO dataset and is able to detect 20 [PASCAL VOC2007](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/) object classes:
 
 - Person: person
 - Animal: bird, cat, cow, dog, horse, sheep
@@ -28,11 +28,11 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Accuracy
 
-The accuracy results were obtained on validation data from VOC2012 dataset.
+The accuracy results were obtained on test data from VOC2007 dataset.
 
 | Metric | Value |
 | ------ | ----- |
-| mAP  | 85.0791%|
+| mAP    | 87.09% |
 
 ## Input
 

--- a/models/public/ssd512/accuracy-check.yml
+++ b/models/public/ssd512/accuracy-check.yml
@@ -6,7 +6,7 @@ models:
         weights: models/VGGNet/VOC0712Plus/SSD_512x512/VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel
         adapter: ssd
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 512
@@ -14,6 +14,12 @@ models:
             mean: 104, 117, 123
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar
+
 
   - name: ssd512
     launchers:
@@ -21,9 +27,14 @@ models:
         adapter: ssd
 
     datasets:
-      - name: VOC2012
+      - name: VOC2007_detection
         preprocessing:
           - type: resize
             size: 512
         postprocessing:
           - type: resize_prediction_boxes
+        metrics:
+          - type: map
+            integral: 11point
+            ignore_difficult: True
+            presenter: print_scalar

--- a/models/public/ssd512/ssd512.md
+++ b/models/public/ssd512/ssd512.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `ssd512` model is the Caffe\* framework implementation of [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) algorithm with 512x512 input resolution and `VGG-16` backbone. The network intended to perform visual object detection. This model is pretrained on VOC2007 + VOC2012 + COCO dataset and is able to detect 20 [PASCAL VOC2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) object classes:
+The `ssd512` model is the Caffe\* framework implementation of [Single-Shot multibox Detection (SSD)](https://arxiv.org/abs/1512.02325) algorithm with 512x512 input resolution and `VGG-16` backbone. The network intended to perform visual object detection. This model is pretrained on VOC2007 + VOC2012 + COCO dataset and is able to detect 20 [PASCAL VOC2007](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/) object classes:
 
 - Person: person
 - Animal: bird, cat, cow, dog, horse, sheep
@@ -28,11 +28,11 @@ See [here](https://github.com/weiliu89/caffe/tree/ssd).
 
 ## Accuracy
 
-The accuracy results were obtained on validation data from VOC2012 dataset.
+The accuracy results were obtained on test data from VOC2007 dataset.
 
 | Metric | Value |
 | ------ | ----- |
-| mAP  | 90.3845%|
+| mAP    | 91.07% |
 
 ## Input
 

--- a/models/public/yolo-v1-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v1-tiny-tf/accuracy-check.yml
@@ -18,7 +18,7 @@ models:
           raw_output: True
 
     datasets:
-      - name: VOC2012_without_background
+      - name: VOC2007_detection_no_bkgr
 
         preprocessing:
           - type: bgr_to_rgb
@@ -57,7 +57,7 @@ models:
           classes: 20
 
     datasets:
-      - name: VOC2012_without_background
+      - name: VOC2007_detection_no_bkgr
 
         preprocessing:
           - type: resize

--- a/models/public/yolo-v1-tiny-tf/yolo-v1-tiny-tf.md
+++ b/models/public/yolo-v1-tiny-tf/yolo-v1-tiny-tf.md
@@ -48,11 +48,11 @@ YOLO v1 Tiny is a real-time object detection model from TensorFlow.js\* framewor
 
 ## Accuracy
 
-Accuracy metric obtained on VOC2012\* validation dataset for converted model.
+Accuracy metric obtained on test data from VOC2007 dataset for converted model.
 
 | Metric | Value |
 | ------ | ------|
-| mAP    | 72.17% |
+| mAP    | 54.79% |
 
 ## Input
 


### PR DESCRIPTION
- Added dataset to dataset_definitions.yml
- Updated docs and accuracy results for mobilenet-ssd, ssd300, ssd512, yolo-v1-tiny-tf public models
- Updated dataset preparation guide, included VOC2007 dataset for object detection task