### PR TITLE
demos: assign default value for scaleFactor

### DIFF
--- a/demos/common/cpp/utils/include/utils/ocv_common.hpp
+++ b/demos/common/cpp/utils/include/utils/ocv_common.hpp
@@ -113,7 +113,7 @@ inline void putHighlightedText(cv::Mat& frame,
 
 class OutputTransform {
     public:
-        OutputTransform() : doResize(false) {}
+        OutputTransform() : doResize(false), scaleFactor(1) {}
 
         OutputTransform(cv::Size inputSize, cv::Size outputResolution) :
             doResize(true), inputSize(inputSize), outputResolution(outputResolution) {}


### PR DESCRIPTION
A code analyzer was worried that `scaleFactor` was uninitialized. We
never use it in such cases, but the fix is simple, so let it be.