### PR TITLE
Replace absolute links to Markdown files with relative ones

### DIFF
--- a/models/public/aclnet-int8/README.md
+++ b/models/public/aclnet-int8/README.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `AclNet-int8` model is quantized and fine-tuned with NNCF variant of [AclNet](https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/aclnet/aclnet.md) model, which is designed to perform sound classification.
+The `AclNet-int8` model is quantized and fine-tuned with NNCF variant of [AclNet](../aclnet/README.md) model, which is designed to perform sound classification.
 The `AclNet-int8` model is trained on an internal dataset of environmental sounds for 53 different classes, listed in file `<omz_dir>/data/dataset_classes/aclnet.txt`.
 For details about the model, see this [paper](https://arxiv.org/abs/1811.06669).
 

--- a/tools/accuracy_checker/README.md
+++ b/tools/accuracy_checker/README.md
@@ -190,7 +190,7 @@ If your dataset data is a well-known competition problem (COCO, Pascal VOC, and 
 it is reasonable to declare it in some global configuration file ([definition file](dataset_definitions.yml)). This way in your local configuration file you can provide only
 `name` and all required steps will be picked from global one. To pass path to this global configuration use `--definition` argument of CLI.
 
-If you want to evaluate models using prepared config files and well-known datasets, you need to organize folders with validation datasets in a certain way. More detailed information about dataset preparation you can find in [Dataset Preparation Guide](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md).
+If you want to evaluate models using prepared config files and well-known datasets, you need to organize folders with validation datasets in a certain way. More detailed information about dataset preparation you can find in [Dataset Preparation Guide](../../data/datasets.md).
 
 Each dataset must have:
 

--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -303,7 +303,7 @@ the script.
 Before you run the model quantizer, you must prepare a directory with
 the datasets required for the quantization process. This directory will be
 referred to as `<DATASET_DIR>` below. You can find more detailed information
-about dataset preparation in the [Dataset Preparation Guide](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/datasets.md).
+about dataset preparation in the [Dataset Preparation Guide](../../data/datasets.md).
 
 The basic usage is to run the script like this:
 


### PR DESCRIPTION
This also ends up fixing the `datasets.md` links, which were broken when that file was moved into the `data/` directory.