### PR TITLE
tools/downloader: dump the information about which models are quantizable

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -435,6 +435,10 @@ describing a single model. Each such object has the following keys:
 
   Additional possible values might be added in the future.
 
+* `quantization_output_precisions`: the list of precisions that the model can be quantized to by
+  the model quantizer. Current possible values are `FP16-INT8` and `FP32-INT8`; additional
+  possible values might be added in the future.
+
 * `subdirectory`: the subdirectory of the output tree into which the downloaded or converted files
   will be placed by the downloader or the converter, respectively.
 

--- a/tools/downloader/src/open_model_zoo/model_tools/_configuration.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/_configuration.py
@@ -254,18 +254,21 @@ class PostprocUnpackArchive(Postproc):
 Postproc.types['unpack_archive'] = PostprocUnpackArchive
 
 class Model:
-    def __init__(self, name, subdirectory, files, postprocessing, mo_args, quantizable, framework,
-                 description, license_url, precisions, task_type, conversion_to_onnx_args):
+    def __init__(
+        self, name, subdirectory, files, postprocessing, mo_args, framework,
+        description, license_url, precisions, quantization_output_precisions,
+        task_type, conversion_to_onnx_args,
+    ):
         self.name = name
         self.subdirectory = subdirectory
         self.files = files
         self.postprocessing = postprocessing
         self.mo_args = mo_args
-        self.quantizable = quantizable
         self.framework = framework
         self.description = description
         self.license_url = license_url
         self.precisions = precisions
+        self.quantization_output_precisions = quantization_output_precisions
         self.task_type = task_type
         self.conversion_to_onnx_args = conversion_to_onnx_args
         self.converter_to_onnx = _common.KNOWN_FRAMEWORKS[framework]
@@ -345,6 +348,8 @@ class Model:
             if not isinstance(quantizable, bool):
                 raise DeserializationError('"quantizable": expected a boolean, got {!r}'.format(quantizable))
 
+            quantization_output_precisions = _common.KNOWN_QUANTIZED_PRECISIONS.keys() if quantizable else set()
+
             description = validate_string('"description"', model['description'])
 
             license_url = validate_string('"license"', model['license'])
@@ -352,8 +357,9 @@ class Model:
             task_type = validate_string_enum('"task_type"', model['task_type'],
                 _common.KNOWN_TASK_TYPES)
 
-            return cls(name, subdirectory, files, postprocessing, mo_args, quantizable, framework,
-                description, license_url, precisions, task_type, conversion_to_onnx_args)
+            return cls(name, subdirectory, files, postprocessing, mo_args, framework,
+                description, license_url, precisions, quantization_output_precisions,
+                task_type, conversion_to_onnx_args)
 
 def load_models(args):
     models = []

--- a/tools/downloader/src/open_model_zoo/model_tools/info_dumper.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/info_dumper.py
@@ -28,6 +28,7 @@ def to_info(model):
         'framework': model.framework,
         'license_url': model.license_url,
         'precisions': sorted(model.precisions),
+        'quantization_output_precisions': sorted(model.quantization_output_precisions),
         'subdirectory': str(model.subdirectory),
         'task_type': str(model.task_type),
     }

--- a/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
@@ -175,8 +175,15 @@ def main():
         }
 
         for model in models:
-            if not model.quantizable:
+            if not model.quantization_output_precisions:
                 reporter.print_section_heading('Skipping {} (quantization not supported)', model.name)
+                reporter.print()
+                continue
+
+            model_precisions = requested_precisions & model.quantization_output_precisions
+
+            if not model_precisions:
+                reporter.print_section_heading('Skipping {} (all precisions skipped)', model.name)
                 reporter.print()
                 continue
 
@@ -184,7 +191,7 @@ def main():
                 'MODELS_DIR': str(args.model_dir / model.subdirectory)
             })
 
-            for precision in sorted(requested_precisions):
+            for precision in sorted(model_precisions):
                 if not quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
                     failed_models.append(model.name)
                     break


### PR DESCRIPTION
This has been long overdue - now the users of the info dumper can determine programmatically which models can be quantized.

Instead of a boolean, we report the quantizer output precisions. This way, we can have different precisions per model in the future. Similarly for the added `if` in the quantizer - it's currently useless, as there's no way to skip every precision for a model, but if some model has an unusual set of output precisions in the future, that will become a possibility.

The name `quantization_output_precisions` is a bit bulky, but I thought that if it was called just `quantization_precisions`, it would be unclear whether that was referring to input or output precisions.