### PR TITLE
Fixed broken <omz_dir> links.

### DIFF
--- a/models/public/aclnet-int8/README.md
+++ b/models/public/aclnet-int8/README.md
@@ -3,7 +3,7 @@
 ## Use Case and High-Level Description
 
 The `AclNet-int8` model is quantized and fine-tuned with NNCF variant of [AclNet](../aclnet/README.md) model, which is designed to perform sound classification.
-The `AclNet-int8` model is trained on an internal dataset of environmental sounds for 53 different classes, listed in file `<omz_dir>/data/dataset_classes/aclnet.txt`.
+The `AclNet-int8` model is trained on an internal dataset of environmental sounds for 53 different classes, listed in file `<omz_dir>/data/dataset_classes/aclnet_53cl.txt`.
 For details about the model, see this [paper](https://arxiv.org/abs/1811.06669).
 
 The model input is a segment of PCM audio samples in `N, C, 1, L` format.

--- a/models/public/aclnet/README.md
+++ b/models/public/aclnet/README.md
@@ -2,7 +2,7 @@
 
 ## Use Case and High-Level Description
 
-The `AclNet` model is designed to perform sound classification and is trained on internal dataset of environmental sounds for 53 different classes, listed in file `<omz_dir>/data/dataset_classes/aclnet.txt`.
+The `AclNet` model is designed to perform sound classification and is trained on internal dataset of environmental sounds for 53 different classes, listed in file `<omz_dir>/data/dataset_classes/aclnet_53cl.txt`.
 For details about the model, see this [paper](https://arxiv.org/abs/1811.06669).
 
 The model input is a segment of PCM audio samples in `N, C, 1, L` format.

--- a/models/public/ctdet_coco_dlav0_384/README.md
+++ b/models/public/ctdet_coco_dlav0_384/README.md
@@ -49,7 +49,7 @@ Expected color order: `BGR`.
 
 ## Output
 
-1. Object center points heatmap, name: `center_heatmap`. Contains predicted objects center point, for each of the 80 categories, according to [Common Objects in Context (COCO)](https://cocodataset.org/#home) dataset version with 80 categories of objects, without background label, mapping to class names provided in `<omz_dir>/data/dataset_classes/coco_00cl.txt` file.
+1. Object center points heatmap, name: `center_heatmap`. Contains predicted objects center point, for each of the 80 categories, according to [Common Objects in Context (COCO)](https://cocodataset.org/#home) dataset version with 80 categories of objects, without background label, mapping to class names provided in `<omz_dir>/data/dataset_classes/coco_80cl.txt` file.
 2. Object size output, name: `width_height`. Contains predicted width and height for each object.
 3. Regression output, name: `regression`. Contains offsets for each prediction.
 


### PR DESCRIPTION
Fixed broken <omz_dir> links to files with datasets classes (`aclnet_53cl.txt` and `coco_80cl.txt`).