### PR TITLE
Add class distribution for segmentation demo results

### DIFF
--- a/demos/common/cpp/models/include/models/segmentation_model.h
+++ b/demos/common/cpp/models/include/models/segmentation_model.h
@@ -25,6 +25,8 @@ public:
     /// Otherwise, image will be preprocessed and resized using OpenCV routines.
     SegmentationModel(const std::string& modelFileName, bool useAutoResize);
 
+    static std::vector<std::string> loadLabels(const std::string& labelFilename);
+
     std::shared_ptr<InternalModelData> preprocess(
         const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -22,6 +22,26 @@ using namespace InferenceEngine;
 SegmentationModel::SegmentationModel(const std::string& modelFileName, bool useAutoResize) :
     ImageModel(modelFileName, useAutoResize) {}
 
+std::vector<std::string> SegmentationModel::loadLabels(const std::string & labelFilename)
+{
+    std::vector<std::string> labelsList;
+
+    /* Read labels (if any) */
+    if (!labelFilename.empty()) {
+        std::ifstream inputFile(labelFilename);
+        if (!inputFile.is_open())
+            throw std::runtime_error("Can't open the labels file: " + labelFilename);
+        std::string label;
+        while (std::getline(inputFile, label)) {
+            labelsList.push_back(label);
+        }
+        if (labelsList.empty())
+            throw std::logic_error("File is empty: " + labelFilename);
+    }
+
+    return labelsList;
+}
+
 void SegmentationModel::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNetwork)
 {
     // --------------------------- Configure input & output ---------------------------------------------

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -18,14 +18,20 @@ import cv2
 import numpy as np
 
 from .model import Model
+from .utils import load_labels
 
 
 class SegmentationModel(Model):
-    def __init__(self, ie, model_path):
+    def __init__(self, ie, model_path, labels=None):
         super().__init__(ie, model_path)
 
         self.input_blob_name = self.prepare_inputs()
         self.out_blob_name = self.prepare_outputs()
+
+        if isinstance(labels, (list, tuple)):
+            self.labels = labels
+        else:
+            self.labels = load_labels(labels) if labels else None
 
     def prepare_inputs(self):
         if len(self.net.input_info) != 1:

--- a/demos/segmentation_demo/cpp/README.md
+++ b/demos/segmentation_demo/cpp/README.md
@@ -65,7 +65,9 @@ Options:
           Or
       -c "<absolute_path>"    Required for GPU custom kernels. Absolute path to the .xml file with the kernel descriptions.
     -d "<device>"             Optional. Specify the target device to infer on (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The demo will look for a suitable plugin for a specified device.
+    -labels "<path>"          Optional. Path to a file with labels mapping.
     -pc                       Optional. Enables per-layer performance report.
+    -r                        Optional. Output inference results as mask histogram.
     -nireq "<integer>"        Optional. Number of infer requests. If this option is omitted, number of infer requests is determined automatically.
     -auto_resize              Optional. Enables resizable input with support of ROI crop & auto resize.
     -nthreads "<integer>"     Optional. Number of threads.

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -202,9 +202,9 @@ void print_raw_results(const ImageResult& result, std::vector<std::string> label
     cv::minMaxLoc(result.resultImage, &min_val, &max_val);
     int max_classes = static_cast<int>(max_val) + 1; // We use +1 for only background case
     const float range[] = { 0, static_cast<float>(max_classes) };
-    const float * ranges = { range };
+    const float * ranges[] = { range };
     cv::Mat histogram;
-    cv::calcHist(&result.resultImage, 1, 0, cv::Mat(), histogram, 1, &max_classes, &ranges);
+    cv::calcHist(&result.resultImage, 1, 0, cv::Mat(), histogram, 1, &max_classes, ranges);
 
     const double all = result.resultImage.cols * result.resultImage.rows;
     for (int i = 0; i < max_classes; ++i)

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -212,7 +212,7 @@ void print_raw_results(const ImageResult& result, std::vector<std::string> label
         const int value = static_cast<int>(histogram.at<float>(i));
         if (value > 0)
         {
-            std::string label = i < labels.size() ? labels[i] : "#" + std::to_string(i);
+            std::string label = (size_t)i < labels.size() ? labels[i] : "#" + std::to_string(i);
             slog::info << " "
                 << std::setw(16) << std::left << label << " | "
                 << std::setw(6) << value << " | "

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -196,26 +196,27 @@ cv::Mat renderSegmentationData(const ImageResult& result, OutputTransform& outpu
 
 void print_raw_results(const ImageResult& result, std::vector<std::string> labels)
 {
+    slog::info << "     Class ID     | Pixels | Percentage " << slog::endl;
 
-    slog::info << " Class ID | Pixels | Percentage " << slog::endl;
-    cv::Mat histogram;
     double min_val, max_val;
     cv::minMaxLoc(result.resultImage, &min_val, &max_val);
     int max_classes = static_cast<int>(max_val) + 1; // We use +1 for only background case
-    const float range[] = { 0, max_classes };
+    const float range[] = { 0, static_cast<float>(max_classes) };
     const float * ranges = { range };
+    cv::Mat histogram;
     cv::calcHist(&result.resultImage, 1, 0, cv::Mat(), histogram, 1, &max_classes, &ranges);
+
     const double all = result.resultImage.cols * result.resultImage.rows;
     for (int i = 0; i < max_classes; ++i)
     {
-        const int value = histogram.at<int>(i);
+        const int value = static_cast<int>(histogram.at<float>(i));
         if (value > 0)
         {
             std::string label = i < labels.size() ? labels[i] : "#" + std::to_string(i);
             slog::info << " "
-                << std::setw(7) << label << " | "
-                << std::setw(6) << histogram.at<float>(i) << " | "
-                << std::setw(6) << histogram.at<float>(i) / all * 100 << "%"
+                << std::setw(16) << std::left << label << " | "
+                << std::setw(6) << value << " | "
+                << std::setw(6) << std::setprecision(4) << value / all * 100 << "%"
                 << slog::endl;
         }
     }

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -40,11 +40,13 @@ static const char model_message[] = "Required. Path to an .xml file with a train
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). "
 "Default value is CPU. Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "
 "The demo will look for a suitable plugin for a specified device.";
+static const char labels_message[] = "Optional. Path to a file with labels mapping.";
 static const char performance_counter_message[] = "Optional. Enables per-layer performance report.";
 static const char custom_cldnn_message[] = "Required for GPU custom kernels. "
 "Absolute path to the .xml file with the kernel descriptions.";
 static const char custom_cpu_library_message[] = "Required for CPU custom layers. "
 "Absolute path to a shared library with the kernel implementations.";
+static const char raw_output_message[] = "Optional. Output inference results as mask histogram.";
 static const char nireq_message[] = "Optional. Number of infer requests. If this option is omitted, number of infer requests is determined automatically.";
 static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 static const char num_threads_message[] = "Optional. Number of threads.";
@@ -59,9 +61,11 @@ static const char output_resolution_message[] = "Optional. Specify the maximum o
 DEFINE_bool(h, false, help_message);
 DEFINE_string(m, "", model_message);
 DEFINE_string(d, "CPU", target_device_message);
+DEFINE_string(labels, "", labels_message);
 DEFINE_bool(pc, false, performance_counter_message);
 DEFINE_string(c, "", custom_cldnn_message);
 DEFINE_string(l, "", custom_cpu_library_message);
+DEFINE_bool(r, false, raw_output_message);
 DEFINE_uint32(nireq, 0, nireq_message);
 DEFINE_bool(auto_resize, false, input_resizable_message);
 DEFINE_uint32(nthreads, 0, num_threads_message);
@@ -87,7 +91,9 @@ static void showUsage() {
     std::cout << "          Or" << std::endl;
     std::cout << "      -c \"<absolute_path>\"    " << custom_cldnn_message << std::endl;
     std::cout << "    -d \"<device>\"             " << target_device_message << std::endl;
+    std::cout << "    -labels \"<path>\"          " << labels_message << std::endl;
     std::cout << "    -pc                       " << performance_counter_message << std::endl;
+    std::cout << "    -r                        " << raw_output_message << std::endl;
     std::cout << "    -nireq \"<integer>\"        " << nireq_message << std::endl;
     std::cout << "    -auto_resize              " << input_resizable_message << std::endl;
     std::cout << "    -nthreads \"<integer>\"     " << num_threads_message << std::endl;
@@ -188,6 +194,33 @@ cv::Mat renderSegmentationData(const ImageResult& result, OutputTransform& outpu
     return output;
 }
 
+void print_raw_results(const ImageResult& result, std::vector<std::string> labels)
+{
+
+    slog::info << " Class ID | Pixels | Percentage " << slog::endl;
+    cv::Mat histogram;
+    double min_val, max_val;
+    cv::minMaxLoc(result.resultImage, &min_val, &max_val);
+    int max_classes = static_cast<int>(max_val) + 1; // We use +1 for only background case
+    const float range[] = { 0, max_classes };
+    const float * ranges = { range };
+    cv::calcHist(&result.resultImage, 1, 0, cv::Mat(), histogram, 1, &max_classes, &ranges);
+    const double all = result.resultImage.cols * result.resultImage.rows;
+    for (int i = 0; i < max_classes; ++i)
+    {
+        const int value = histogram.at<int>(i);
+        if (value > 0)
+        {
+            std::string label = i < labels.size() ? labels[i] : "#" + std::to_string(i);
+            slog::info << " "
+                << std::setw(7) << label << " | "
+                << std::setw(6) << histogram.at<float>(i) << " | "
+                << std::setw(6) << histogram.at<float>(i) / all * 100 << "%"
+                << slog::endl;
+        }
+    }
+}
+
 int main(int argc, char* argv[])
 {
     try
@@ -213,6 +246,10 @@ int main(int argc, char* argv[])
             ConfigFactory::getUserConfig(FLAGS_d,FLAGS_l,FLAGS_c,FLAGS_pc,FLAGS_nireq,FLAGS_nstreams,FLAGS_nthreads),
             core);
         Presenter presenter(FLAGS_u);
+
+        std::vector<std::string> labels;
+        if (!FLAGS_labels.empty())
+            labels = SegmentationModel::loadLabels(FLAGS_labels);
 
         bool keepRunning = true;
         int64_t frameNum = -1;
@@ -275,6 +312,8 @@ int main(int argc, char* argv[])
             while (keepRunning && (result = pipeline.getResult())) {
                 cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform);
                 //--- Showing results and device information
+                if (FLAGS_r)
+                    print_raw_results(result->asRef<ImageResult>(), labels);
                 presenter.drawGraphs(outFrame);
                 metrics.update(result->metaData->asRef<ImageMetaData>().timeStamp,
                     outFrame, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX, 0.65);
@@ -306,6 +345,8 @@ int main(int argc, char* argv[])
             {
                 cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform);
                 //--- Showing results and device information
+                if (FLAGS_r)
+                    print_raw_results(result->asRef<ImageResult>(), labels);
                 presenter.drawGraphs(outFrame);
                 metrics.update(result->metaData->asRef<ImageMetaData>().timeStamp,
                     outFrame, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX, 0.65);

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -216,7 +216,7 @@ void print_raw_results(const ImageResult& result, std::vector<std::string> label
             slog::info << " "
                 << std::setw(16) << std::left << label << " | "
                 << std::setw(6) << value << " | "
-                << std::setw(6) << std::setprecision(4) << value / all * 100 << "%"
+                << std::setw(5) << std::setprecision(2) << std::fixed << std::right << value / all * 100 << "%"
                 << slog::endl;
         }
     }

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -83,6 +83,7 @@ Common model options:
   -c COLORS, --colors COLORS
                         Optional. Path to a text file containing colors for
                         classes.
+  --labels LABELS       Optional. Labels mapping file.
 
 Inference options:
   -nireq NUM_INFER_REQUESTS, --num_infer_requests NUM_INFER_REQUESTS
@@ -111,6 +112,10 @@ Input/output options:
                         Input frame size used by default.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
+
+Debug options:
+  -r, --raw_output_message
+                        Optional. Output inference results as mask histogram.
 ```
 
 Running the application with the empty list of options yields the usage message given above and an error message.

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -163,14 +163,14 @@ def get_model(ie, args):
 
 
 def print_raw_results(mask, labels=None):
-    log.info(' Class ID | Pixels | Percentage ')
+    log.info('     Class ID     | Pixels | Percentage ')
     max_classes = int(np.max(mask)) + 1 # We use +1 for only background case
     histogram = cv2.calcHist([np.expand_dims(mask, axis=-1)], [0], None, [max_classes], [0, max_classes])
     all = np.product(mask.shape)
     for id, val in enumerate(histogram[:, 0]):
         if val > 0:
             label = labels[id] if labels and len(labels) >= id else '#{}'.format(id)
-            log.info('{:^9} | {:6d} | {:5.2f}% '.format(label, int(val), val / all * 100))
+            log.info(' {:<16} | {:6d} | {:5.2f}% '.format(label, int(val), val / all * 100))
 
 
 def main():


### PR DESCRIPTION
With `-r` option on, both C++ and Python segmentation demo print raw result as class distribution, e.g.:
```
[ INFO ]  Class ID | Pixels | Percentage
[ INFO ]        #0 | 870304 | 94.434%
[ INFO ]        #1 |  51296 | 5.56597%
```

TODO:
- [x] Add labels for cpp/segmentation model
- [x] Update documentation