### PR TITLE
multi_camera_multi_target_tracking_demo: remove setuptools from requirements.txt

### DIFF
--- a/demos/multi_camera_multi_target_tracking_demo/python/requirements.txt
+++ b/demos/multi_camera_multi_target_tracking_demo/python/requirements.txt
@@ -1,4 +1,3 @@
-setuptools
 matplotlib>=3.0.3
 motmetrics>=1.2.0
 opencv-python>=3.4.5.20


### PR DESCRIPTION
Not sure why it was there in the first place. The demo doesn't use it.