### PR TITLE
demos: align C++ and Python IE configs

### DIFF
--- a/demos/common/cpp/utils/src/args_helper.cpp
+++ b/demos/common/cpp/utils/src/args_helper.cpp
@@ -101,9 +101,9 @@ std::vector<std::string> parseDevices(const std::string& device_string) {
     return {device_string};
 }
 
+// Format: <device1>:<value1>,<device2>:<value2> or just <value>
 std::map<std::string, uint32_t> parseValuePerDevice(const std::set<std::string>& devices,
                                                     const std::string& values_string) {
-    //  Format: <device1>:<value1>,<device2>:<value2> or just <value>
     auto values_string_upper = values_string;
     std::transform(values_string_upper.begin(),
                    values_string_upper.end(),

--- a/demos/common/cpp/utils/src/config_factory.cpp
+++ b/demos/common/cpp/utils/src/config_factory.cpp
@@ -40,14 +40,7 @@ CnnConfig ConfigFactory::getUserConfig(const std::string& flags_d, const std::st
             if (flags_nthreads != 0)
                 config.execNetworkConfig.emplace(CONFIG_KEY(CPU_THREADS_NUM), std::to_string(flags_nthreads));
 
-            if (flags_d.find("MULTI") != std::string::npos
-                && devices.find("GPU") != devices.end()) {
-                config.execNetworkConfig.emplace(CONFIG_KEY(CPU_BIND_THREAD), CONFIG_VALUE(NO));
-            }
-            else {
-                // pin threads for CPU portion of inference
-                config.execNetworkConfig.emplace(CONFIG_KEY(CPU_BIND_THREAD), CONFIG_VALUE(YES));
-            }
+            config.execNetworkConfig.emplace(CONFIG_KEY(CPU_BIND_THREAD), CONFIG_VALUE(NO));
 
             // for CPU execution, more throughput-oriented execution via streams
             config.execNetworkConfig.emplace(CONFIG_KEY(CPU_THROUGHPUT_STREAMS),

--- a/demos/common/python/pipelines/__init__.py
+++ b/demos/common/python/pipelines/__init__.py
@@ -1,5 +1,6 @@
-from .async_pipeline import AsyncPipeline
+from .async_pipeline import get_user_configs, AsyncPipeline
 
 __all__ = [
+    'get_user_configs',
     'AsyncPipeline',
 ]

--- a/demos/common/python/pipelines/async_pipeline.py
+++ b/demos/common/python/pipelines/async_pipeline.py
@@ -100,8 +100,8 @@ class AsyncPipeline:
         self.event = threading.Event()
 
     def inference_completion_callback(self, status, callback_args):
-        request, id, meta, preprocessing_meta = callback_args
         try:
+            request, id, meta, preprocessing_meta = callback_args
             if status != 0:
                 raise RuntimeError('Infer Request has returned status code {}'.format(status))
             raw_outputs = {key: blob.buffer for key, blob in request.output_blobs.items()}

--- a/demos/common/python/pipelines/async_pipeline.py
+++ b/demos/common/python/pipelines/async_pipeline.py
@@ -89,6 +89,7 @@ class AsyncPipeline:
         self.exec_net = ie.load_network(network=self.model.net, device_name=device,
                                         config=plugin_config, num_requests=max_num_requests)
         if max_num_requests == 0:
+            # ExecutableNetwork doesn't allow creation of additional InferRequests. Reload ExecutableNetwork
             # +1 to use it as a buffer of the pipeline
             self.exec_net = ie.load_network(network=self.model.net, device_name=device,
                                             config=plugin_config, num_requests=len(self.exec_net.requests) + 1)

--- a/demos/common/python/pipelines/async_pipeline.py
+++ b/demos/common/python/pipelines/async_pipeline.py
@@ -17,6 +17,67 @@
 import logging
 import threading
 from collections import deque
+from typing import Dict, Set
+
+
+def parse_devices(device_string):
+    colon_position = device_string.find(':')
+    if colon_position != -1:
+        device_type = device_string[:colon_position]
+        if device_type == 'HETERO' or device_type == 'MULTI':
+            comma_separated_devices = device_string[colon_position + 1:]
+            devices = comma_separated_devices.split(',')
+            for device in devices:
+                parenthesis_position = device.find(':')
+                if parenthesis_position != -1:
+                    device = device[:parenthesis_position]
+            return devices
+    return (device_string,)
+
+
+def parse_value_per_device(devices: Set[str], values_string: str)-> Dict[str, int]:
+    """Format: <device1>:<value1>,<device2>:<value2> or just <value>"""
+    values_string_upper = values_string.upper()
+    result = {}
+    device_value_strings = values_string_upper.split(',')
+    for device_value_string in device_value_strings:
+        device_value_list = device_value_string.split(':')
+        if len(device_value_list) == 2:
+            if device_value_list[0] in devices:
+                result[device_value_list[0]] = int(device_value_list[1])
+        elif len(device_value_list) == 1 and device_value_list[0] != '':
+            for device in devices:
+                result[device] = int(device_value_list[0])
+        elif device_value_list[0] != '':
+            raise RuntimeError(f'Unknown string format: {values_string}')
+    return result
+
+
+def get_user_configs(flags_d: str, flags_nstreams: str, flags_nthreads: int)-> Dict[str, str]:
+    config = {}
+
+    devices = set(parse_devices(flags_d))
+
+    device_nstreams = parse_value_per_device(devices, flags_nstreams)
+    for device in devices:
+        if device == 'CPU':  # CPU supports a few special performance-oriented keys
+            # limit threading for CPU portion of inference
+            if flags_nthreads:
+                config['CPU_THREADS_NUM'] = str(flags_nthreads)
+
+            config['CPU_BIND_THREAD'] = 'NO'
+
+            # for CPU execution, more throughput-oriented execution via streams
+            config['CPU_THROUGHPUT_STREAMS'] = str(device_nstreams[device]) \
+                if device in device_nstreams else 'CPU_THROUGHPUT_AUTO'
+        elif device == 'GPU':
+            config['GPU_THROUGHPUT_STREAMS'] = str(device_nstreams[device]) \
+                if device in device_nstreams else 'GPU_THROUGHPUT_AUTO'
+            if 'MULTI' in flags_d and 'CPU' in devices:
+                # multi-device execution with the CPU + GPU performs best with GPU throttling hint,
+                # which releases another CPU thread (that is otherwise used by the GPU driver for active polling)
+                config['CLDNN_PLUGIN_THROTTLE'] = '1'
+    return config
 
 
 class AsyncPipeline:
@@ -27,6 +88,10 @@ class AsyncPipeline:
         self.logger.info('Loading network to {} plugin...'.format(device))
         self.exec_net = ie.load_network(network=self.model.net, device_name=device,
                                         config=plugin_config, num_requests=max_num_requests)
+        if max_num_requests == 0:
+            # +1 to use it as a buffer of the pipeline
+            self.exec_net = ie.load_network(network=self.model.net, device_name=device,
+                                            config=plugin_config, num_requests=len(self.exec_net.requests) + 1)
 
         self.empty_requests = deque(self.exec_net.requests)
         self.completed_request_results = {}

--- a/demos/human_pose_estimation_demo/cpp/main.cpp
+++ b/demos/human_pose_estimation_demo/cpp/main.cpp
@@ -264,6 +264,7 @@ int main(int argc, char *argv[]) {
 
         uint32_t framesProcessed = 0;
         bool keepRunning = true;
+        int64_t frameNum = -1;
         std::unique_ptr<ResultBase> result;
 
         while (keepRunning) {
@@ -275,7 +276,7 @@ int main(int argc, char *argv[]) {
                     // Input stream is over
                     break;
                 }
-                pipeline.submitData(ImageInputData(curr_frame),
+                frameNum = pipeline.submitData(ImageInputData(curr_frame),
                     std::make_shared<ImageMetaData>(curr_frame, startTime));
                 }
 
@@ -311,7 +312,8 @@ int main(int argc, char *argv[]) {
 
         //// ------------ Waiting for completion of data processing and rendering the rest of results ---------
         pipeline.waitForTotalCompletion();
-        while (result = pipeline.getResult()) {
+        for (; framesProcessed <= frameNum; framesProcessed++) {
+            while (!(result = pipeline.getResult())) {}
             cv::Mat outFrame = renderHumanPose(result->asRef<HumanPoseResult>());
             //--- Showing results and device information
             presenter.drawGraphs(outFrame);
@@ -325,7 +327,6 @@ int main(int argc, char *argv[]) {
                 //--- Updating output window
                 cv::waitKey(1);
             }
-            framesProcessed++;
         }
 
         //// --------------------------- Report metrics -------------------------------------------------------

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -29,7 +29,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 import models
 import monitors
 from images_capture import open_images_capture
-from pipelines import AsyncPipeline
+from pipelines import get_user_configs, AsyncPipeline
 from performance_metrics import PerformanceMetrics
 
 logging.basicConfig(format='[ %(levelname)s ] %(message)s', level=logging.INFO, stream=sys.stdout)
@@ -74,7 +74,7 @@ def build_argparser():
 
     infer_args = parser.add_argument_group('Inference options')
     infer_args.add_argument('-nireq', '--num_infer_requests', help='Optional. Number of infer requests',
-                            default=1, type=int)
+                            default=0, type=int)
     infer_args.add_argument('-nstreams', '--num_streams',
                             help='Optional. Number of streams to use for inference on the CPU or/and GPU in throughput '
                                  'mode (for HETERO and MULTI device cases use format '
@@ -107,32 +107,6 @@ def get_model(ie, args, aspect_ratio):
     else:
         raise RuntimeError('No model type or invalid model type (-at) provided: {}'.format(args.architecture_type))
     return model
-
-
-def get_plugin_configs(device, num_streams, num_threads):
-    config_user_specified = {}
-
-    devices_nstreams = {}
-    if num_streams:
-        devices_nstreams = {device: num_streams for device in ['CPU', 'GPU'] if device in device} \
-            if num_streams.isdigit() \
-            else dict(device.split(':', 1) for device in num_streams.split(','))
-
-    if 'CPU' in device:
-        if num_threads is not None:
-            config_user_specified['CPU_THREADS_NUM'] = str(num_threads)
-        if 'CPU' in devices_nstreams:
-            config_user_specified['CPU_THROUGHPUT_STREAMS'] = devices_nstreams['CPU'] \
-                if int(devices_nstreams['CPU']) > 0 \
-                else 'CPU_THROUGHPUT_AUTO'
-
-    if 'GPU' in device:
-        if 'GPU' in devices_nstreams:
-            config_user_specified['GPU_THROUGHPUT_STREAMS'] = devices_nstreams['GPU'] \
-                if int(devices_nstreams['GPU']) > 0 \
-                else 'GPU_THROUGHPUT_AUTO'
-
-    return config_user_specified
 
 
 default_skeleton = ((15, 13), (13, 11), (16, 14), (14, 12), (11, 12), (5, 11), (6, 12), (5, 6),
@@ -190,7 +164,7 @@ def main():
     log.info('Initializing Inference Engine...')
     ie = IECore()
 
-    plugin_config = get_plugin_configs(args.device, args.num_streams, args.num_threads)
+    plugin_config = get_user_configs(args.device, args.num_streams, args.num_threads)
 
     cap = open_images_capture(args.input, args.loop)
 

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -237,33 +237,31 @@ def main():
 
     hpe_pipeline.await_all()
     # Process completed requests
-    while hpe_pipeline.has_completed_request():
+    for next_frame_id_to_show in range(next_frame_id_to_show, next_frame_id):
         results = hpe_pipeline.get_result(next_frame_id_to_show)
-        if results:
-            (poses, scores), frame_meta = results
-            frame = frame_meta['frame']
-            start_time = frame_meta['start_time']
+        while results is None:
+            results = hpe_pipeline.get_result(next_frame_id_to_show)
+        (poses, scores), frame_meta = results
+        frame = frame_meta['frame']
+        start_time = frame_meta['start_time']
 
-            if len(poses) and args.raw_output_message:
-                print_raw_results(poses, scores)
+        if len(poses) and args.raw_output_message:
+            print_raw_results(poses, scores)
 
-            presenter.drawGraphs(frame)
-            frame = draw_poses(frame, poses, args.prob_threshold)
-            metrics.update(start_time, frame)
-            if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
-                video_writer.write(frame)
-            if not args.no_show:
-                cv2.imshow('Pose estimation results', frame)
-                key = cv2.waitKey(1)
+        presenter.drawGraphs(frame)
+        frame = draw_poses(frame, poses, args.prob_threshold)
+        metrics.update(start_time, frame)
+        if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
+            video_writer.write(frame)
+        if not args.no_show:
+            cv2.imshow('Pose estimation results', frame)
+            key = cv2.waitKey(1)
 
-                ESC_KEY = 27
-                # Quit.
-                if key in {ord('q'), ord('Q'), ESC_KEY}:
-                    break
-                presenter.handleKey(key)
-            next_frame_id_to_show += 1
-        else:
-            break
+            ESC_KEY = 27
+            # Quit.
+            if key in {ord('q'), ord('Q'), ESC_KEY}:
+                break
+            presenter.handleKey(key)
 
     metrics.print_total()
     print(presenter.reportMeans())

--- a/demos/object_detection_demo/cpp/main.cpp
+++ b/demos/object_detection_demo/cpp/main.cpp
@@ -384,7 +384,8 @@ int main(int argc, char *argv[]) {
 
         //// ------------ Waiting for completion of data processing and rendering the rest of results ---------
         pipeline.waitForTotalCompletion();
-        while (result = pipeline.getResult()) {
+        for (; framesProcessed <= frameNum; framesProcessed++) {
+            while (!(result = pipeline.getResult())) {}
             cv::Mat outFrame = renderDetectionData(result->asRef<DetectionResult>(), palette);
             //--- Showing results and device information
             presenter.drawGraphs(outFrame);
@@ -398,7 +399,6 @@ int main(int argc, char *argv[]) {
                 //--- Updating output window
                 cv::waitKey(1);
             }
-            framesProcessed++;
         }
 
         //// --------------------------- Report metrics -------------------------------------------------------

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -32,7 +32,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 
 import models
 import monitors
-from pipelines import AsyncPipeline
+from pipelines import get_user_configs, AsyncPipeline
 from images_capture import open_images_capture
 from performance_metrics import PerformanceMetrics
 
@@ -70,7 +70,7 @@ def build_argparser():
 
     infer_args = parser.add_argument_group('Inference options')
     infer_args.add_argument('-nireq', '--num_infer_requests', help='Optional. Number of infer requests',
-                            default=1, type=int)
+                            default=0, type=int)
     infer_args.add_argument('-nstreams', '--num_streams',
                             help='Optional. Number of streams to use for inference on the CPU or/and GPU in throughput '
                                  'mode (for HETERO and MULTI device cases use format '
@@ -178,32 +178,6 @@ def get_model(ie, args):
         raise RuntimeError('No model type or invalid model type (-at) provided: {}'.format(args.architecture_type))
 
 
-def get_plugin_configs(device, num_streams, num_threads):
-    config_user_specified = {}
-
-    devices_nstreams = {}
-    if num_streams:
-        devices_nstreams = {device: num_streams for device in ['CPU', 'GPU'] if device in device} \
-            if num_streams.isdigit() \
-            else dict(device.split(':', 1) for device in num_streams.split(','))
-
-    if 'CPU' in device:
-        if num_threads is not None:
-            config_user_specified['CPU_THREADS_NUM'] = str(num_threads)
-        if 'CPU' in devices_nstreams:
-            config_user_specified['CPU_THROUGHPUT_STREAMS'] = devices_nstreams['CPU'] \
-                if int(devices_nstreams['CPU']) > 0 \
-                else 'CPU_THROUGHPUT_AUTO'
-
-    if 'GPU' in device:
-        if 'GPU' in devices_nstreams:
-            config_user_specified['GPU_THROUGHPUT_STREAMS'] = devices_nstreams['GPU'] \
-                if int(devices_nstreams['GPU']) > 0 \
-                else 'GPU_THROUGHPUT_AUTO'
-
-    return config_user_specified
-
-
 def draw_detections(frame, detections, palette, labels, threshold):
     size = frame.shape[:2]
     for detection in detections:
@@ -244,7 +218,7 @@ def main():
     log.info('Initializing Inference Engine...')
     ie = IECore()
 
-    plugin_config = get_plugin_configs(args.device, args.num_streams, args.num_threads)
+    plugin_config = get_user_configs(args.device, args.num_streams, args.num_threads)
 
     log.info('Loading network...')
 

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -271,7 +271,8 @@ int main(int argc, char *argv[]) {
 
         //// ------------ Waiting for completion of data processing and rendering the rest of results ---------
         pipeline.waitForTotalCompletion();
-        while (result = pipeline.getResult()) {
+        for (; framesProcessed <= frameNum; framesProcessed++) {
+            while (!(result = pipeline.getResult())) {}
             cv::Mat outFrame = renderSegmentationData(result->asRef<SegmentationResult>());
             //--- Showing results and device information
             presenter.drawGraphs(outFrame);
@@ -285,7 +286,6 @@ int main(int argc, char *argv[]) {
                 //--- Updating output window
                 cv::waitKey(1);
             }
-            framesProcessed++;
         }
 
         //// --------------------------- Report metrics -------------------------------------------------------

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -224,26 +224,24 @@ def main():
 
     pipeline.await_all()
     # Process completed requests
-    while pipeline.has_completed_request():
+    for next_frame_id_to_show in range(next_frame_id_to_show, next_frame_id):
         results = pipeline.get_result(next_frame_id_to_show)
-        if results:
-            objects, frame_meta = results
-            frame = frame_meta['frame']
-            start_time = frame_meta['start_time']
+        while results is None:
+            results = pipeline.get_result(next_frame_id_to_show)
+        objects, frame_meta = results
+        frame = frame_meta['frame']
+        start_time = frame_meta['start_time']
 
-            frame = visualizer.overlay_masks(frame, objects)
-            presenter.drawGraphs(frame)
-            metrics.update(start_time, frame)
+        frame = visualizer.overlay_masks(frame, objects)
+        presenter.drawGraphs(frame)
+        metrics.update(start_time, frame)
 
-            if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
-                video_writer.write(frame)
+        if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
+            video_writer.write(frame)
 
-            if not args.no_show:
-                cv2.imshow('Segmentation Results', frame)
-                key = cv2.waitKey(1)
-            next_frame_id_to_show += 1
-        else:
-            break
+        if not args.no_show:
+            cv2.imshow('Segmentation Results', frame)
+            key = cv2.waitKey(1)
 
     metrics.print_total()
     print(presenter.reportMeans())

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -29,7 +29,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 
 from models import SegmentationModel, SalientObjectDetectionModel
 import monitors
-from pipelines import AsyncPipeline
+from pipelines import get_user_configs, AsyncPipeline
 from images_capture import open_images_capture
 from performance_metrics import PerformanceMetrics
 
@@ -144,37 +144,12 @@ def build_argparser():
     return parser
 
 
-def get_plugin_configs(device, num_streams, num_threads):
-    config_user_specified = {}
-
-    devices_nstreams = {}
-    if num_streams:
-        devices_nstreams = {device: num_streams for device in ['CPU', 'GPU'] if device in device} \
-            if num_streams.isdigit() \
-            else dict(device.split(':', 1) for device in num_streams.split(','))
-
-    if 'CPU' in device:
-        if num_threads is not None:
-            config_user_specified['CPU_THREADS_NUM'] = str(num_threads)
-        if 'CPU' in devices_nstreams:
-            config_user_specified['CPU_THROUGHPUT_STREAMS'] = devices_nstreams['CPU'] \
-                if int(devices_nstreams['CPU']) > 0 \
-                else 'CPU_THROUGHPUT_AUTO'
-
-    if 'GPU' in device:
-        if 'GPU' in devices_nstreams:
-            config_user_specified['GPU_THROUGHPUT_STREAMS'] = devices_nstreams['GPU'] \
-                if int(devices_nstreams['GPU']) > 0 \
-                else 'GPU_THROUGHPUT_AUTO'
-
-    return config_user_specified
-
-
 def get_model(ie, args):
     if args.architecture_type == 'segmentation':
         return SegmentationModel(ie, args.model), SegmentationVisualizer(args.colors)
     if args.architecture_type == 'salient_object_detection':
         return SalientObjectDetectionModel(ie, args.model), SaliencyMapVisualizer()
+
 
 def main():
     metrics = PerformanceMetrics()
@@ -183,7 +158,7 @@ def main():
     log.info('Initializing Inference Engine...')
     ie = IECore()
 
-    plugin_config = get_plugin_configs(args.device, args.num_streams, args.num_threads)
+    plugin_config = get_user_configs(args.device, args.num_streams, args.num_threads)
 
     log.info('Loading network...')
 


### PR DESCRIPTION
Don't bind threads: thread binding came from benchmark_app which
does't run anything during inference. But if -d MULTI:CPU,GPU is
set, there is an extra thread to maintain GPU. In that case threads
aren't bound. Following that logic demos never bind threads because
there is main thread running pre and postprocessing. Additionally,
that's what IE says:
> 'YES' (default) binding option maps threads to cores - this
works best for static/synthetic scenarios like benchmarks.

Fix Python IE configs and follow C++ implementation.