### PR TITLE
AC: bugfixes for label me and interval metric

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/label_me_converter.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/label_me_converter.py
@@ -90,7 +90,7 @@ class LabelMeDetectionConverter(BaseFormatConverter):
                 x_maxs.append(max(x_coords))
                 y_mins.append(min(y_coords))
                 y_maxs.append(max(y_coords))
-                labels.append(label)
+                labels.append(int(label))
 
             if check_content:
                 if not check_file_existence(self.image_dir / identifier):
@@ -194,6 +194,8 @@ def get_label_map(labels, has_background=False):
         raise ValueError('label_map must be provided in dataset_meta_file')
 
     if isinstance(labels, dict):
+        if not isinstance(next(iter(labels)), int):
+            return {int(k): v for k, v in labels.items()}
         return labels
 
     labels_offset = int(has_background)

--- a/tools/accuracy_checker/accuracy_checker/metrics/coco_metrics.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/coco_metrics.py
@@ -80,6 +80,7 @@ class MSCOCOBaseMetric(PerImageEvaluationMetric):
             raise ConfigError('coco metrics require label_map providing in dataset_meta'
                               'Please provide dataset meta file or regenerate annotation')
         self.meta['names'] = [label_map[label] for label in self.labels]
+        self.meta['orig_label_names'] = [label_map[label] for label in self.labels]
         self.matching_results = [[] for _ in self.labels]
 
     def update(self, annotation, prediction):
@@ -132,7 +133,7 @@ class MSCOCOAveragePrecision(MSCOCOBaseMetric):
             compute_precision_recall(self.thresholds, self.matching_results[i])[0]
             for i, _ in enumerate(self.labels)
         ]
-        precision, self.meta['names'] = finalize_metric_result(precision, self.meta['names'])
+        precision, self.meta['names'] = finalize_metric_result(precision, self.meta['orig_label_names'])
 
         return precision
 
@@ -158,7 +159,7 @@ class MSCOCORecall(MSCOCOBaseMetric):
             compute_precision_recall(self.thresholds, self.matching_results[i])[1]
             for i, _ in enumerate(self.labels)
         ]
-        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['names'])
+        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['orig_label_names'])
 
         return recalls
 
@@ -241,7 +242,7 @@ class MSCOCOKeypointsPrecision(MSCOCOKeypointsBaseMetric):
             compute_precision_recall(self.thresholds, self.matching_results[i])[0]
             for i, _ in enumerate(self.labels)
         ]
-        precision, self.meta['names'] = finalize_metric_result(precision, self.meta['names'])
+        precision, self.meta['names'] = finalize_metric_result(precision, self.meta['orig_label_names'])
 
         return precision
 
@@ -260,7 +261,7 @@ class MSCOCOKeypointsRecall(MSCOCOKeypointsBaseMetric):
             compute_precision_recall(self.thresholds, self.matching_results[i])[1]
             for i, _ in enumerate(self.labels)
         ]
-        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['names'])
+        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['orig_label_names'])
 
         return recalls
 

--- a/tools/accuracy_checker/accuracy_checker/metrics/detection.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/detection.py
@@ -94,6 +94,7 @@ class BaseDetectionMetricMixin(Metric):
         self.labels = list(labels.keys())
         valid_labels = list(filter(lambda x: x != self.dataset.metadata.get('background_label'), self.labels))
         self.meta['names'] = [labels[name] for name in valid_labels]
+        self.meta['orig_label_names'] = [labels[name] for name in valid_labels]
 
     def per_class_detection_statistics(self, annotations, predictions, labels, profile_boxes=False):
         labels_stat = {}
@@ -196,7 +197,9 @@ class DetectionMAP(BaseDetectionMetricMixin, FullDatasetEvaluationMetric, PerIma
     def evaluate(self, annotations, predictions):
         super().evaluate(annotations, predictions)
         average_precisions = self._calculate_map(annotations, predictions)
-        average_precisions, self.meta['names'] = finalize_metric_result(average_precisions, self.meta['names'])
+        average_precisions, self.meta['names'] = finalize_metric_result(
+            average_precisions, self.meta['orig_label_names']
+        )
         if not average_precisions:
             warnings.warn("No detections to compute mAP")
             average_precisions.append(0)
@@ -300,7 +303,7 @@ class Recall(BaseDetectionMetricMixin, FullDatasetEvaluationMetric, PerImageEval
     def evaluate(self, annotations, predictions):
         super().evaluate(annotations, predictions)
         recalls = self._calculate_recall(annotations, predictions)
-        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['names'])
+        recalls, self.meta['names'] = finalize_metric_result(recalls, self.meta['orig_label_names'])
         if not recalls:
             warnings.warn("No detections to compute mAP")
             recalls.append(0)

--- a/tools/accuracy_checker/accuracy_checker/metrics/regression.py
+++ b/tools/accuracy_checker/accuracy_checker/metrics/regression.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import copy
 import warnings
 from collections import OrderedDict
 from functools import singledispatch
@@ -229,7 +230,7 @@ class BaseRegressionOnIntervals(PerImageEvaluationMetric):
             self.magnitude = self.magnitude[1:-1]
 
         result = [[np.mean(values), np.std(values)] if values else [np.nan, np.nan] for values in self.magnitude]
-        result, self.meta['names'] = finalize_metric_result(np.reshape(result, -1), self.meta['names'])
+        result, self.meta['names'] = finalize_metric_result(np.reshape(result, -1), self.meta['orig_names'])
 
         if not result:
             warnings.warn("No values in given interval")
@@ -252,6 +253,7 @@ class BaseRegressionOnIntervals(PerImageEvaluationMetric):
         if not self.ignore_out_of_range:
             self.meta['names'].append('mean: > ' + str(self.intervals[-1]))
             self.meta['names'].append('std: > ' + str(self.intervals[-1]))
+        self.meta['orig_names'] = copy.deepcopy(self.meta['names'])
 
     def reset(self):
         self.magnitude = [[] for _ in range(len(self.intervals) + 1)]
@@ -339,7 +341,7 @@ class RootMeanSquaredErrorOnInterval(BaseRegressionOnIntervals):
             error = [np.sqrt(np.mean(values)), np.sqrt(np.std(values))] if values else [np.nan, np.nan]
             result.append(error)
 
-        result, self.meta['names'] = finalize_metric_result(np.reshape(result, -1), self.meta['names'])
+        result, self.meta['names'] = finalize_metric_result(np.reshape(result, -1), self.meta['orig_names'])
 
         if not result:
             warnings.warn("No values in given interval")

--- a/tools/accuracy_checker/tests/test_regression_metrics.py
+++ b/tools/accuracy_checker/tests/test_regression_metrics.py
@@ -163,7 +163,7 @@ class TestRegressionMetric:
             'mae_on_interval',
             None,
             None,
-            {'postfix': ' ', 'scale': 1, 'names': [], 'calculate_mean': False, 'target': 'higher-worse'}
+            {'postfix': ' ', 'scale': 1, 'names': [], 'calculate_mean': False, 'target': 'higher-worse', 'orig_names': ['mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0']}
         )
         dispatcher = MetricsExecutor(config, None)
 
@@ -189,7 +189,8 @@ class TestRegressionMetric:
                 'scale': 1,
                 'names': ['mean: < 0.0', 'std: < 0.0', 'mean: > 1.0', 'std: > 1.0'],
                 'calculate_mean': False,
-                'target': 'higher-worse'
+                'target': 'higher-worse',
+                'orig_names': ['mean: < 0.0', 'std: < 0.0', 'mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0', 'mean: > 1.0', 'std: > 1.0']
             }
         )
         config = [{'type': 'mae_on_interval', 'end': 1, 'ignore_values_not_in_interval': False}]
@@ -211,7 +212,8 @@ class TestRegressionMetric:
             'mae_on_interval',
             None,
             None,
-            {'postfix': ' ', 'scale': 1, 'names': ['mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0'], 'calculate_mean': False, 'target': 'higher-worse'}
+            {'postfix': ' ', 'scale': 1, 'names': ['mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0'], 'calculate_mean': False, 'target': 'higher-worse',
+             'orig_names': ['mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0']}
         )
         dispatcher = MetricsExecutor(config, None)
 
@@ -251,7 +253,8 @@ class TestRegressionMetric:
                     'std: > 1.0'
                 ],
                 'calculate_mean': False,
-                'target': 'higher-worse'
+                'target': 'higher-worse',
+                'orig_names': ['mean: < 0.0', 'std: < 0.0', 'mean: <= 0.0 < 1.0', 'std: <= 0.0 < 1.0', 'mean: > 1.0', 'std: > 1.0']
             }
         )
         dispatcher = MetricsExecutor(config, None)
@@ -285,7 +288,8 @@ class TestRegressionMetric:
                 'scale': 1,
                 'names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0'],
                 'calculate_mean': False,
-                'target': 'higher-worse'
+                'target': 'higher-worse',
+                'orig_names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0']
             }
         )
         dispatcher = MetricsExecutor(config, None)
@@ -318,6 +322,7 @@ class TestRegressionMetric:
                 'postfix': ' ',
                 'scale': 1,
                 'names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0'],
+                'orig_names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0'],
                 'calculate_mean': False,
                 'target': 'higher-worse'
             }
@@ -351,6 +356,7 @@ class TestRegressionMetric:
             {
                 'postfix': ' ', 'scale': 1,
                 'names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0'],
+                'orig_names': ['mean: <= 0.0 < 2.0', 'std: <= 0.0 < 2.0', 'mean: <= 2.0 < 4.0', 'std: <= 2.0 < 4.0'],
                 'calculate_mean': False,
                 'target': 'higher-worse'
             }


### PR DESCRIPTION
1. sometimes json can not automatically detect int keys in dict, need to be explicitly casted
2. interval metric get incorrect result due to wrong list of class names in metrc