### PR TITLE
reduce models.lst to only supported model

### DIFF
--- a/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
+++ b/demos/multi_channel_human_pose_estimation_demo/cpp/README.md
@@ -34,9 +34,6 @@ python3 <omz_dir>/tools/downloader/converter.py --list models.lst
 ### Supported Models
 
 * human-pose-estimation-0001
-* human-pose-estimation-0005
-* human-pose-estimation-0006
-* human-pose-estimation-0007
 
 > **NOTE**: Refer to the tables [Intel's Pre-Trained Models Device Support](../../../models/intel/device_support.md) and [Public Pre-Trained Models Device Support](../../../models/public/device_support.md) for the details on models inference support at different devices.
 

--- a/demos/multi_channel_human_pose_estimation_demo/cpp/models.lst
+++ b/demos/multi_channel_human_pose_estimation_demo/cpp/models.lst
@@ -1,2 +1,2 @@
 # This file can be used with the --list option of the model downloader.
-human-pose-estimation-????
+human-pose-estimation-0001


### PR DESCRIPTION
multi_channel_human_pose_estimation_demo support only human-pose-estimation-0001 model, but we got more models with similar name and other versions, so template in models.lst have to be reduced to single supported model