### PR TITLE
Use code spans to format paths in the documentation

### DIFF
--- a/demos/action_recognition_demo/python/README.md
+++ b/demos/action_recognition_demo/python/README.md
@@ -107,7 +107,7 @@ Options:
 
 Running the application with an empty list of options yields the usage message given above and an error message.
 
-**For example**, to run the demo for in-cabin driver monitoring scenario, please provide a path to the encoder and decoder models, an input video and a file with label names, located at demo folder, <omz_dir>/demos/action_recognition_demo/python/driver_actions.txt:
+**For example**, to run the demo for in-cabin driver monitoring scenario, please provide a path to the encoder and decoder models, an input video and a file with label names, located at demo folder, `<omz_dir>/demos/action_recognition_demo/python/driver_actions.txt`:
 
 ```sh
 python3 action_recognition_demo.py \

--- a/demos/monodepth_demo/python/README.md
+++ b/demos/monodepth_demo/python/README.md
@@ -3,7 +3,7 @@
 This topic demonstrates how to run the MonoDepth demo application, which produces a disparity map for a given input image.
 To this end, the code uses the network described in [Towards Robust Monocular Depth Estimation: Mixing Datasets for Zero-shot Cross-dataset Transfer](https://arxiv.org/abs/1907.01341).
 
-Below is the `midasnet` model inference result for <openvino_install_dir>/deployment_tools\demo\car_1.bmp sample image
+Below is the `midasnet` model inference result for `<openvino_dir>/deployment_tools/demo/car_1.bmp` sample image
 
 ![example](./disp.png)
 

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/README.md
@@ -203,7 +203,7 @@ The main difference between this converter and `super_resolution` in data organi
   * `images_dir` - path to dataset root, where directories with low and high resolutions are located.
   * `lr_dir` - path to directory, where images in low resolution are located (Optional, default `<images_dir>/LR`).
   * `hr_dir` - path to directory, where images in high resolution are located (Optional, default `<images_dir>/HR`). **Note:** inside converted annotation, path to directory is not stored, only file name, please use `additional_data_source` for providing prefix.
-  * `upsampled_dir` - path to directory, where upsampled images are located, if 2 streams used (Optional, default <images_dir>/upsample).
+  * `upsampled_dir` - path to directory, where upsampled images are located, if 2 streams used (Optional, default `<images_dir>/upsample`).
   * `relaxed_names` - allow to use more relaxed search of high resolution or/and upsampled images matching only numeric ids. Optional, by default full name matching required.
   * `hr_prefixed` - allow to use partial name matching  when low resolution filename is a part of high resolution filename. Not applicable when `relaxed_names` is set. Optional, by default full name matching required.
 * `multi_frame_super_resolution` - converts dataset for super resolution task with multiple input frames usage.


### PR DESCRIPTION
This improves consistency, and, in the case of `driver_actions.txt`, enables automatic path checking.

Also, replace the `<openvino_install_dir>` placeholder (which isn't used anywhere else) with `<openvino_dir>` (which is).