### PR TITLE
object_detection_demo.py: move boxes clipping to postprocess

### DIFF
--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -19,7 +19,7 @@ import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
 from .model import Model
-from .utils import Detection, load_labels
+from .utils import Detection, load_labels, clip_detections
 
 
 class CenterNet(Model):
@@ -89,7 +89,7 @@ class CenterNet(Model):
         center = np.array(meta['original_shape'][:2])/2.0
         dets = self._transform(filtered_detections, np.flip(center, 0), scale, height, width)
         dets = [Detection(x[0], x[1], x[2], x[3], score=x[4], id=x[5]) for x in dets]
-        return dets
+        return clip_detections(dets, meta['original_shape'])
 
     @staticmethod
     def get_affine_transform(center, scale, rot, output_size, inv=False):

--- a/demos/common/python/models/ctpn.py
+++ b/demos/common/python/models/ctpn.py
@@ -18,7 +18,7 @@ import cv2
 import numpy as np
 
 from .model import Model
-from .utils import Detection, nms
+from .utils import Detection, nms, clip_detections
 
 
 class CTPN(Model):
@@ -115,7 +115,8 @@ class CTPN(Model):
             second_scales = meta['scales'].pop()
             boxes[:, 0:8:2] /= second_scales[0]
             boxes[:, 1:8:2] /= second_scales[1]
-        return [Detection(box[0], box[1], box[2], box[5], box[8], 0) for box in boxes]
+        detections = [Detection(box[0], box[1], box[2], box[5], box[8], 0) for box in boxes]
+        return clip_detections(detections, meta['original_shape'])
 
     @staticmethod
     def ctpn_keep_aspect_ratio(dst_width, dst_height, image_width, image_height):

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -18,7 +18,7 @@ import math
 import numpy as np
 
 from .model import Model
-from .utils import Detection, resize_image, nms
+from .utils import Detection, resize_image, nms, clip_detections
 
 
 class FaceBoxes(Model):
@@ -116,7 +116,7 @@ class FaceBoxes(Model):
             detections = [Detection(*det, 0) for det in zip(x_mins, y_mins, x_maxs, y_maxs, filtered_score)]
 
         detections = self.resize_boxes(detections, meta['original_shape'][:2])
-        return detections
+        return clip_detections(detections, meta['original_shape'])
 
     @staticmethod
     def calculate_anchors(list_x, list_y, min_size, image_size, step):

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -20,7 +20,7 @@ import numpy as np
 from itertools import product as product
 
 from .model import Model
-from .utils import DetectionWithLandmarks, Detection, resize_image, nms
+from .utils import DetectionWithLandmarks, Detection, resize_image, nms, clip_detections
 
 
 class RetinaFace(Model):
@@ -62,7 +62,7 @@ class RetinaFace(Model):
         scale_y = meta['resized_shape'][0] / meta['original_shape'][0]
 
         outputs = self.postprocessor.process_output(outputs, scale_x, scale_y, self.threshold, self.mask_threshold)
-        return outputs
+        return clip_detections(outputs, meta['original_shape'])
 
 
 class RetinaFacePostprocessor:

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -341,7 +341,7 @@ class RetinaFacePyTorch(Model):
 
         outputs = self.postprocessor.process_output(outputs, scale_x, scale_y, self.threshold,
                                                     meta['resized_shape'][:2])
-        return outputs
+        return clip_detections(outputs, meta['original_shape'])
 
 
 class RetinaFacePyTorchPostprocessor:

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -16,11 +16,12 @@
 import numpy as np
 
 from .model import Model
-from .utils import Detection, resize_image, load_labels
+from .utils import Detection, resize_image, load_labels, clip_detections
 
 
 class SSD(Model):
-    def __init__(self, ie, model_path, input_transform, labels=None, keep_aspect_ratio_resize=False):
+    def __init__(self, ie, model_path, input_transform, labels=None,
+        keep_aspect_ratio_resize=False, threshold=0.5):
         super().__init__(ie, model_path, input_transform)
 
         self.keep_aspect_ratio_resize = keep_aspect_ratio_resize
@@ -29,6 +30,7 @@ class SSD(Model):
         else:
             self.labels = load_labels(labels) if labels else None
 
+        self.threshold = threshold
         self.image_blob_name, self.image_info_blob_name = self._get_inputs()
         self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
 
@@ -94,6 +96,7 @@ class SSD(Model):
 
     def postprocess(self, outputs, meta):
         detections = self.output_parser(outputs)
+        detections = [d for d in detections if d.score > self.threshold]
         orginal_image_shape = meta['original_shape']
         resized_image_shape = meta['resized_shape']
         scale_x = self.w / resized_image_shape[1] * orginal_image_shape[1]
@@ -103,7 +106,7 @@ class SSD(Model):
             detection.xmax *= scale_x
             detection.ymin *= scale_y
             detection.ymax *= scale_y
-        return detections
+        return clip_detections(detections, orginal_image_shape)
 
 
 def find_layer_by_name(name, layers):

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -16,7 +16,7 @@
 import numpy as np
 
 from .model import Model
-from .utils import Detection, resize_image, nms
+from .utils import Detection, resize_image, nms, clip_detections
 
 
 class UltraLightweightFaceDetection(Model):
@@ -84,4 +84,5 @@ class UltraLightweightFaceDetection(Model):
         x_maxs = x_maxs[keep] * meta['original_shape'][1]
         y_maxs = y_maxs[keep] * meta['original_shape'][0]
 
-        return [Detection(*det, 0) for det in zip(x_mins, y_mins, x_maxs, y_maxs, filtered_score)]
+        detections = [Detection(*det, 0) for det in zip(x_mins, y_mins, x_maxs, y_maxs, filtered_score)]
+        return clip_detections(detections, meta['original_shape'])

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -33,6 +33,18 @@ class Detection:
     def top_right_point(self):
         return self.xmax, self.ymax
 
+    def get_coords(self):
+        return self.xmin, self.ymin, self.xmax, self.ymax
+
+
+def clip_detections(detections, size):
+    for detection in detections:
+        detection.xmin = max(int(detection.xmin), 0)
+        detection.ymin = max(int(detection.ymin), 0)
+        detection.xmax = min(int(detection.xmax), size[1])
+        detection.ymax = min(int(detection.ymax), size[0])
+    return detections
+
 
 class DetectionWithLandmarks(Detection):
     def __init__(self, xmin, ymin, xmax, ymax, score, id, landmarks_x, landmarks_y):

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -18,7 +18,7 @@ import numpy as np
 import ngraph
 
 from .model import Model
-from .utils import Detection, resize_image, resize_image_letterbox, load_labels
+from .utils import Detection, resize_image, resize_image_letterbox, load_labels, clip_detections
 
 class YOLO(Model):
     class Params:
@@ -213,7 +213,7 @@ class YOLO(Model):
         else:
             detections = self._resize_detections(detections, meta['original_shape'][1::-1])
 
-        return detections
+        return clip_detections(detections, meta['original_shape'])
 
 
 class YoloV4(YOLO):

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -164,7 +164,8 @@ def get_model(ie, args):
         raise ValueError("{} model doesn't support input transforms.".format(args.architecture_type))
 
     if args.architecture_type == 'ssd':
-        return models.SSD(*common_args, labels=args.labels, keep_aspect_ratio_resize=args.keep_aspect_ratio)
+        return models.SSD(*common_args, labels=args.labels, keep_aspect_ratio_resize=args.keep_aspect_ratio,
+                          threshold=args.prob_threshold)
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':
@@ -187,41 +188,32 @@ def get_model(ie, args):
         raise RuntimeError('No model type or invalid model type (-at) provided: {}'.format(args.architecture_type))
 
 
-def draw_detections(frame, detections, palette, labels, threshold, output_transform):
-    size = frame.shape[:2]
+def draw_detections(frame, detections, palette, labels, output_transform):
     frame = output_transform.resize(frame)
     for detection in detections:
-        if detection.score > threshold:
-            class_id = int(detection.id)
-            color = palette[class_id]
-            det_label = labels[class_id] if labels and len(labels) >= class_id else '#{}'.format(class_id)
-            xmin = max(int(detection.xmin), 0)
-            ymin = max(int(detection.ymin), 0)
-            xmax = min(int(detection.xmax), size[1])
-            ymax = min(int(detection.ymax), size[0])
-            xmin, ymin, xmax, ymax = output_transform.scale([xmin, ymin, xmax, ymax])
-            cv2.rectangle(frame, (xmin, ymin), (xmax, ymax), color, 2)
-            cv2.putText(frame, '{} {:.1%}'.format(det_label, detection.score),
-                        (xmin, ymin - 7), cv2.FONT_HERSHEY_COMPLEX, 0.6, color, 1)
-            if isinstance(detection, models.DetectionWithLandmarks):
-                for landmark in detection.landmarks:
-                    landmark = output_transform.scale(landmark)
-                    cv2.circle(frame, (int(landmark[0]), int(landmark[1])), 2, (0, 255, 255), 2)
+        class_id = int(detection.id)
+        color = palette[class_id]
+        det_label = labels[class_id] if labels and len(labels) >= class_id else '#{}'.format(class_id)
+        xmin, ymin, xmax, ymax = detection.get_coords()
+        xmin, ymin, xmax, ymax = output_transform.scale([xmin, ymin, xmax, ymax])
+        cv2.rectangle(frame, (xmin, ymin), (xmax, ymax), color, 2)
+        cv2.putText(frame, '{} {:.1%}'.format(det_label, detection.score),
+                    (xmin, ymin - 7), cv2.FONT_HERSHEY_COMPLEX, 0.6, color, 1)
+        if isinstance(detection, models.DetectionWithLandmarks):
+            for landmark in detection.landmarks:
+                landmark = output_transform.scale(landmark)
+                cv2.circle(frame, (int(landmark[0]), int(landmark[1])), 2, (0, 255, 255), 2)
     return frame
 
 
-def print_raw_results(size, detections, labels, threshold):
+def print_raw_results(detections, labels):
     log.info(' Class ID | Confidence | XMIN | YMIN | XMAX | YMAX ')
     for detection in detections:
-        if detection.score > threshold:
-            xmin = max(int(detection.xmin), 0)
-            ymin = max(int(detection.ymin), 0)
-            xmax = min(int(detection.xmax), size[1])
-            ymax = min(int(detection.ymax), size[0])
-            class_id = int(detection.id)
-            det_label = labels[class_id] if labels and len(labels) >= class_id else '#{}'.format(class_id)
-            log.info('{:^9} | {:10f} | {:4} | {:4} | {:4} | {:4} '
-                     .format(det_label, detection.score, xmin, ymin, xmax, ymax))
+        xmin, ymin, xmax, ymax = detection.get_coords()
+        class_id = int(detection.id)
+        det_label = labels[class_id] if labels and len(labels) >= class_id else '#{}'.format(class_id)
+        log.info('{:^9} | {:10f} | {:4} | {:4} | {:4} | {:4} '
+                 .format(det_label, detection.score, xmin, ymin, xmax, ymax))
 
 
 def main():
@@ -264,10 +256,10 @@ def main():
             start_time = frame_meta['start_time']
 
             if len(objects) and args.raw_output_message:
-                print_raw_results(frame.shape[:2], objects, model.labels, args.prob_threshold)
+                print_raw_results(objects, model.labels)
 
             presenter.drawGraphs(frame)
-            frame = draw_detections(frame, objects, palette, model.labels, args.prob_threshold, output_transform)
+            frame = draw_detections(frame, objects, palette, model.labels, output_transform)
             metrics.update(start_time, frame)
 
             if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
@@ -323,10 +315,10 @@ def main():
         start_time = frame_meta['start_time']
 
         if len(objects) and args.raw_output_message:
-            print_raw_results(frame.shape[:2], objects, model.labels, args.prob_threshold)
+            print_raw_results(objects, model.labels)
 
         presenter.drawGraphs(frame)
-        frame = draw_detections(frame, objects, palette, model.labels, args.prob_threshold, output_transform)
+        frame = draw_detections(frame, objects, palette, model.labels, output_transform)
         metrics.update(start_time, frame)
 
         if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):


### PR DESCRIPTION
1. `draw_detections` and `print_raw_results` functions don't have to apply thresholding, because all models (except ssd) filter detections by threshold in postprocess. Added thresholding to SSD models instead
2. In two stage pipelining the second model may require clipped boxes, so the clipping should be moved to postprocess (otherwise the clipping is applied twice)