### PR TITLE
tools/downloader: consistently represent hashes as bytes objects

### DIFF
--- a/tools/downloader/src/open_model_zoo/model_tools/_configuration.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/_configuration.py
@@ -176,11 +176,13 @@ class ModelFile:
         with deserialization_context('In file "{}"'.format(name)):
             size = validate_nonnegative_int('"size"', file['size'])
 
-            sha256 = validate_string('"sha256"', file['sha256'])
+            sha256_str = validate_string('"sha256"', file['sha256'])
 
-            if not RE_SHA256SUM.fullmatch(sha256):
+            if not RE_SHA256SUM.fullmatch(sha256_str):
                 raise DeserializationError(
-                    '"sha256": got invalid hash {!r}'.format(sha256))
+                    '"sha256": got invalid hash {!r}'.format(sha256_str))
+
+            sha256 = bytes.fromhex(sha256_str)
 
             with deserialization_context('"source"'):
                 source = FileSource.deserialize(file['source'])


### PR DESCRIPTION
Historically, hashes have sometimes been represented as bytes and sometimes as character strings. Fundamentally, however, hashes are bytestrings, so represent them as such internally and convert them from/to strings when doing input/output.