### PR TITLE
resnest-50-pytorch: replace weights download link again

### DIFF
--- a/models/public/resnest-50-pytorch/model.yml
+++ b/models/public/resnest-50-pytorch/model.yml
@@ -30,8 +30,7 @@ files:
   - name: resnest50-528c19ca.pth
     sha256: 528c19ca6509420548c8359f63ff37975e7d92f42eaf72a7af152a015c8ef48c
     size: 110273258
-    # see https://github.com/zhanghang1989/ResNeSt/issues/152
-    source: https://dl.dropboxusercontent.com/s/fi72lae1exon3o4/resnest50-528c19ca.pth?dl=0
+    source: https://github.com/zhanghang1989/ResNeSt/releases/download/weights_step1/resnest50-528c19ca.pth
   - name: model/resnest.py
     size: 2908
     sha256: ef4629dca658fb7b52dff05ca6b4cdd2f62eae387a67c8f3036e58aaf23955d1


### PR DESCRIPTION
The Dropbox upload was evidently temporary, as the repository author has now uploaded the weights as GitHub release artifacts (zhanghang1989/ResNeSt#156).