### PR TITLE
Fix AC install after docs update

### DIFF
--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -48,7 +48,7 @@ class PyTest(test_command):
 
 def read(*path):
     input_file = os.path.join(here, *path)
-    with open(str(input_file)) as file:
+    with open(str(input_file), encoding='utf-8') as file:
         return file.read()
 
 


### PR DESCRIPTION
AC installer uses readme during installation as long description. After last docs update https://github.com/openvinotoolkit/open_model_zoo/pull/2321 , install process was broken due to addition symbols which can be unsuccessfully decoded on some systems. Added decoding during file reading. Currently internal validation CI is broken... so please merge ASAP

P.S. @ntyukaev please in the next time call me on review if you will update AC docs to prevent such situations.