### PR TITLE
ci/check-release-readiness.py: update to match layout changes

### DIFF
--- a/ci/check-release-readiness.py
+++ b/ci/check-release-readiness.py
@@ -32,16 +32,22 @@ def main():
         all_passed = False
 
     for model_dir in OMZ_ROOT.glob('models/*/*/'):
-        # searching recursively, because this could be a composite model
-        has_config = bool(list(model_dir.glob('**/model.yml')))
+        has_model_yml = (model_dir / 'model.yml').is_file()
+        has_composite_model_yml = (model_dir / 'composite-model.yml').is_file()
 
-        has_doc = bool(list(model_dir.glob('**/*.md')))
+        has_config = has_model_yml or has_composite_model_yml
+
+        has_doc = (model_dir / 'README.md').is_file()
 
         if has_config and not has_doc:
             complain('model {} has no documentation', model_dir.name)
 
         if has_doc and not has_config:
             complain('model {} has no config file', model_dir.name)
+
+        if has_composite_model_yml:
+            if not list(model_dir.glob('*/model.yml')):
+                complain('composite model {} has no components', model_dir.name)
 
     for models_lst_path in OMZ_ROOT.glob('demos/**/models.lst'):
         with models_lst_path.open() as models_lst:


### PR DESCRIPTION
* Documentation files have a specific name now (`README.md`).

* We now have `composite-model.yml` files which also should be checked (they are needed for correct documentation generation).