### PR TITLE
Don't make -output_resolution flag as default

### DIFF
--- a/demos/common/cpp/utils/include/utils/default_flags.hpp
+++ b/demos/common/cpp/utils/include/utils/default_flags.hpp
@@ -12,13 +12,10 @@ DEFINE_bool(loop, false, loop_message);
 
 #define DEFINE_OUTPUT_FLAGS \
 DEFINE_string(o, "", output_message); \
-DEFINE_uint32(limit, 1000, limit_message); \
-DEFINE_string(output_resolution, "", output_resolution_message);
+DEFINE_uint32(limit, 1000, limit_message);
 
 static const char input_message[] = "Required. An input to process. The input must be a single image, a folder of "
     "images, video file or camera id.";
 static const char loop_message[] = "Optional. Enable reading the input in a loop.";
 static const char output_message[] = "Optional. Name of output to save.";
 static const char limit_message[] = "Optional. Number of frames to store in output. If 0 is set, all frames are stored.";
-static const char output_resolution_message[] = "Optional. Specify the maximum output window resolution "
-    "in (width x height) format. Example: 1280x720. Input frame size used by default.";

--- a/demos/human_pose_estimation_demo/cpp/main.cpp
+++ b/demos/human_pose_estimation_demo/cpp/main.cpp
@@ -59,6 +59,8 @@ static const char num_streams_message[] = "Optional. Number of streams to use fo
 "<device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 static const char no_show_message[] = "Optional. Don't show output.";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+static const char output_resolution_message[] = "Optional. Specify the maximum output window resolution "
+    "in (width x height) format. Example: 1280x720. Input frame size used by default.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(at, "", at_message);
@@ -74,6 +76,7 @@ DEFINE_uint32(nthreads, 0, num_threads_message);
 DEFINE_string(nstreams, "", num_streams_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_string(u, "", utilization_monitors_message);
+DEFINE_string(output_resolution, "", output_resolution_message);
 
 /**
 * \brief This function shows a help message

--- a/demos/object_detection_demo/cpp/main.cpp
+++ b/demos/object_detection_demo/cpp/main.cpp
@@ -65,6 +65,8 @@ static const char no_show_message[] = "Optional. Don't show output.";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
 static const char iou_thresh_output_message[] = "Optional. Filtering intersection over union threshold for overlapping boxes.";
 static const char yolo_af_message[] = "Optional. Use advanced postprocessing/filtering algorithm for YOLO.";
+static const char output_resolution_message[] = "Optional. Specify the maximum output window resolution "
+    "in (width x height) format. Example: 1280x720. Input frame size used by default.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(at, "", at_message);
@@ -84,6 +86,7 @@ DEFINE_string(nstreams, "", num_streams_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_string(u, "", utilization_monitors_message);
 DEFINE_bool(yolo_af, true, yolo_af_message);
+DEFINE_string(output_resolution, "", output_resolution_message);
 
 /**
 * \brief This function shows a help message

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -53,6 +53,8 @@ static const char num_streams_message[] = "Optional. Number of streams to use fo
 "<device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
 static const char no_show_message[] = "Optional. Don't show output.";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+static const char output_resolution_message[] = "Optional. Specify the maximum output window resolution "
+    "in (width x height) format. Example: 1280x720. Input frame size used by default.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(m, "", model_message);
@@ -66,6 +68,7 @@ DEFINE_uint32(nthreads, 0, num_threads_message);
 DEFINE_string(nstreams, "", num_streams_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_string(u, "", utilization_monitors_message);
+DEFINE_string(output_resolution, "", output_resolution_message);
 
 /**
 * \brief This function shows a help message


### PR DESCRIPTION
It is better to define the flag only for demos, where it is used.