### PR TITLE
AC: fix paths storing in annotation meta

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
@@ -302,6 +302,8 @@ def get_conversion_attributes(config, dataset_size):
                     if is_relative_to(value, m_path):
                         break
             conversion_parameters[key] = str(value.relative_to(m_path))
+        if isinstance(value, Path):
+            conversion_parameters[key] = 'PATH/{}'.format(value.name)
 
     subset_size = config.get('subsample_size')
     subset_parameters = {}


### PR DESCRIPTION
when conversion executed via `convert_annotation` script there is no commandline mapping, however paths are still present in annotation parameters. 
Previous solution skips this case and make annotation incompatible to run on different platforms (e.g. convert on linux and run on windows)