### PR TITLE
Fix broken links

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -137,7 +137,7 @@ Please run the following command before the demos build (assuming that the binar
 source <INSTALL_DIR>/deployment_tools/bin/setupvars.sh
 ```
 You can also build demos manually using Inference Engine built from the [openvino](https://github.com/openvinotoolkit/openvino) repo. In this case please set `InferenceEngine_DIR` environment variable to a folder containing `InferenceEngineConfig.cmake` and `ngraph_DIR` to a folder containing `ngraphConfig.cmake` in a build folder. Please also set the `OpenCV_DIR` to point to the OpenCV package to use. The same OpenCV version should be used both for Inference Engine and demos build. Alternatively these values can be provided via command line while running `cmake`. See [CMake's search procedure](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure).
-Please refer to the Inference Engine [build instructions](https://github.com/openvinotoolkit/openvino/blob/master/build-instruction.md)
+Please refer to the Inference Engine [build instructions](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode)
 for details. Please also add path to built Inference Engine libraries to `LD_LIBRARY_PATH` (Linux*) or `PATH` (Windows*) variable before building the demos.
 
 ### <a name="build_demos_linux"></a>Build the Demo Applications on Linux*

--- a/demos/image_retrieval_demo/python/README.md
+++ b/demos/image_retrieval_demo/python/README.md
@@ -83,7 +83,7 @@ python image_retrieval_demo.py \
 --ground_truth text_label
 ```
 
-An example of file listing gallery images can be found [here](https://github.com/openvinotoolkit/training_extensions/blob/develop/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt).
+An example of file listing gallery images can be found [here](https://github.com/openvinotoolkit/training_extensions/blob/089de2f/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt).
 
 Examples of videos can be found [here](https://github.com/19900531/test).
 

--- a/demos/instance_segmentation_demo/python/README.md
+++ b/demos/instance_segmentation_demo/python/README.md
@@ -2,7 +2,10 @@
 
 ![](./instance_segmentation.gif)
 
-This demo shows how to run Instance Segmentation models from [OpenVINO&trade; Training Extensions (OTE)](https://github.com/openvinotoolkit/training_extensions/tree/develop/pytorch_toolkit/instance_segmentation#get-pretrained-models) and `yolact` models family.
+This demo shows how to perform instance segmentation with one of the following Open Model Zoo models:
+
+* `instance-segmentation-security-????`
+* `yolact-resnet50-fpn-pytorch`
 
 > **NOTE**: Only batch size of 1 is supported.
 

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
@@ -324,7 +324,7 @@ The main difference between this converter and `super_resolution` in data organi
   * `max_seq_length` - maximum total input sequence length after word-piece tokenization (Optional, default value is 128).
   * `lower_case` - allows switching tokens to lower case register. It is useful for working with uncased models (Optional, default value is False).
   * `language_filter` - comma-separated list of used in annotation language tags for selecting records for specific languages only. (Optional, if not used full annotation will be converted).
-* `mnli` - converts The Multi-Genre Natural Language Inference Corpus ([MNLI](http://www.nyu.edu/projects/bowman/multinli/)) to `TextClassificationAnnotattion`. **Note: This converter not only converts data to metric specific format but also tokenize and encodes input for BERT.**
+* `mnli` - converts The Multi-Genre Natural Language Inference Corpus ([MNLI](https://cims.nyu.edu/~sbowman/multinli/)) to `TextClassificationAnnotattion`. **Note: This converter not only converts data to metric specific format but also tokenize and encodes input for BERT.**
   * `annotation_file` - path to dataset annotation file in tsv format.
   * `vocab_file` - path to model vocabulary file for WordPiece tokinezation. (Optional, can be not provided in case, when another tokenization approach used.)
   * `sentence_piece_model_file` - model used for [SentencePiece](https://github.com/google/sentencepiece) tokenization (Optional in case, when another tokenization approach used).
@@ -358,7 +358,7 @@ The main difference between this converter and `super_resolution` in data organi
   * `annotattion_file` - path to annotation file in tf records format.
 * `cmu_panoptic_keypoints` - converts CMU Panoptic dataset to `PoseEstimation3dAnnotation` format.
   * `data_dir` - dataset root directory, which contain subdirectories with validation scenes data.
-* `clip_action_recognition` - converts annotation video-based action recognition datasets. Before conversion validation set should be preprocessed using approach described [here](https://github.com/openvinotoolkit/training_extensions/tree/develop/pytorch_toolkit/action_recognition#preparation).
+* `clip_action_recognition` - converts annotation video-based action recognition datasets. Before conversion validation set should be preprocessed using approach described [here](https://github.com/openvinotoolkit/training_extensions/blob/develop/misc/pytorch_toolkit/action_recognition/README.md#preparation).
   * `annotation_file` - path to annotation file in json format.
   * `data_dir` - path to directory with prepared data (e. g. data/kinetics/frames_data).
   * `clips_per_video` - number of clips per video (Optional, default 3).

--- a/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/onnx_runtime_launcher_readme.md
@@ -5,7 +5,7 @@ For enabling ONNX Runtime launcher you need to add `framework: onnx_runtime` in 
 * `device` - specifies which device will be used for infer (`cpu`, `gpu` and so on). Optional, cpu used as default or can depend on used executable provider.
 * `model`- path to the network file in ONNX format.
 * `adapter` - approach how raw output will be converted to representation of dataset problem, some adapters can be specific to framework. You can find detailed instruction how to use adapters [here](../adapters/README.md).
-* `execution_providers` - list of execution providers for evaluation, e.g. [OpenVINO Execution Provider](https://github.com/microsoft/onnxruntime/blob/master/docs/execution_providers/OpenVINO-ExecutionProvider.md). Default [`CPUExecutionProvider`] used.
+* `execution_providers` - list of execution providers for evaluation, e.g. [OpenVINO Execution Provider](https://www.onnxruntime.ai/docs/reference/execution-providers/OpenVINO-ExecutionProvider.html). Default [`CPUExecutionProvider`] used.
 
 **Note: execution providers available only with newest versions of ONNXRuntime, if your installed version does not support such API, please update or does not specify this field.**
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
@@ -23,7 +23,7 @@ Each input description should has following info:
     Optionally you can determine `layout` in case when your model was trained with non-standard data layout (For PyTorch default layout is `NCHW`) and`precision` (Supported precisions: `FP32` - float, `FP16` - signed shot, `U8`  - unsigned char, `U16` - unsigned short int, `I8` - signed char, `I16` - short int, `I32` - int, `I64` - long int).
 If you model has several outputs you also need specify their names in config for ability to get their values in adapter using option `output_names`.
 
-PyTorch launcher config example (demonstrates how to run AlexNet model from [torchvision](https://pytorch.org/docs/stable/torchvision/models.html)):
+PyTorch launcher config example (demonstrates how to run AlexNet model from [torchvision](https://pytorch.org/vision/stable/models.html)):
 
 ```yml
 launchers:


### PR DESCRIPTION
Notes about specific links:

* In `image_retrieval_demo`, use a specific commit to prevent the link from breaking in the future (the same commit that's referenced in `run_tests.py`). Since it's supposed to just be an example, there's no reason to reference the latest version of the file.

* In `instance_segmentation_demo`, remove the link entirely, because OTE no longer contains the text that was referenced.