### PR TITLE
fix multi channel demo description

### DIFF
--- a/demos/multi_channel_common/cpp/multichannel_params.hpp
+++ b/demos/multi_channel_common/cpp/multichannel_params.hpp
@@ -12,9 +12,9 @@ static const char help_message[] = "Print a usage message";
 static const char input_message[] = "Required. A comma separated list of inputs to process. Each input must be a "
     "single image, a folder of images or anything that cv::VideoCapture can process.";
 static const char loop_message[] = "Optional. Enable reading the inputs in a loop.";
-static const char duplication_channel_number_message[] = "Optional. Multiply the inputs by the given factor. For "
-    "example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel"
-    " and duplicated the same data as the second input channel.";
+static const char duplication_channel_number_message[] = "Optional. Multiply the inputs by the given factor."
+    " For example, if only one input is provided, but -duplicate_num is set to 2, the demo will split real input across channels,"
+    " by interleaving frames between channels."
 static const char model_path_message[] = "Required. Path to an .xml file with a trained model.";
 static const char target_device_message[] = "Optional. Specify the target device for a network (the list of available devices is shown below). "
                                             "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "

--- a/demos/multi_channel_common/cpp/multichannel_params.hpp
+++ b/demos/multi_channel_common/cpp/multichannel_params.hpp
@@ -14,7 +14,7 @@ static const char input_message[] = "Required. A comma separated list of inputs 
 static const char loop_message[] = "Optional. Enable reading the inputs in a loop.";
 static const char duplication_channel_number_message[] = "Optional. Multiply the inputs by the given factor."
     " For example, if only one input is provided, but -duplicate_num is set to 2, the demo will split real input across channels,"
-    " by interleaving frames between channels."
+    " by interleaving frames between channels.";
 static const char model_path_message[] = "Required. Path to an .xml file with a trained model.";
 static const char target_device_message[] = "Optional. Specify the target device for a network (the list of available devices is shown below). "
                                             "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "

--- a/demos/multi_channel_common/cpp/multichannel_params.hpp
+++ b/demos/multi_channel_common/cpp/multichannel_params.hpp
@@ -13,8 +13,8 @@ static const char input_message[] = "Required. A comma separated list of inputs 
     "single image, a folder of images or anything that cv::VideoCapture can process.";
 static const char loop_message[] = "Optional. Enable reading the inputs in a loop.";
 static const char duplication_channel_number_message[] = "Optional. Multiply the inputs by the given factor. For "
-    "example, if only one input is provided, but -ni is set to 2, the demo uses half of images from the input as it was"
-    " the first input and another half goes as the second input.";
+    "example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel"
+    " and duplicated the same data as the second input channel.";
 static const char model_path_message[] = "Required. Path to an .xml file with a trained model.";
 static const char target_device_message[] = "Optional. Specify the target device for a network (the list of available devices is shown below). "
                                             "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "

--- a/demos/multi_channel_face_detection_demo/cpp/README.md
+++ b/demos/multi_channel_face_detection_demo/cpp/README.md
@@ -76,7 +76,7 @@ Video files will be processed simultaneously.
 
 ### Input Video Sources
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
+General parameter for input source is `-i`. You can run the demo on web cameras and video files simultaneously by specifying: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source (a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 4`. You will see four channels. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
 Below are some examples of demo input specification:
 

--- a/demos/multi_channel_face_detection_demo/cpp/README.md
+++ b/demos/multi_channel_face_detection_demo/cpp/README.md
@@ -39,7 +39,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo will split real input across channels, by interleaving frames between channels.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or

--- a/demos/multi_channel_face_detection_demo/cpp/README.md
+++ b/demos/multi_channel_face_detection_demo/cpp/README.md
@@ -39,7 +39,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -ni is set to 2, the demo uses half of images from the input as it was the first input and another half goes as the second input.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or
@@ -58,32 +58,31 @@ Options:
     -u                           Optional. List of monitors to show initially.
 ```
 
+Running the application with an empty list of options yields the usage message given above and an error message.
+
 For example, to run the demo with the pre-trained face detection model on CPU, with one single camera, use the following command:
 
 ```sh
-./multi_channel_face_detection_demo -m <path_to_model>/face-detection-retail-0004.xml -d CPU -nc 1
+./multi_channel_face_detection_demo -m <path_to_model>/face-detection-retail-0004.xml -d CPU -i 0
 ```
 
 To run the demo using two recorded video files, use the following command:
 
 ```sh
-./multi_channel_face_detection_demo -m <path_to_model>/face-detection-retail-0004.xml -d CPU -i <path_to_file>/file1 <path_to_file>/file2
+./multi_channel_face_detection_demo -m <path_to_model>/face-detection-retail-0004.xml -d CPU -i <path_to_file>/file1,<path_to_file>/file2
 ```
 
-Video files will be processed repeatedly.
+Video files will be processed simultaneously.
 
 ### Input Video Sources
 
-You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-nc <number_of_cams> -i <video_file1> <video_file2>` with paths to video files separated by a space.
-To run the demo with a single input source (a web camera or a video file), but several channels, specify an additional parameter: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
+General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can add the parameter to a sample command line as follows:
+Below are some examples of demo input specification:
 
 ```sh
--i <file1> <file2>
+-i <file1>,<file2>
 ```
-
-`-nc <nc_value>` parameter simplifies usage of multiple web cameras. It connects web cameras with indexes from `0` to `nc_value-1`.
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
@@ -95,17 +94,13 @@ user@user-PC:~ $ ls /dev/video*
 You can use `-i` option to connect all the three web cameras:
 
 ```sh
--i /dev/video0  /dev/video1  /dev/video2
+-i 0,1,2
 ```
-
-Alternatively, you can just set `-nc 3`, which simplifies application usage.
-
-If your cameras are connected to PC with indexes gap (for example, `0,1,3`), use the `-i` parameter.
 
 To connect to IP cameras, use RTSP URIs:
 
 ```sh
--i rtsp://camera_address_1/ rtsp://camera_address_2/
+-i rtsp://camera_address_1/,rtsp://camera_address_2/
 ```
 
 ## Demo Output

--- a/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
+++ b/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
@@ -75,7 +75,7 @@ Video files will be processed simultaneously.
 
 ### Input Video Sources
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
+General parameter for input source is `-i`. You can run the demo on web cameras and video files simultaneously by specifying: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source (a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 4`. You will see four channels. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
 Below are some examples of demo input specification:
 

--- a/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
+++ b/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
@@ -39,7 +39,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo will split real input across channels, by interleaving frames between channels.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or

--- a/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
+++ b/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
@@ -39,7 +39,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -ni is set to 2, the demo uses half of images from the input as it was the first input and another half goes as the second input.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or
@@ -62,29 +62,26 @@ Running the application with an empty list of options yields the usage message g
 For example, to run the demo with the pre-trained Human Pose Estimation model on CPU with one camera, use the following command:
 
 ```sh
-./multi_channel_human_pose_estimation_demo -m <path_to_model>/human-pose-estimation-0001.xml -d CPU -nc 1
+./multi_channel_human_pose_estimation_demo -m <path_to_model>/human-pose-estimation-0001.xml -d CPU -i 0
 ```
 
 To run the demo using two recorded video files, use the following command:
 
 ```sh
-./multi_channel_human_pose_estimation_demo -m <path_to_model>/human-pose-estimation-0001.xml -d CPU -i <path_to_file>/file1 <path_to_file>/file2
+./multi_channel_human_pose_estimation_demo -m <path_to_model>/human-pose-estimation-0001.xml -d CPU -i <path_to_file>/file1,<path_to_file>/file2
 ```
 
-Video files will be processed repeatedly.
+Video files will be processed simultaneously.
 
 ### Input Video Sources
 
-You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-nc <number_of_cams> -i <video_file1> <video_file2>` with paths to video files separated by a space.
-To run the demo with a single input source (a web camera or a video file), but several channels, specify an additional parameter: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate channels for each of them.
+General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can add the parameter to a sample command line as follows:
+Below are some examples of demo input specification:
 
 ```sh
--i <file1> <file2>
+-i <file1>,<file2>
 ```
-
-`-nc <nc_value>` parameter simplifies usage of multiple web cameras. It connects web cameras with indexes from `0` to `nc_value-1`.
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
@@ -96,17 +93,13 @@ user@user-PC:~ $ ls /dev/video*
 You can use `-i` option to connect all the three web cameras:
 
 ```sh
--i /dev/video0  /dev/video1  /dev/video2
+-i 0,1,2
 ```
-
-Alternatively, you can just set `-nc 3`, which simplifies application usage.
-
-If your cameras are connected to PC with indexes gap (for example, `0,1,3`), use the `-i` parameter.
 
 To connect to IP cameras, use RTSP URIs:
 
 ```sh
--i rtsp://camera_address_1/ rtsp://camera_address_2/
+-i rtsp://camera_address_1/,rtsp://camera_address_2/
 ```
 
 ## Demo Output

--- a/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
+++ b/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
@@ -37,7 +37,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo will split real input across channels, by interleaving frames between channels.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or

--- a/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
+++ b/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
@@ -81,7 +81,7 @@ To achieve 100% utilization of one Myriad X, the rule of thumb is to run 4 infer
 
 ### Input Video Sources
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
+General parameter for input source is `-i`. You can run the demo on web cameras and video files simultaneously by specifying: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source (a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 4`. You will see four channels. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
 Below are some examples of demo input specification:
 

--- a/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
+++ b/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
@@ -37,7 +37,7 @@ Options:
     -h                           Print a usage message
     -i                           Required. A comma separated list of inputs to process. Each input must be a single image, a folder of images or anything that cv::VideoCapture can process.
     -loop                        Optional. Enable reading the inputs in a loop.
-    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -ni is set to 2, the demo uses half of images from the input as it was the first input and another half goes as the second input.
+    -duplicate_num               Optional. Multiply the inputs by the given factor. For example, if only one input is provided, but -duplicate_num is set to 2, the demo uses real input as the first input channel and duplicated the same data as the second input channel.
     -m "<path>"                  Required. Path to an .xml file with a trained model.
       -l "<absolute_path>"       Required for CPU custom layers. Absolute path to a shared library with the kernel implementations
           Or
@@ -56,39 +56,38 @@ Options:
     -u                           Optional. List of monitors to show initially.
 ```
 
+Running the application with an empty list of options yields the usage message given above and an error message.
+
 For example, to run the demo on CPU, with one single camera, use the following command:
 
 ```sh
-./multi_channel_object_detection_demo_yolov3 -m <path_to_model>/model.xml -d CPU -nc 1
+./multi_channel_object_detection_demo_yolov3 -m <path_to_model>/model.xml -d CPU -i 0
 ```
 
 To run the demo on HDDL, using two recorded video files, use the following command:
 
 ```sh
-./multi_channel_object_detection_demo_yolov3 -m <path_to_mdel>/model.xml -d HDDL -i <path_to_file>/file1 <path_to_file>/file2
+./multi_channel_object_detection_demo_yolov3 -m <path_to_mdel>/model.xml -d HDDL -i <path_to_file>/file1,<path_to_file>/file2
 ```
 
-Video files will be processed repeatedly.
+Video files will be processed simultaneously.
 
 To achieve 100% utilization of one Myriad X, the rule of thumb is to run 4 infer requests on each Myriad X. Option `-nireq 32` can be added to above command to use 100% of HDDL-R card. The 32 here is 8 (Myriad X on HDDL-R card) x 4 (infer requests), such as following command:
 
 ```sh
 ./multi_channel_object_detection_demo_yolov3 -m <path_to_model>/model.xml -d HDDL
--i <path_to_file>/file1 <path_to_file>/file2 <path_to_file>/file3 <path_to_file>/file4 -nireq 32
+-i <path_to_file>/file1,<path_to_file>/file2,<path_to_file>/file3,<path_to_file>/file4 -nireq 32
 ```
 
 ### Input Video Sources
 
-You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-nc <number of cams> -i <video files sequentially, separated by space>`.
-To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
+General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can also run the demo on web cameras and video files simultaneously by specifying both parameters: `-i <webcam_id0>,<webcam_id1>,<video_file1>,<video_file2>` with paths to webcams and video files separated by a comma. To run the demo with a single input source(a web camera or a video file), but several channels, specify an additional parameter, `duplicate_num`, for example: `-duplicate_num 3`. You will see four channels: one real and three duplicated. With several input sources, the `-duplicate_num` parameter will duplicate each of them.
 
-General parameter for input video source is `-i`. Use it to specify video files or web cameras as input video sources. You can add the parameter to a sample command line as follows:
+Below are some examples of demo input specification:
 
 ```sh
--i <file1> <file2>
+-i <file1>,<file2>
 ```
-
-`-nc <nc_value>` parameter simplifies usage of multiple web cameras. It connects web cameras with indexes from `0` to `nc_value-1`.
 
 To see all available web cameras, run the `ls /dev/video*` command. You will get output similar to the following:
 
@@ -100,17 +99,13 @@ user@user-PC:~ $ ls /dev/video*
 You can use `-i` option to connect all the three web cameras:
 
 ```sh
--i /dev/video0  /dev/video1  /dev/video2
+-i 0,1,2
 ```
-
-Alternatively, you can just set `-nc 3`, which simplifies application usage.
-
-If your cameras are connected to PC with indexes gap (for example, `0,1,3`), use the `-i` parameter.
 
 To connect to IP cameras, use RTSP URIs:
 
 ```sh
--i rtsp://camera_address_1/ rtsp://camera_address_2/
+-i rtsp://camera_address_1/,rtsp://camera_address_2/
 ```
 
 ## Demo Output


### PR DESCRIPTION
fix multi-channel demos `-i` option description, missed at 7916a098af33203c64a0d184dd9dcfaae4cbe553 commit