### PR TITLE
add OpenVINO Training Extensions links

### DIFF
--- a/models/intel/face-detection-0200/README.md
+++ b/models/intel/face-detection-0200/README.md
@@ -46,5 +46,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/face-detection-0202/README.md
+++ b/models/intel/face-detection-0202/README.md
@@ -46,5 +46,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/face-detection-0204/README.md
+++ b/models/intel/face-detection-0204/README.md
@@ -46,5 +46,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/face-detection-0205/README.md
+++ b/models/intel/face-detection-0205/README.md
@@ -47,5 +47,10 @@ Expected color order: `BGR`.
 2. The `labels` is a blob with the shape `200` in the format `N`, where `N` is the number of detected
    bounding boxes. It contains predicted class ID (0 - face) per each detected box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/face-detection-0206/README.md
+++ b/models/intel/face-detection-0206/README.md
@@ -47,5 +47,10 @@ Expected color order: `BGR`.
 2. The `labels` is a blob with the shape `750` in the format `N`, where `N` is the number of detected
    bounding boxes. It contains predicted class ID (0 - face) per each detected box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/horizontal-text-detection-0001/README.md
+++ b/models/intel/horizontal-text-detection-0001/README.md
@@ -42,5 +42,10 @@ Expected color order - `BGR`.
 2. The `labels` is a blob with the shape `100` in the format `N`, where `N` is the number of detected
    bounding boxes. In case of text detection, it is equal to `0` for each detected box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/horizontal-text-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-0002/README.md
+++ b/models/intel/instance-segmentation-security-0002/README.md
@@ -38,13 +38,17 @@ The expected channel order is `BGR`.
 
 ## Outputs
 
-1.	Name: `labels`, shape: `100` - Contiguous integer class ID for every
-    detected object.
-2.	Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
-    in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
-    confidence score in range [0, 1].
-3.	Name: `masks`, shape: `100, 28, 28` - Segmentation heatmaps for every output
-    bounding box.
+1. Name: `labels`, shape: `100` - Contiguous integer class ID for every
+   detected object.
+2. Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
+   in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
+   confidence score in range [0, 1].
+3. Name: `masks`, shape: `100, 28, 28` - Segmentation heatmaps for every output
+   bounding box.
+
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-0091/README.md
+++ b/models/intel/instance-segmentation-security-0091/README.md
@@ -38,12 +38,12 @@ The expected channel order is `BGR`
 
 ## Outputs
 
-1.	Name: `labels`, shape: `100` - Contiguous integer class ID for every
-    detected object.
-2.	Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
-    in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
-    confidence score in range [0, 1].
-3.	Name: `masks`, shape: `100, 28, 28]` - Segmentation heatmaps for every output
+1. Name: `labels`, shape: `100` - Contiguous integer class ID for every
+   detected object.
+2. Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
+   in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
+   confidence score in range [0, 1].
+3. Name: `masks`, shape: `100, 28, 28]` - Segmentation heatmaps for every output
     bounding box.
 
 ## Training Pipeline

--- a/models/intel/instance-segmentation-security-0091/README.md
+++ b/models/intel/instance-segmentation-security-0091/README.md
@@ -46,5 +46,10 @@ The expected channel order is `BGR`
 3.	Name: `masks`, shape: `100, 28, 28]` - Segmentation heatmaps for every output
     bounding box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-0228/README.md
+++ b/models/intel/instance-segmentation-security-0228/README.md
@@ -36,13 +36,13 @@ The expected channel order is `BGR`
 
 ## Outputs
 
-1.	Name: `labels`, shape: `100` - Contiguous integer class ID for every
-    detected object.
-2.	Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
-    in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
-    confidence score in range [0, 1].
-3.	Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
-    bounding box.
+1. Name: `labels`, shape: `100` - Contiguous integer class ID for every
+   detected object.
+2. Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
+   in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
+   confidence score in range [0, 1].
+3. Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
+   bounding box.
 
 ## Training Pipeline
 

--- a/models/intel/instance-segmentation-security-0228/README.md
+++ b/models/intel/instance-segmentation-security-0228/README.md
@@ -44,5 +44,10 @@ The expected channel order is `BGR`
 3.	Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
     bounding box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-1039/README.md
+++ b/models/intel/instance-segmentation-security-1039/README.md
@@ -36,13 +36,13 @@ The expected channel order is `BGR`
 
 ## Outputs
 
-1.	Name: `labels`, shape: `100` - Contiguous integer class ID for every
-    detected object.
-2.	Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
-    in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
-    confidence score in range [0, 1].
-3.	Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
-    bounding box.
+1. Name: `labels`, shape: `100` - Contiguous integer class ID for every
+   detected object.
+2. Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
+   in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
+   confidence score in range [0, 1].
+3. Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
+   bounding box.
 
 ## Training Pipeline
 

--- a/models/intel/instance-segmentation-security-1039/README.md
+++ b/models/intel/instance-segmentation-security-1039/README.md
@@ -44,5 +44,10 @@ The expected channel order is `BGR`
 3.	Name: `masks`, shape: `100, 14, 14` - Segmentation heatmaps for every output
     bounding box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-1040/README.md
+++ b/models/intel/instance-segmentation-security-1040/README.md
@@ -36,13 +36,13 @@ The expected channel order is `BGR`
 
 ## Outputs
 
-1.	Name: `labels`, shape: `100` - Contiguous integer class ID for every
-    detected object.
-2.	Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
-    in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
-    confidence score in range [0, 1].
-3.	Name: `masks`, shape: `100, 28, 28` - Segmentation heatmaps for every output
-    bounding box.
+1. Name: `labels`, shape: `100` - Contiguous integer class ID for every
+   detected object.
+2. Name: `boxes`, shape: `100, 5` - Bounding boxes around every detected objects
+   in (top_left_x, top_left_y, bottom_right_x, bottom_right_y) format and its
+   confidence score in range [0, 1].
+3. Name: `masks`, shape: `100, 28, 28` - Segmentation heatmaps for every output
+   bounding box.
 
 ## Training Pipeline
 

--- a/models/intel/instance-segmentation-security-1040/README.md
+++ b/models/intel/instance-segmentation-security-1040/README.md
@@ -44,5 +44,10 @@ The expected channel order is `BGR`
 3.	Name: `masks`, shape: `100, 28, 28` - Segmentation heatmaps for every output
     bounding box.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-detection-0200/README.md
+++ b/models/intel/person-detection-0200/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-detection-0201/README.md
+++ b/models/intel/person-detection-0201/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-detection-0202/README.md
+++ b/models/intel/person-detection-0202/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-detection-0203/README.md
+++ b/models/intel/person-detection-0203/README.md
@@ -46,5 +46,10 @@ Expected color order is `BGR`.
 2. The `labels` is a blob with the shape `100` in the format `N`, where `N` is the number of detected
    bounding boxes. In case of person detection, it is equal to `1` for each detected box with person in it and `0` for the background.
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-vehicle-bike-detection-2000/README.md
+++ b/models/intel/person-vehicle-bike-detection-2000/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-vehicle-bike-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-vehicle-bike-detection-2001/README.md
+++ b/models/intel/person-vehicle-bike-detection-2001/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-vehicle-bike-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-vehicle-bike-detection-2002/README.md
+++ b/models/intel/person-vehicle-bike-detection-2002/README.md
@@ -41,5 +41,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-vehicle-bike-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-vehicle-bike-detection-2003/README.md
+++ b/models/intel/person-vehicle-bike-detection-2003/README.md
@@ -47,5 +47,10 @@ Expected color order is `BGR`.
    bounding boxes. The value of each label is equal to predicted class ID
    (0 - vehicle, 1 - person, 2 - non-vehicle).
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-vehicle-bike-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/person-vehicle-bike-detection-2004/README.md
+++ b/models/intel/person-vehicle-bike-detection-2004/README.md
@@ -47,5 +47,10 @@ Expected color order is `BGR`.
    bounding boxes. The value of each label is equal to predicted class ID
    (0 - vehicle, 1 - person, 2 - non-vehicle).
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-vehicle-bike-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/text-spotting-0004/README.md
+++ b/models/intel/text-spotting-0004/README.md
@@ -42,17 +42,17 @@ The text-spotting-0004-detector model is a Mask-RCNN-based text detector with Re
 
     The expected channel order is `BGR`.
 
-2.	Name: `im_info`, shape: `1, 3`. Image information: processed image height,
-    processed image width, and processed image scale with respect to the original image resolution.
+2. Name: `im_info`, shape: `1, 3`. Image information: processed image height,
+   processed image width, and processed image scale with respect to the original image resolution.
 
 ### Outputs
 
-1.	Name: `labels`, shape: `100`. Contiguous integer class ID for every
-    detected object, `0` is for text class.
-2.	Name: `boxes`, shape: `100, 5`. Bounding boxes around every detected object
-    in the (top_left_x, top_left_y, bottom_right_x, bottom_right_y, confidence) format.
-3.	Name: `masks`, shape: `100, 28, 28`. Text segmentation masks for every output bounding box.
-4.  Name: `text_features.0`, shape `100, 64, 28, 28`. Text features that are fed to a text recognition head.
+1. Name: `labels`, shape: `100`. Contiguous integer class ID for every
+   detected object, `0` is for text class.
+2. Name: `boxes`, shape: `100, 5`. Bounding boxes around every detected object
+   in the (top_left_x, top_left_y, bottom_right_x, bottom_right_y, confidence) format.
+3. Name: `masks`, shape: `100, 28, 28`. Text segmentation masks for every output bounding box.
+4. Name: `text_features.0`, shape `100, 64, 28, 28`. Text features that are fed to a text recognition head.
 
 ## Encoder model specification
 
@@ -80,15 +80,20 @@ Name: `output`, shape: `1, 256, 28, 28`. Encoded text recognition features.
 
 ### Inputs
 
-1.	Name: `encoder_outputs`, shape: `1, (28*28), 256`. Encoded text recognition features.
-2.	Name: `prev_symbol`, shape: `1, 1`. Index in alphabet of previously generated symbol.
-3.	Name: `prev_hidden`, shape: `1, 1, 256`. Previous hidden state of GRU.
+1. Name: `encoder_outputs`, shape: `1, (28*28), 256`. Encoded text recognition features.
+2. Name: `prev_symbol`, shape: `1, 1`. Index in alphabet of previously generated symbol.
+3. Name: `prev_hidden`, shape: `1, 1, 256`. Previous hidden state of GRU.
 
 ### Outputs
 
-1.	Name: `output`, shape: `1, 38`. Encoded text recognition features. Indices starting from 2 correspond to symbols from the
+1. Name: `output`, shape: `1, 38`. Encoded text recognition features. Indices starting from 2 correspond to symbols from the
 alphabet. The 0 and 1 are special Start of Sequence and End of Sequence symbols correspondingly.
-2.	Name: `hidden`, shape: `1, 1, 256`. Current hidden state of GRU.
+2. Name: `hidden`, shape: `1, 1, 256`. Current hidden state of GRU.
+
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/text_spotting/model_templates/alphanumeric-text-spotting/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/vehicle-detection-0200/README.md
+++ b/models/intel/vehicle-detection-0200/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/vehicle-detection-0201/README.md
+++ b/models/intel/vehicle-detection-0201/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/vehicle-detection-0202/README.md
+++ b/models/intel/vehicle-detection-0202/README.md
@@ -45,5 +45,10 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 
+## Training Pipeline
+
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+
 ## Legal Information
+
 [*] Other names and brands may be claimed as the property of others.


### PR DESCRIPTION
Add links in model descriptions to OpenVINO Training Extensions, where applicable
- [x] instance-segmentation-security-0002/0091/0228/1039/1040
- [x] face-detection-0200/0202/0204/0205/0206/0207
- [x] horizontal-text-detection-0001
- [x] person-detection-0200/0201/0202/0203
- [x] person-vehicle-bike-detection-2000/2001/2002/2003/2004
- [x] vehicle-detection-0200/0201/0202
- [x] text-spotting-0004