### PR TITLE
Model Converter: try to run Model Optimizer as a package

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -260,13 +260,31 @@ option:
 
 If the specified precision is not supported for a model, that model will be skipped.
 
-The script will attempt to locate Model Optimizer using the environment
-variables set by the OpenVINO&trade; toolkit's `setupvars.sh`/`setupvars.bat`
-script. You can override this heuristic with the `--mo` option:
+By default, the script will run Model Optimizer using the same Python executable
+that was used to run the script itself. To use a different Python executable,
+use the `-p`/`--python` option:
 
 ```sh
-./converter.py --all --mo my/openvino/path/model_optimizer/mo.py
+./converter.py --all --python my/python
 ```
+
+The script will attempt to locate Model Optimizer using several methods:
+
+1. If the `--mo` option was specified, then its value will be used as the path
+   to the script to run:
+
+   ```sh
+   ./converter.py --all --mo my/openvino/path/model_optimizer/mo.py
+   ```
+
+2. Otherwise, if the selected Python executable can import the `mo` package,
+   then that package will be used.
+
+3. Otherwise, if the OpenVINO&trade; toolkit's `setupvars.sh`/`setupvars.bat`
+   script has been executed, the environment variables set by that script will
+   be used to locate Model Optimizer within the toolkit.
+
+4. Otherwise, the script will fail.
 
 You can add extra Model Optimizer arguments to the ones specified in the model
 configuration by using the `--add_mo_arg` option. The option can be repeated
@@ -274,14 +292,6 @@ to add multiple arguments:
 
 ```sh
 ./converter.py --name=caffenet --add_mo_arg=--reverse_input_channels --add_mo_arg=--silent
-```
-
-By default, the script will run Model Optimizer using the same Python executable
-that was used to run the script itself. To use a different Python executable,
-use the `-p`/`--python` option:
-
-```sh
-./converter.py --all --python my/python
 ```
 
 The script can run multiple conversion commands concurrently. To enable this,


### PR DESCRIPTION
If our tools are installed as part of the `openvino-dev` distribution, then it doesn't make sense to ask the user to run `setupvars`, seeing as:

1. It doesn't exist.
2. We know that MO is installed as part of the same distribution.

Therefore, before trying to find MO the old way, try to locate its package and if that succeeds, run it as a package.

I moved the documentation for the `-p` option up, because I'm referencing its value in the documentation for the `--mo` option.

`get_package_path` is in `_common`, because we're likely going to implement the same thing in the quantizer (for POT).