### PR TITLE
fix for wave reader mono flag processing

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -765,7 +765,7 @@ class WavReader(BaseReader):
 
             data = data.reshape(-1, channels).T
             if channels > 1 and self.mono:
-                data = data.mean(0,keepdims=True)
+                data = data.mean(0, keepdims=True)
             if self.to_float:
                 data = data.astype(np.float32) / np.iinfo(self._samplewidth_types[sample_width]).max
 

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -765,7 +765,7 @@ class WavReader(BaseReader):
 
             data = data.reshape(-1, channels).T
             if channels > 1 and self.mono:
-                data = data.mean(1)
+                data = data.mean(0,keepdims=True)
             if self.to_float:
                 data = data.astype(np.float32) / np.iinfo(self._samplewidth_types[sample_width]).max
 


### PR DESCRIPTION
fix average over channels (it was averaged over samples)
add keepdim to be sure that 1 and 2 channels audio files produces output with the same dim [chanel_num, samples_num]