### PR TITLE
Refactoring: init paramteres are added to the Results classes

### DIFF
--- a/demos/common/cpp/models/include/models/results.h
+++ b/demos/common/cpp/models/include/models/results.h
@@ -22,9 +22,11 @@
 
 struct MetaData;
 struct ResultBase {
+    ResultBase(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        frameId(frameId), metaData(metaData) {}
     virtual ~ResultBase() {}
 
-    int64_t frameId = -1;
+    int64_t frameId;
 
     std::shared_ptr<MetaData> metaData;
     bool IsEmpty() { return frameId < 0; }
@@ -57,6 +59,9 @@ struct InferenceResult : public ResultBase {
 };
 
 struct ClassificationResult : public ResultBase {
+    ClassificationResult(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        ResultBase(frameId, metaData) {}
+
     std::vector<std::pair<unsigned int, std::string>> topLabels;
 };
 
@@ -67,14 +72,21 @@ struct DetectedObject : public cv::Rect2f {
 };
 
 struct DetectionResult : public ResultBase {
+    DetectionResult(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        ResultBase(frameId, metaData) {}
     std::vector<DetectedObject> objects;
 };
 
 struct RetinaFaceDetectionResult : public DetectionResult {
+    RetinaFaceDetectionResult(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        DetectionResult(frameId, metaData) {
+    }
     std::vector<cv::Point2f> landmarks;
 };
 
 struct SegmentationResult : public ResultBase {
+    SegmentationResult(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        ResultBase(frameId, metaData) {}
     cv::Mat mask;
 };
 
@@ -84,5 +96,8 @@ struct HumanPose {
 };
 
 struct HumanPoseResult : public ResultBase {
+    HumanPoseResult(int64_t frameId = -1, const std::shared_ptr<MetaData>& metaData = nullptr) :
+        ResultBase(frameId, metaData) {
+    }
     std::vector<HumanPose> poses;
 };

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -30,10 +30,8 @@ std::unique_ptr<ResultBase> ClassificationModel::postprocess(InferenceResult& in
     InferenceEngine::LockedMemory<const void> outputMapped = infResult.getFirstOutputBlob()->rmap();
     const float *classificationData = outputMapped.as<float*>();
 
-    ClassificationResult* result = new ClassificationResult;
+    ClassificationResult* result = new ClassificationResult(infResult.frameId, infResult.metaData);
     auto retVal = std::unique_ptr<ResultBase>(result);
-
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
 
     std::vector<unsigned> indices(infResult.getFirstOutputBlob()->size());
     std::iota(std::begin(indices), std::end(indices), 0);

--- a/demos/common/cpp/models/src/detection_model_centernet.cpp
+++ b/demos/common/cpp/models/src/detection_model_centernet.cpp
@@ -266,8 +266,7 @@ std::unique_ptr<ResultBase> ModelCenterNet::postprocess(InferenceResult& infResu
     transform(bboxes, sz, scale, centerX, centerY);
 
     // --------------------------- Create detection result objects ------------------------------------
-    DetectionResult* result = new DetectionResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    DetectionResult* result = new DetectionResult(infResult.frameId, infResult.metaData);
 
     result->objects.reserve(scores.size());
     for (size_t i = 0; i < scores.size(); ++i) {

--- a/demos/common/cpp/models/src/detection_model_faceboxes.cpp
+++ b/demos/common/cpp/models/src/detection_model_faceboxes.cpp
@@ -222,8 +222,7 @@ std::unique_ptr<ResultBase> ModelFaceBoxes::postprocess(InferenceResult& infResu
     std::vector<int> keep = nms(bboxes, scores.second, boxIOUThreshold);
 
     // --------------------------- Create detection result objects --------------------------------------------------------
-    DetectionResult* result = new DetectionResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    DetectionResult* result = new DetectionResult(infResult.frameId, infResult.metaData);
     auto imgWidth = infResult.internalModelData->asRef<InternalImageModelData>().inputImgWidth;
     auto imgHeight = infResult.internalModelData->asRef<InternalImageModelData>().inputImgHeight;
     float scaleX = static_cast<float>(netInputWidth) / imgWidth;

--- a/demos/common/cpp/models/src/detection_model_retinaface.cpp
+++ b/demos/common/cpp/models/src/detection_model_retinaface.cpp
@@ -319,8 +319,7 @@ std::unique_ptr<ResultBase> ModelRetinaFace::postprocess(InferenceResult& infRes
     auto keep = nms(bboxes, scores, boxIOUThreshold, !shouldDetectLandmarks);
 
     // --------------------------- Create detection result objects --------------------------------------------------------
-    RetinaFaceDetectionResult* result = new RetinaFaceDetectionResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    RetinaFaceDetectionResult* result = new RetinaFaceDetectionResult(infResult.frameId, infResult.metaData);
 
     auto imgWidth = infResult.internalModelData->asRef<InternalImageModelData>().inputImgWidth;
     auto imgHeight = infResult.internalModelData->asRef<InternalImageModelData>().inputImgHeight;

--- a/demos/common/cpp/models/src/detection_model_ssd.cpp
+++ b/demos/common/cpp/models/src/detection_model_ssd.cpp
@@ -50,10 +50,8 @@ std::unique_ptr<ResultBase> ModelSSD::postprocessSingleOutput(InferenceResult& i
     LockedMemory<const void> outputMapped = infResult.getFirstOutputBlob()->rmap();
     const float *detections = outputMapped.as<float*>();
 
-    DetectionResult* result = new DetectionResult;
+    DetectionResult* result = new DetectionResult(infResult.frameId, infResult.metaData);
     auto retVal = std::unique_ptr<ResultBase>(result);
-
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
 
     const auto& internalData = infResult.internalModelData->asRef<InternalImageModelData>();
 
@@ -94,10 +92,8 @@ std::unique_ptr<ResultBase> ModelSSD::postprocessMultipleOutputs(InferenceResult
     const float *labels = mappedMemoryAreas[1].as<float*>();
     const float *scores = mappedMemoryAreas.size() > 2 ? mappedMemoryAreas[2].as<float*>() : nullptr;
 
-    DetectionResult* result = new DetectionResult;
+    DetectionResult* result = new DetectionResult(infResult.frameId, infResult.metaData);
     auto retVal = std::unique_ptr<ResultBase>(result);
-
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
 
     const auto& internalData = infResult.internalModelData->asRef<InternalImageModelData>();
 

--- a/demos/common/cpp/models/src/detection_model_yolo.cpp
+++ b/demos/common/cpp/models/src/detection_model_yolo.cpp
@@ -82,9 +82,7 @@ void ModelYolo3::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork) {
 }
 
 std::unique_ptr<ResultBase> ModelYolo3::postprocess(InferenceResult & infResult) {
-    DetectionResult* result = new DetectionResult;
-
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    DetectionResult* result = new DetectionResult(infResult.frameId, infResult.metaData);
     std::vector<DetectedObject> objects;
 
     // Parsing outputs

--- a/demos/common/cpp/models/src/hpe_model_associative_embedding.cpp
+++ b/demos/common/cpp/models/src/hpe_model_associative_embedding.cpp
@@ -131,8 +131,7 @@ std::shared_ptr<InternalModelData> HpeAssociativeEmbedding::preprocess(const Inp
 }
 
 std::unique_ptr<ResultBase> HpeAssociativeEmbedding::postprocess(InferenceResult& infResult) {
-    HumanPoseResult* result = new HumanPoseResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    HumanPoseResult* result = new HumanPoseResult(infResult.frameId, infResult.metaData);
 
     auto aembds = infResult.outputsData[embeddingsBlobName];
     const SizeVector& aembdsDims = aembds->getTensorDesc().getDims();

--- a/demos/common/cpp/models/src/hpe_model_openpose.cpp
+++ b/demos/common/cpp/models/src/hpe_model_openpose.cpp
@@ -120,8 +120,7 @@ std::shared_ptr<InternalModelData> HPEOpenPose::preprocess(const InputData& inpu
 }
 
 std::unique_ptr<ResultBase> HPEOpenPose::postprocess(InferenceResult& infResult) {
-    HumanPoseResult* result = new HumanPoseResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+    HumanPoseResult* result = new HumanPoseResult(infResult.frameId, infResult.metaData);
 
     auto outputMapped = infResult.outputsData[outputsNames[0]];
     auto heatMapsMapped = infResult.outputsData[outputsNames[1]];

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -94,10 +94,8 @@ std::shared_ptr<InternalModelData> SegmentationModel::preprocess(const InputData
     return resPtr;
 }
 
-std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infResult)
-{
-    SegmentationResult* result = new SegmentationResult;
-    *static_cast<ResultBase*>(result) = static_cast<ResultBase&>(infResult);
+std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infResult) {
+    SegmentationResult* result = new SegmentationResult(infResult.frameId, infResult.metaData);
 
     const auto& inputImgSize = infResult.internalModelData->asRef<InternalImageModelData>();
 


### PR DESCRIPTION
Initializing results object fields using constructors instead of implicit copying after object instantiation.