### PR TITLE
multi_camera_multi_target_tracking_demo: remove TensorBoard from deps

### DIFF
--- a/ci/requirements-demos.txt
+++ b/ci/requirements-demos.txt
@@ -1,35 +1,16 @@
 # use update-requirements.py to update this file
 
-absl-py==0.12.0
-    # via tensorboard
 attrs==20.3.0
     # via pytest
-cachetools==4.2.1
-    # via google-auth
-certifi==2020.12.5
-    # via requests
-chardet==4.0.0
-    # via requests
 cycler==0.10.0
     # via matplotlib
 flake8-import-order==0.18.1
     # via motmetrics
 flake8==3.9.0
     # via motmetrics
-google-auth-oauthlib==0.4.3
-    # via tensorboard
-google-auth==1.28.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-grpcio==1.36.1
-    # via tensorboard
-idna==2.10
-    # via requests
 importlib-metadata==3.7.3
     # via
     #   flake8
-    #   markdown
     #   pluggy
     #   pytest
 iniconfig==1.1.1
@@ -38,8 +19,6 @@ joblib==1.0.1
     # via scikit-learn
 kiwisolver==1.3.1
     # via matplotlib
-markdown==3.3.4
-    # via tensorboard
 matplotlib==3.3.4
     # via -r demos/requirements.txt
 mccabe==0.6.1
@@ -58,10 +37,7 @@ numpy==1.19.5 ; python_version >= "3.4"
     #   pandas
     #   scikit-learn
     #   scipy
-    #   tensorboard
     #   tensorboardx
-oauthlib==3.1.0
-    # via requests-oauthlib
 packaging==20.9
     # via
     #   nibabel
@@ -73,19 +49,11 @@ pillow==8.1.2
 pluggy==0.13.1
     # via pytest
 protobuf==3.15.6
-    # via
-    #   tensorboard
-    #   tensorboardx
+    # via tensorboardx
 py-cpuinfo==7.0.0
     # via pytest-benchmark
 py==1.10.0
     # via pytest
-pyasn1-modules==0.2.8
-    # via google-auth
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
 pycodestyle==2.7.0
     # via
     #   flake8
@@ -108,14 +76,6 @@ python-dateutil==2.8.1
     #   pandas
 pytz==2021.1
     # via pandas
-requests-oauthlib==1.3.0
-    # via google-auth-oauthlib
-requests==2.25.1
-    # via
-    #   requests-oauthlib
-    #   tensorboard
-rsa==4.7.2
-    # via google-auth
 scikit-learn==0.24.1
     # via -r demos/requirements.txt
 scipy==1.5.4
@@ -125,17 +85,9 @@ scipy==1.5.4
     #   scikit-learn
 six==1.15.0
     # via
-    #   absl-py
-    #   google-auth
-    #   grpcio
     #   protobuf
     #   python-dateutil
-    #   tensorboard
     #   tensorboardx
-tensorboard-plugin-wit==1.8.0
-    # via tensorboard
-tensorboard==2.4.1
-    # via -r demos/requirements.txt
 tensorboardx==2.1
     # via -r demos/requirements.txt
 threadpoolctl==2.1.0
@@ -148,12 +100,6 @@ tqdm==4.59.0
     # via -r demos/requirements.txt
 typing-extensions==3.7.4.3
     # via importlib-metadata
-urllib3==1.26.4
-    # via requests
-werkzeug==1.0.1
-    # via tensorboard
-wheel==0.36.2
-    # via tensorboard
 xmltodict==0.12.0
     # via motmetrics
 zipp==3.4.1

--- a/demos/multi_camera_multi_target_tracking_demo/python/README.md
+++ b/demos/multi_camera_multi_target_tracking_demo/python/README.md
@@ -255,7 +255,10 @@ Two options are available during the demo execution:
 
 By default these options are disabled.
 To enable the first one please set in configuration file for `analyzer` parameter
-`enable` to `True`, for the second one for `embeddings` specify parameter `path`
+`enable` to `True`.
+
+For the second one, install TensorBoard (for example, with `pip install tensorboard`).
+Then, for `embeddings` specify parameter `save_path`
 that is a directory where data related to embeddings will be saved
 (if it is an empty string the option is disabled). There is paramater `use_images` in `embeddings`.
 If it is `True` an image with object will be drawn for every embedding instead of point.

--- a/demos/multi_camera_multi_target_tracking_demo/python/requirements.txt
+++ b/demos/multi_camera_multi_target_tracking_demo/python/requirements.txt
@@ -4,6 +4,5 @@ motmetrics>=1.2.0
 opencv-python>=3.4.5.20
 numpy>=1.16.4
 scipy>=1.3.0
-tensorboard>=2.1.0
 tensorboardX>=2.0
 tqdm>=4.32.2

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -5,6 +5,5 @@ numpy
 scikit-learn
 scipy
 tokenizers>=0.9.3
-tensorboard
 tensorboardX
 tqdm


### PR DESCRIPTION
TensorBoard is a heavy package with a lot of dependencies, and it's not actually *used* by the demo - the user is supposed to run it manually.