### PR TITLE
Enable quantization for set of public models

### DIFF
--- a/data/dataset_definitions.yml
+++ b/data/dataset_definitions.yml
@@ -1167,6 +1167,7 @@ datasets:
       images_dir: nyudepthv2/val/converted/images
       depth_map_dir: nyudepthv2/val/converted/depth
       data_dir: nyudepthv2/val/official
+      allow_convert_data: False
 
   - name: SCUT_EPT
     data_source: SCUT_EPT/test

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -141,3 +141,110 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 ### Datasets in dataset_definitions.yml
 * `VOC2007_detection` used for evaluation models on VOC2007 dataset for object detection task. Background label + label map with 20 object categories are used. (model examples: [`mobilenet-ssd`](../models/public/mobilenet-ssd/README.md), [`ssd300`](../models/public/ssd300/README.md))
 * `VOC2007_detection_no_bkgr` used for evaluation models on VOC2007 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [`yolo-v1-tiny-tf`](../models/public/yolo-v1-tiny-tf/README.md))
+
+## [PASCAL-S](http://cbs.ic.gatech.edu/salobj/)
+
+### How download dataset
+
+To download PASCAL-S dataset, you need to follow the steps below:
+1. Download [archive](http://cbs.ic.gatech.edu/salobj/download/salObj.zip) from the [The Secrets of Salient Object Segmentation](http://cbs.ic.gatech.edu/salobj/) website
+2. Unpack archive
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `PASCAL-S` - directory containing images and salient region masks subdirectories
+    * `image` - directory containing the PASCAL-S images from the directory `datasets/imgs/pascal` in the unpacked archive
+    * `mask` - directory containing the PASCAL-S salient region masks from the directory `datasets/masks/pascal` in the unpacked archive
+
+### Datasets in dataset_definitions.yml
+* `PASCAL-S` used for evaluation models on PASCAL-S dataset for salient object detection task. (model examples: [`f3net`](../models/public/f3net/README.md))
+
+## [CoNLL2003 Named Entity Recognition](https://www.aclweb.org/anthology/W03-0419/)
+
+### How download dataset
+
+To download CoNLL2003 dataset, you need to follow the steps below:
+1. Download [archive](https://data.deepai.org/conll2003.zip) from the [CoNLL 2003 (English) Dataset](https://deepai.org/dataset/conll-2003-english) page in the [DeepAI Datasets](https://deepai.org/datasets) website
+2. Unpack archive
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `CONLL-2003` - directory containing annotation files
+    * `valid.txt` - annotation file for CoNLL2003 validation set
+
+### Datasets in dataset_definitions.yml
+* `CONLL2003_bert_cased` used for evaluation models on CoNLL2003 dataset for named entity recognition task. (model examples: [`bert-base-ner`](../models/public/bert-base-ner/README.md))
+
+## [MRL Eye](http://mrl.cs.vsb.cz/eyedataset)
+
+### How download dataset
+
+To download MRL Eye dataset, you need to follow the steps below:
+1. Download [archive](http://mrl.cs.vsb.cz/data/eyedataset/mrlEyes_2018_01.zip) from the [MRL Eye Dataset](http://mrl.cs.vsb.cz/eyedataset) website
+2. Unpack archive
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `mrlEyes_2018_01` - directory containing subdirectories with dataset images
+
+### Datasets in dataset_definitions.yml
+* `mrlEyes_2018_01` used for evaluation models on MRL Eye dataset for recognition of eye state. (model examples: [`open-closed-eye-0001`](../models/public/open-closed-eye-0001/README.md))
+
+## [Labeled Faces in the Wild (LFW)](http://vis-www.cs.umass.edu/lfw/)
+
+### How download dataset
+
+To download LFW dataset, you need to follow the steps below:
+1. Go to the [Labeled Faces in the Wild](http://vis-www.cs.umass.edu/lfw/) website
+2. Go to the `Download the database` section
+3. Select `All images as gzipped tar file` and download archive
+4. Unpack archive
+5. Go to the `Training, Validation, and Testing` section
+6. Select `pairs.txt` and download pairs file
+7. Download [`lfw_landmark`](https://raw.githubusercontent.com/clcarwin/sphereface_pytorch/master/data/lfw_landmark.txt) file
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `LFW` - directory containing images directories, pairs and landmarks files
+    * `lfw` - directory containing the LFW images
+    * `annotation` - directory containing pairs and landmarks files
+        * `pairs.txt` - file with annotation positive and negative pairs for LFW dataset
+        * `lfw_landmark.txt` - file with facial landmarks coordinates for annotation images of LFW dataset
+
+### Datasets in dataset_definitions.yml
+* `lfw` used for evaluation models on LFW dataset for face recognition task. (model examples: [`Sphereface`](../models/public/Sphereface/README.md))
+
+## [NYU Depth Dataset V2](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html)
+
+### How download dataset
+
+To download NYU Depth Dataset V2 preprocessed data stored in HDF5 format, you need to follow the steps below:
+1. Download [archive](http://datasets.lids.mit.edu/fastdepth/data/nyudepthv2.tar.gz) from the [website](http://datasets.lids.mit.edu/fastdepth/data/)
+2. Unpack archive
+
+### Files layout
+
+To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the following:
+
+* `nyudepthv2/val` - directory with dataset official data and converted images and depth map
+    * `official` - directory with data stored in original hdf5 format
+    * `converted` - directory with converted data
+        * `images` - directory with converted images
+        * `depth` -  directory with depth maps
+
+Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use [convert.py](../tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py) and  following command line to get converted data .
+
+```sh
+convert_annotation nyu_depth_v2 --data_dir <DATASET_DIR>/nyudepthv2/val/official --allow_convert_data True
+```
+
+### Datasets in dataset_definitions.yml
+* `NYU_Depth_V2` used for evaluation models on NYU Depth Dataset V2 for monocular depth estimation task. (model examples: [`fcrn-dp-nyu-depth-v2-tf`](../models/public/fcrn-dp-nyu-depth-v2-tf/README.md))

--- a/models/public/Sphereface/model.yml
+++ b/models/public/Sphereface/model.yml
@@ -35,4 +35,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/Sphereface.caffemodel
   - --input_proto=$dl_dir/Sphereface.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/wy1iu/sphereface/master/LICENSE

--- a/models/public/bert-base-ner/model.yml
+++ b/models/public/bert-base-ner/model.yml
@@ -89,4 +89,5 @@ model_optimizer_args:
   - --input_model=$conv_dir/bert-base-ner.onnx
   - --output=output
 framework: pytorch
+quantizable: yes
 license: https://raw.githubusercontent.com/huggingface/transformers/master/LICENSE

--- a/models/public/bert-base-ner/quantization.yml
+++ b/models/public/bert-base-ner/quantization.yml
@@ -1,0 +1,16 @@
+compression:
+  model_type: transformer
+  algorithms:
+    - name: DefaultQuantization
+      params:
+        preset: mixed
+        stat_subset_size: 300
+        use_fast_bias: False
+        activations:
+          range_estimator:
+            max:
+              aggregator: max
+              type: abs_max
+            min:
+              aggregator: min
+              type: min

--- a/models/public/deeplabv3/model.yml
+++ b/models/public/deeplabv3/model.yml
@@ -32,4 +32,5 @@ model_optimizer_args:
   - --output=ArgMax
   - --input_model=$dl_dir/deeplabv3_mnv2_pascal_train_aug/frozen_inference_graph.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/tensorflow/models/master/LICENSE

--- a/models/public/dla-34/model.yml
+++ b/models/public/dla-34/model.yml
@@ -50,4 +50,5 @@ model_optimizer_args:
   - --output=prob
   - --input_model=$conv_dir/dla-34.onnx
 framework: pytorch
+quantizable: yes
 license: https://raw.githubusercontent.com/ucbdrive/dla/master/LICENSE

--- a/models/public/f3net/model.yml
+++ b/models/public/f3net/model.yml
@@ -69,4 +69,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output="saliency_map"
 framework: pytorch
+quantizable: yes
 license: https://github.com/weijun88/F3Net/blob/master/LICENSE

--- a/models/public/faceboxes-pytorch/model.yml
+++ b/models/public/faceboxes-pytorch/model.yml
@@ -46,4 +46,5 @@ model_optimizer_args:
   - --mean_values=input.1[104.0,117.0,123.0]
   - --output=boxes,scores
 framework: pytorch
+quantizable: yes
 license: https://github.com/zisianw/FaceBoxes.PyTorch/blob/master/LICENSE

--- a/models/public/faster_rcnn_inception_v2_coco/model.yml
+++ b/models/public/faster_rcnn_inception_v2_coco/model.yml
@@ -34,4 +34,5 @@ model_optimizer_args:
   - --tensorflow_object_detection_api_pipeline_config=$dl_dir/faster_rcnn_inception_v2_coco_2018_01_28/pipeline.config
   - --input_model=$dl_dir/faster_rcnn_inception_v2_coco_2018_01_28/frozen_inference_graph.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/tensorflow/models/master/LICENSE

--- a/models/public/faster_rcnn_inception_v2_coco/quantization.yml
+++ b/models/public/faster_rcnn_inception_v2_coco/quantization.yml
@@ -1,0 +1,14 @@
+compression:
+  algorithms:
+    - name: DefaultQuantization
+      params:
+        preset: performance
+        stat_subset_size: 300
+        ignored:
+          scope:
+            - proposals/conv
+        activations:
+          range_estimator:
+            max:
+              aggregator: max
+              type: abs_max

--- a/models/public/fcrn-dp-nyu-depth-v2-tf/model.yml
+++ b/models/public/fcrn-dp-nyu-depth-v2-tf/model.yml
@@ -36,4 +36,5 @@ model_optimizer_args:
   - --input_shape=[1,228,304,3]
   - --output=ConvPred/ConvPred
   - --input_meta=$dl_dir/NYU_FCRN.ckpt.meta
+quantizable: yes
 license: https://raw.githubusercontent.com/iro-cp/FCRN-DepthPrediction/master/LICENSE

--- a/models/public/googlenet-v2-tf/model.yml
+++ b/models/public/googlenet-v2-tf/model.yml
@@ -86,4 +86,5 @@ model_optimizer_args:
   - --input_model=$conv_dir/inception_v2.frozen.pb
   - --reverse_input_channels
 framework: tf
+quantizable: yes
 license: https://github.com/tensorflow/models/blob/master/LICENSE

--- a/models/public/hbonet-0.5/model.yml
+++ b/models/public/hbonet-0.5/model.yml
@@ -43,4 +43,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/hbonet_0_5.onnx
+quantizable: yes
 license: https://github.com/d-li14/HBONet/blob/master/LICENSE

--- a/models/public/hbonet-0.5/quantization.yml
+++ b/models/public/hbonet-0.5/quantization.yml
@@ -1,0 +1,6 @@
+compression:
+  algorithms:
+    - name: DefaultQuantization
+      params:
+        preset: mixed
+        stat_subset_size: 300

--- a/models/public/hbonet-1.0/model.yml
+++ b/models/public/hbonet-1.0/model.yml
@@ -43,4 +43,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=prob
   - --input_model=$conv_dir/hbonet_1_0.onnx
+quantizable: yes
 license: https://github.com/d-li14/HBONet/blob/master/LICENSE

--- a/models/public/mobilefacedet-v1-mxnet/model.yml
+++ b/models/public/mobilefacedet-v1-mxnet/model.yml
@@ -33,4 +33,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/mobilefacedet_v1_mxnet-0000.params
   - --transformations_config=$config_dir/mobileface_det.json
 framework: mxnet
+quantizable: yes
 license: https://raw.githubusercontent.com/becauseofAI/MobileFace/master/LICENSE

--- a/models/public/mobilefacedet-v1-mxnet/quantization.yml
+++ b/models/public/mobilefacedet-v1-mxnet/quantization.yml
@@ -1,0 +1,9 @@
+compression:
+  algorithms:
+    - name: DefaultQuantization
+      params:
+        num_samples_for_tuning: 2000
+        preset: accuracy
+        stat_subset_size: 300
+        use_fast_bias: False
+        use_layerwise_tuning: False

--- a/models/public/mobilenet-ssd/model.yml
+++ b/models/public/mobilenet-ssd/model.yml
@@ -45,4 +45,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/mobilenet-ssd.caffemodel
   - --input_proto=$dl_dir/mobilenet-ssd.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/master/LICENSE

--- a/models/public/nfnet-f0/model.yml
+++ b/models/public/nfnet-f0/model.yml
@@ -63,4 +63,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=probs
 framework: pytorch
+quantizable: yes
 license: https://raw.githubusercontent.com/rwightman/pytorch-image-models/master/LICENSE

--- a/models/public/open-closed-eye-0001/model.yml
+++ b/models/public/open-closed-eye-0001/model.yml
@@ -26,4 +26,5 @@ model_optimizer_args:
   - --scale_values=[255, 255, 255]
   - --output=19
   - --input_model=$dl_dir/open-closed-eye.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/opencv/openvino_training_extensions/develop/LICENSE

--- a/models/public/regnetx-3.2gf/model.yml
+++ b/models/public/regnetx-3.2gf/model.yml
@@ -109,4 +109,5 @@ model_optimizer_args:
   - --output=prob
   - --input_model=$conv_dir/regnetx-3.2gf.onnx
 framework: pytorch
+quantizable: yes
 license: https://raw.githubusercontent.com/facebookresearch/pycls/master/LICENSE

--- a/models/public/retinanet-tf/model.yml
+++ b/models/public/retinanet-tf/model.yml
@@ -30,4 +30,5 @@ model_optimizer_args:
   - --transformations_config=$mo_dir/extensions/front/tf/retinanet.json
   - --input_model=$dl_dir/retinanet_resnet50_coco_best_v2.1.0.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/fizyr/keras-retinanet/master/LICENSE

--- a/models/public/shufflenet-v2-x1.0/model.yml
+++ b/models/public/shufflenet-v2-x1.0/model.yml
@@ -47,4 +47,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --output=output
   - --input_model=$conv_dir/shufflenet-v2-x1.0.onnx
+quantizable: yes
 license: https://raw.githubusercontent.com/pytorch/vision/master/LICENSE

--- a/models/public/ssd300/model.yml
+++ b/models/public/ssd300/model.yml
@@ -57,4 +57,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/models/VGGNet/VOC0712Plus/SSD_300x300_ft/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.caffemodel
   - --input_proto=$dl_dir/models/VGGNet/VOC0712Plus/SSD_300x300_ft/deploy.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/weiliu89/caffe/ssd/LICENSE

--- a/models/public/ssd512/model.yml
+++ b/models/public/ssd512/model.yml
@@ -57,4 +57,5 @@ model_optimizer_args:
   - --input_model=$dl_dir/models/VGGNet/VOC0712Plus/SSD_512x512/VGG_VOC0712Plus_SSD_512x512_iter_240000.caffemodel
   - --input_proto=$dl_dir/models/VGGNet/VOC0712Plus/SSD_512x512/deploy.prototxt
 framework: caffe
+quantizable: yes
 license: https://raw.githubusercontent.com/weiliu89/caffe/ssd/LICENSE

--- a/models/public/ssd_resnet50_v1_fpn_coco/model.yml
+++ b/models/public/ssd_resnet50_v1_fpn_coco/model.yml
@@ -36,4 +36,5 @@ model_optimizer_args:
   - --output=detection_scores,detection_boxes,num_detections
   - --input_model=$dl_dir/ssd_resnet50_v1_fpn_shared_box_predictor_640x640_coco14_sync_2018_07_03/frozen_inference_graph.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/tensorflow/models/master/LICENSE

--- a/models/public/ssh-mxnet/model.yml
+++ b/models/public/ssh-mxnet/model.yml
@@ -32,4 +32,5 @@ model_optimizer_args:
   - --mean_values=data[123.68,116.779,103.939]
   - --reverse_input_channels
 framework: mxnet
+quantizable: yes
 license: https://raw.githubusercontent.com/deepinsight/mxnet-SSH/master/LICENSE

--- a/models/public/ssh-mxnet/model.yml
+++ b/models/public/ssh-mxnet/model.yml
@@ -32,5 +32,4 @@ model_optimizer_args:
   - --mean_values=data[123.68,116.779,103.939]
   - --reverse_input_channels
 framework: mxnet
-quantizable: yes
 license: https://raw.githubusercontent.com/deepinsight/mxnet-SSH/master/LICENSE

--- a/models/public/yolo-v1-tiny-tf/model.yml
+++ b/models/public/yolo-v1-tiny-tf/model.yml
@@ -28,5 +28,6 @@ model_optimizer_args:
   - --reverse_input_channels
   - --transformations_config=$mo_dir/extensions/front/tf/yolo_v2_tiny_voc.json
   - --input_model=$dl_dir/yolo-v1-tiny.pb
+quantizable: yes
 framework: tf
 license: https://raw.githubusercontent.com/shaqian/tfjs-yolo/master/LICENSE

--- a/models/public/yolo-v2-tf/model.yml
+++ b/models/public/yolo-v2-tf/model.yml
@@ -30,5 +30,6 @@ model_optimizer_args:
   - --reverse_input_channels
   - --transformations_config=$mo_dir/extensions/front/tf/yolo_v2.json
   - --input_model=$dl_dir/yolo-v2.pb
+quantizable: yes
 framework: tf
 license: https://raw.githubusercontent.com/david8862/keras-YOLOv3-model-set/master/LICENSE

--- a/models/public/yolo-v3-tiny-tf/model.yml
+++ b/models/public/yolo-v3-tiny-tf/model.yml
@@ -35,5 +35,5 @@ model_optimizer_args:
   - --transformations_config=$dl_dir/yolo-v3-tiny-tf/yolo-v3-tiny-tf.json
   - --input_model=$dl_dir/yolo-v3-tiny-tf/yolo-v3-tiny-tf.pb
 framework: tf
-
+quantizable: yes
 license: https://raw.githubusercontent.com/david8862/keras-YOLOv3-model-set/master/LICENSE

--- a/models/public/yolo-v4-tf/model.yml
+++ b/models/public/yolo-v4-tf/model.yml
@@ -76,4 +76,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --input_model=$conv_dir/yolo-v4.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/david8862/keras-YOLOv3-model-set/master/LICENSE

--- a/models/public/yolo-v4-tf/quantization.yml
+++ b/models/public/yolo-v4-tf/quantization.yml
@@ -1,0 +1,6 @@
+compression:
+  algorithms:
+    - name: DefaultQuantization
+      params:
+        preset: mixed
+        stat_subset_size: 300

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py
@@ -298,7 +298,14 @@ def get_conversion_attributes(config, dataset_size):
                 continue
 
             if isinstance(m_path, list):
-                for m_path in config['_command_line_mapping'][key]:
+                path_list = []
+                for path in m_path:
+                    if isinstance(path, list):
+                        path_list.extend(path)
+                    else:
+                        path_list.append(path)
+
+                for m_path in path_list:
                     if is_relative_to(value, m_path):
                         break
             conversion_parameters[key] = str(value.relative_to(m_path))

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/nyu_depth.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/nyu_depth.py
@@ -1,7 +1,7 @@
 import numpy as np
 import cv2
 
-from ..config import PathField, ConfigError
+from ..config import PathField, ConfigError, BoolField
 from ..utils import contains_all, get_path, check_file_existence, UnsupportedPackage
 from ..representation import DepthEstimationAnnotation
 from ..representation.depth_estimation import GTLoader
@@ -28,33 +28,44 @@ class NYUDepthV2Converter(BaseFormatConverter):
             'data_dir': PathField(
                 is_directory=True, optional=True,
                 description='path to directory with data in original hdf5 format stored'
+            ),
+            'allow_convert_data': BoolField(
+                optional=True, default=True, description="Allows to convert data from hdf5 format"
             )
         })
         return parameters
 
     def configure(self):
         self.data_dir = self.get_value_from_config('data_dir')
-        if self.data_dir is None and not contains_all(self.config, ['images_dir', 'depth_map_dir']):
-            raise ConfigError('data_dir or both images_dir and depth_map_dir should be provided')
+        self.allow_convert_data = self.get_value_from_config('allow_convert_data')
         self.images_dir = self.get_value_from_config('images_dir')
         self.depths_dir = self.get_value_from_config('depth_map_dir')
-        if self.data_dir and isinstance(h5py, UnsupportedPackage):
-            h5py.raise_error(self.__provider__)
-        if self.images_dir is None:
-            self.images_dir = self.data_dir.parent / 'converted/images'
-        if self.depths_dir is None:
-            self.depths_dir = self.data_dir.parent / 'converted/depth'
-        if self.data_dir is None:
-            self.images_dir = get_path(self.images_dir, is_directory=True)
-            self.depths_dir = get_path(self.depths_dir, is_directory=True)
-        else:
+
+        if self.allow_convert_data:
+            if isinstance(h5py, UnsupportedPackage):
+                h5py.raise_error(self.__provider__)
+            if self.data_dir is None:
+                raise ConfigError('please provide data_dir to convert data from hdf5 format')
+
+            if self.images_dir is None:
+                self.images_dir = self.data_dir.parent / 'converted/images'
+            if self.depths_dir is None:
+                self.depths_dir = self.data_dir.parent / 'converted/depth'
+
             if not self.images_dir.exists():
                 self.images_dir.mkdir(parents=True)
             if not self.depths_dir.exists():
                 self.depths_dir.mkdir(parents=True)
 
+        else:
+            if not contains_all(self.config, ['images_dir', 'depth_map_dir']):
+                raise ConfigError('both images_dir and depth_map_dir should be provided')
+            self.images_dir = get_path(self.images_dir, is_directory=True)
+            self.depths_dir = get_path(self.depths_dir, is_directory=True)
+
+
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
-        if self.data_dir is not None:
+        if self.allow_convert_data:
             images_list = self.convert_data()
         else:
             images_list = list(self.images_dir.glob('*.png'))

--- a/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
@@ -180,6 +180,10 @@ def main():
                 reporter.print()
                 continue
 
+            pot_env.update({
+                'MODELS_DIR': str(args.model_dir / model.subdirectory)
+            })
+
             for precision in sorted(requested_precisions):
                 if not quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
                     failed_models.append(model.name)

--- a/tools/downloader/tests/representative-models-quantization.lst
+++ b/tools/downloader/tests/representative-models-quantization.lst
@@ -1,3 +1,6 @@
 # A list of models for testing quantization features.
 
+# default quantization config
 mobilenet-v1-0.25-128
+# custom quantization config
+hbonet-0.5


### PR DESCRIPTION
to extend number of quantized public models extend description of datasets with
[PASCAL-S](http://cbs.ic.gatech.edu/salobj/)
[CoNLL2003 Named Entity Recognition](https://www.aclweb.org/anthology/W03-0419/)
[MRL Eye](http://mrl.cs.vsb.cz/eyedataset)
[Labeled Faces in the Wild (LFW)](http://vis-www.cs.umass.edu/lfw/)
[NYU Depth Dataset V2](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html)
and following models marked as quantizable
Sphereface
bert-base-ner
deeplabv3
dla-34
f3net
faceboxes-pytorch
faster_rcnn_inception_v2_coco
fcrn-dp-nyu-depth-v2-tf
googlenet-v2-tf
hbonet-0.5
hbonet-1.0
mobilefacedet-v1-mxnet
mobilenet-ssd
nfnet-f0
open-closed-eye-0001
regnetx-3.2gf
retinanet-tf
shufflenet-v2-x1.0
ssd300
ssd512
ssd_resnet50_v1_fpn_coco
yolo-v1-tiny-tf
yolo-v2-tf
yolo-v3-tiny-tf
yolo-v4-tf
