### PR TITLE
tools/downloader/tests/representative-models.lst: add hbonet-0.5

### DIFF
--- a/tools/downloader/tests/representative-models.lst
+++ b/tools/downloader/tests/representative-models.lst
@@ -1,6 +1,7 @@
 # A list of models that covers all Model Downloader/Converter features
 
 faceboxes-pytorch # PyTorch (external module), Google Drive downloads, --model-param
+hbonet-0.5 # used for quantization testing
 mobilenet-v1-0.25-128 # TensorFlow, HTTP downloads
 mobilenet-v2-pytorch # PyTorch (torchvision)
 mtcnn-p # Caffe, HTTPS downloads, regex replacement


### PR DESCRIPTION
It's in `representative-models-quantization.lst`, but for it to be quantized, it has to be downloaded/converted first, and the CI scripts use this file to select models for downloading and conversion.