### PR TITLE
Model Quantizer: try to run POT as a package

### DIFF
--- a/tools/downloader/README.md
+++ b/tools/downloader/README.md
@@ -356,14 +356,6 @@ the `--precisions` option:
 ./quantizer.py --all --dataset_dir <DATASET_DIR> --precisions=FP16-INT8
 ```
 
-The script will attempt to locate Post-Training Optimization Toolkit using
-the environment variables set by the OpenVINO&trade; toolkit's `setupvars.sh`/`setupvars.bat`
-script. You can override this heuristic with the `--pot` option:
-
-```sh
-./quantizer.py --all --dataset_dir <DATASET_DIR> --pot my/openvino/path/post_training_optimization_toolkit/main.py
-```
-
 By default, the script will run Post-Training Optimization Toolkit using the same
 Python executable that was used to run the script itself. To use a different
 Python executable, use the `-p`/`--python` option:
@@ -371,6 +363,24 @@ Python executable, use the `-p`/`--python` option:
 ```sh
 ./quantizer.py --all --dataset_dir <DATASET_DIR> --python my/python
 ```
+
+The script will attempt to locate Post-Training Optimization Toolkit using several methods:
+
+1. If the `--pot` option was specified, then its value will be used as the path
+   to the script to run:
+
+   ```sh
+   ./quantizer.py --all --dataset_dir <DATASET_DIR> --pot my/openvino/path/post_training_optimization_toolkit/main.py
+   ```
+
+2. Otherwise, if the selected Python executable can import the `pot` package,
+   then that package will be used.
+
+3. Otherwise, if the OpenVINO&trade; toolkit's `setupvars.sh`/`setupvars.bat`
+   script has been executed, the environment variables set by that script will
+   be used to locate Post-Training Optimization Toolkit within the OpenVINO toolkit.
+
+4. Otherwise, the script will fail.
 
 It's possible to specify a target device for Post-Training Optimization Toolkit
 to optimize for, by using the `--target_device` option:

--- a/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
+++ b/tools/downloader/src/open_model_zoo/model_tools/quantizer.py
@@ -40,7 +40,7 @@ DEFAULT_POT_CONFIG_BASE = {
     },
 }
 
-def quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
+def quantize(reporter, model, precision, args, output_dir, pot_cmd_prefix, pot_env):
     input_precision = _common.KNOWN_QUANTIZED_PRECISIONS[precision]
 
     pot_config_base_path = _common.MODEL_ROOT / model.subdirectory / 'quantization.yml'
@@ -82,7 +82,7 @@ def quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
     pot_output_dir = model_output_dir / 'pot-output'
     pot_output_dir.mkdir(parents=True, exist_ok=True)
 
-    pot_cmd = [str(args.python), '--', str(pot_path),
+    pot_cmd = [*pot_cmd_prefix,
         '--config={}'.format(pot_config_path),
         '--direct-dump',
         '--output-dir={}'.format(pot_output_dir),
@@ -137,11 +137,19 @@ def main():
 
     pot_path = args.pot
     if pot_path is None:
-        try:
-            pot_path = Path(os.environ['INTEL_OPENVINO_DIR']) / 'deployment_tools/tools/post_training_optimization_toolkit/main.py'
-        except KeyError:
-            sys.exit('Unable to locate Post-Training Optimization Toolkit. '
-                + 'Use --pot or run setupvars.sh/setupvars.bat from the OpenVINO toolkit.')
+        if _common.get_package_path(args.python, 'pot'):
+            # run POT as a module
+            pot_cmd_prefix = [str(args.python), '-m', 'pot']
+        else:
+            try:
+                pot_path = Path(os.environ['INTEL_OPENVINO_DIR']) / 'deployment_tools/tools/post_training_optimization_toolkit/main.py'
+            except KeyError:
+                sys.exit('Unable to locate Post-Training Optimization Toolkit. '
+                    + 'Use --pot or run setupvars.sh/setupvars.bat from the OpenVINO toolkit.')
+
+    if pot_path is not None:
+        # run POT as a script
+        pot_cmd_prefix = [str(args.python), '--', str(pot_path)]
 
     models = _configuration.load_models_from_args(parser, args)
 
@@ -192,7 +200,7 @@ def main():
             })
 
             for precision in sorted(model_precisions):
-                if not quantize(reporter, model, precision, args, output_dir, pot_path, pot_env):
+                if not quantize(reporter, model, precision, args, output_dir, pot_cmd_prefix, pot_env):
                     failed_models.append(model.name)
                     break
 


### PR DESCRIPTION
Basically, the same thing as in 1df8e872, but for POT instead of MO. The code is simpler here, because we don't need to know the directory POT is installed in.