### PR TITLE
build_demos_msvc.bat: fix syntax error when %0 contains parentheses

### DIFF
--- a/demos/build_demos_msvc.bat
+++ b/demos/build_demos_msvc.bat
@@ -84,7 +84,8 @@ if "%VS_VERSION%" == "" (
         echo vswhere.exe was not found.
         echo To use Visual Studio autodetection, make sure Visual Studio 2017 version 15.2
         echo or a newer version of Visual Studio is installed. If you'd like to use Visual
-        echo Studio 2015, request it explicitly by running "%0 VS2015".
+        echo Studio 2015, request it explicitly by running:
+        echo     "%~0" VS2015
         goto errorHandling
     )
 


### PR DESCRIPTION
Parentheses are special characters in the Windows command line interpreter, so if `%0` contains them (which will often be the case, given that OpenVINO installs into "C:\Program Files (x86)" by default), its substitution will create a syntax error on the `echo` line.

Normally, quotes suppress processing of special characters, and the substitution of `%0` _was_ in quotes. However, `%0` contains quotes of its own (since you have to quote the batch file path to run it), which end up canceling out the quotes around the substitution.

The solution is to strip the inner quotes from `%0` (by using `%~0` instead), so that the outer quotes can suppress the processing of the parentheses. (I could remove the outer quotes instead, but I'm not sure we can rely upon the inner quotes always being present).

I also change the formatting of the message so that it's clear where the command ends.