### PR TITLE
Added check for relative links to non-markdown files

### DIFF
--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -138,7 +138,7 @@ def add_page(output_root, parent, *, id=None, path=None, title=None):
         relative_path = (OMZ_ROOT / Path(path).parent / non_md_link).resolve().relative_to(OMZ_ROOT)
         suggested_path = OMZ_PREFIX + Path(relative_path).as_posix()
 
-        raise RuntimeError(f'{path}: Relative link to non-markdown file "{non_md_link}".'
+        raise RuntimeError(f'{path}: Relative link to non-markdown file "{non_md_link}". '
                            f'Replace it by `{suggested_path}`')
     return element
 

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -240,7 +240,7 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
         * `images` - directory with converted images
         * `depth` -  directory with depth maps
 
-Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use `<omz_dir>/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py` and  following command line to get converted data .
+Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use `convert_annotation` command line interface:
 
 ```sh
 convert_annotation nyu_depth_v2 --data_dir <DATASET_DIR>/nyudepthv2/val/official --allow_convert_data True

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -4,7 +4,7 @@ If you want to use prepared configs to run the Accuracy Checker tool and the Mod
 
 Each dataset description consists of the following sections:
 * instruction for downloading the dataset
-* structure of `<DATASET_DIR>` that matches the dataset definition in the existing global configuration file ([dataset_definitions.yml](./dataset_definitions.yml))
+* structure of `<DATASET_DIR>` that matches the dataset definition in the existing global configuration file (`<omz_dir>/data/dataset_definitions.yml`)
 * examples of using and presenting the dataset in the global configuration file
 
 More detailed information about using predefined configuration files you can find [here](../tools/accuracy_checker/configs/README.md).
@@ -240,7 +240,7 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
         * `images` - directory with converted images
         * `depth` -  directory with depth maps
 
-Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use [convert.py](../tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py) and  following command line to get converted data .
+Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use `<omz_dir>/tools/accuracy_checker/accuracy_checker/annotation_converters/convert.py` and  following command line to get converted data .
 
 ```sh
 convert_annotation nyu_depth_v2 --data_dir <DATASET_DIR>/nyudepthv2/val/official --allow_convert_data True

--- a/demos/image_processing_demo/cpp/README.md
+++ b/demos/image_processing_demo/cpp/README.md
@@ -93,7 +93,7 @@ Options:
 
 Running the application with the empty list of options yields an error message.
 
-To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md). The list of models supported by the demo is in [models.lst](./models.lst).
+To run the demo, you can use public or pre-trained models. To download the pre-trained models, use the OpenVINO [Model Downloader](../../../tools/downloader/README.md). The list of models supported by the demo is in `<omz_dir>/demos/image_processing_demo/cpp/models.lst`.
 
 > **NOTE**: Before running the demo with a trained model, make sure the model is converted to the Inference Engine format (\*.xml + \*.bin) using the [Model Optimizer tool](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 

--- a/models/intel/formula-recognition-medium-scan-0001/README.md
+++ b/models/intel/formula-recognition-medium-scan-0001/README.md
@@ -24,7 +24,7 @@ Vocabulary file is located under corresponding model configuration directory, `<
 | im2latex_medium_rendered dataset, im2latex-match-images metric     | 95.7%     |
 | Source framework                                                   | PyTorch\* |
 
-Im2latex-match-images metric is calculated by [this algorithm](../../../tools/accuracy_checker/accuracy_checker/metrics/im2latex_images_match.py )
+Im2latex-match-images metric is calculated by `<omz_dir>/tools/accuracy_checker/accuracy_checker/metrics/im2latex_images_match.py`
 
 ## Encoder model specification
 

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/README.md
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/README.md
@@ -25,7 +25,7 @@ Vocabulary file is located under corresponding model configuration directory, `<
 | im2latex_polynomials_handwritten dataset, im2latex-match-images metric | 70.5%     |
 | Source framework                                                       | PyTorch\* |
 
-Im2latex-match-images metric is calculated by [this algorithm](../../../tools/accuracy_checker/accuracy_checker/metrics/im2latex_images_match.py )
+Im2latex-match-images metric is calculated by `<omz_dir>/tools/accuracy_checker/accuracy_checker/metrics/im2latex_images_match.py`
 
 ## Encoder model specification
 

--- a/models/public/brain-tumor-segmentation-0001/README.md
+++ b/models/public/brain-tumor-segmentation-0001/README.md
@@ -106,4 +106,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://github.com/lachinov/brats2018-graphlabunn/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/cocosnet/README.md
+++ b/models/public/cocosnet/README.md
@@ -19,7 +19,7 @@ For details see [paper](https://arxiv.org/abs/2004.05571) and [repository](https
 Metrics were calculated between generated images by model and real validation images from ADE20k dataset.
 For some GAN metrics (IS and FID) you need to use classification model as verification network.
 In our case it is [Inception-V3](../googlenet-v3/README.md) model.
-For details, please check Accuracy Checker [config](accuracy-check-pipelined.yml).
+For details, please check Accuracy Checker config `<omz_dir>/models/public/cocosnet/accuracy-check-pipelined.yml`.
 
 | Metric | Original model | Converted model |
 | ------ | -------------- | --------------- |

--- a/models/public/deeplabv3/README.md
+++ b/models/public/deeplabv3/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/densenet-121-caffe2/README.md
+++ b/models/public/densenet-121-caffe2/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/facebookarchive/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/densenet-161-tf/README.md
+++ b/models/public/densenet-161-tf/README.md
@@ -74,4 +74,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/pudae/tensorflow-densenet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-DenseNet.txt](../licenses/APACHE-2.0-TF-DenseNet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-DenseNet.txt`.

--- a/models/public/detr-resnet50/README.md
+++ b/models/public/detr-resnet50/README.md
@@ -101,4 +101,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/facebookresearch/detr/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-FacebookResearch.txt](../licenses/APACHE-2.0-FacebookResearch.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-FacebookResearch.txt`.

--- a/models/public/efficientdet-d0-tf/README.md
+++ b/models/public/efficientdet-d0-tf/README.md
@@ -90,4 +90,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/google/automl/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-AutoML.txt](../licenses/APACHE-2.0-TF-AutoML.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-AutoML.txt`.

--- a/models/public/efficientdet-d1-tf/README.md
+++ b/models/public/efficientdet-d1-tf/README.md
@@ -58,7 +58,7 @@ bounding boxes. For each detection, the description has the format:
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner
 - `confidence` - confidence for the predicted class
-- `label` - predicted class ID, in range [1, 91] across following [labels](../../../data/dataset_classes/coco_91cl.txt)
+- `label` - predicted class ID, in range [1, 91] across following labels at `<omz_dir>/data/dataset_classes/coco_91cl.txt`
 
 ### Converted Model
 
@@ -67,7 +67,7 @@ bounding boxes. For each detection, the description has the format:
 [`image_id`, `label`, `conf`, `x_min`, `y_min`, `x_max`, `y_max`], where:
 
 - `image_id` - ID of the image in the batch
-- `label` - predicted class ID, in range [0, 90] across following [labels](../../../data/dataset_classes/coco_91cl.txt)
+- `label` - predicted class ID, in range [0, 90] across following labels at `<omz_dir>/data/dataset_classes/coco_91cl.txt`
 - `conf` - confidence for the predicted class
 - (`x_min`, `y_min`) - coordinates of the top left bounding box corner (coordinates stored in normalized format, in range [0, 1])
 - (`x_max`, `y_max`) - coordinates of the bottom right bounding box corner  (coordinates stored in normalized format, in range [0, 1])
@@ -90,4 +90,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/google/automl/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-AutoML.txt](../licenses/APACHE-2.0-TF-AutoML.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-AutoML.txt`.

--- a/models/public/efficientnet-b0-pytorch/README.md
+++ b/models/public/efficientnet-b0-pytorch/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/5e91628ed98250989a7ddd20abfe27385e0493c1/LICENSE).
-A copy of the license is provided in [APACHE-2.0-PyTorch-EfficientNet.txt](../licenses/APACHE-2.0-PyTorch-EfficientNet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-PyTorch-EfficientNet.txt`.

--- a/models/public/efficientnet-b0/README.md
+++ b/models/public/efficientnet-b0/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/tpu/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-TPU.txt](../licenses/APACHE-2.0-TF-TPU.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-TPU.txt`.

--- a/models/public/efficientnet-b0_auto_aug/README.md
+++ b/models/public/efficientnet-b0_auto_aug/README.md
@@ -83,4 +83,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/tpu/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-TPU.txt](../licenses/APACHE-2.0-TF-TPU.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-TPU.txt`.

--- a/models/public/efficientnet-b5-pytorch/README.md
+++ b/models/public/efficientnet-b5-pytorch/README.md
@@ -88,4 +88,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/5e91628ed98250989a7ddd20abfe27385e0493c1/LICENSE).
-A copy of the license is provided in [APACHE-2.0-PyTorch-EfficientNet.txt](../licenses/APACHE-2.0-PyTorch-EfficientNet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-PyTorch-EfficientNet.txt`.

--- a/models/public/efficientnet-b5/README.md
+++ b/models/public/efficientnet-b5/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/tpu/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-TPU.txt](../licenses/APACHE-2.0-TF-TPU.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-TPU.txt`.

--- a/models/public/efficientnet-b7-pytorch/README.md
+++ b/models/public/efficientnet-b7-pytorch/README.md
@@ -88,4 +88,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/5e91628ed98250989a7ddd20abfe27385e0493c1/LICENSE).
-A copy of the license is provided in [APACHE-2.0-PyTorch-EfficientNet.txt](../licenses/APACHE-2.0-PyTorch-EfficientNet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-PyTorch-EfficientNet.txt`.

--- a/models/public/efficientnet-b7_auto_aug/README.md
+++ b/models/public/efficientnet-b7_auto_aug/README.md
@@ -83,4 +83,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/tpu/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-TPU.txt](../licenses/APACHE-2.0-TF-TPU.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-TPU.txt`.

--- a/models/public/face-detection-retail-0044/README.md
+++ b/models/public/face-detection-retail-0044/README.md
@@ -93,6 +93,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/opencv/training_toolbox_caffe/develop/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/face-recognition-resnet100-arcface-onnx/README.md
+++ b/models/public/face-recognition-resnet100-arcface-onnx/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/onnx/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/README.md
+++ b/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/faster_rcnn_inception_v2_coco/README.md
+++ b/models/public/faster_rcnn_inception_v2_coco/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/faster_rcnn_resnet101_coco/README.md
+++ b/models/public/faster_rcnn_resnet101_coco/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/faster_rcnn_resnet50_coco/README.md
+++ b/models/public/faster_rcnn_resnet50_coco/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/googlenet-v1-tf/README.md
+++ b/models/public/googlenet-v1-tf/README.md
@@ -81,8 +81,8 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://github.com/tensorflow/models/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.
 
 The original model uses the TF-Slim library, which is distributed under the
 [Apache License, Version 2.0](https://github.com/google-research/tf-slim/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TFSlim.txt](../licenses/APACHE-2.0-TFSlim.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TFSlim.txt`.

--- a/models/public/googlenet-v2-tf/README.md
+++ b/models/public/googlenet-v2-tf/README.md
@@ -81,8 +81,8 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://github.com/tensorflow/models/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.
 
 The original model uses the TF-Slim library, which is distributed under the
 [Apache License, Version 2.0](https://github.com/google-research/tf-slim/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TFSlim.txt](../licenses/APACHE-2.0-TFSlim.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TFSlim.txt`.

--- a/models/public/googlenet-v3/README.md
+++ b/models/public/googlenet-v3/README.md
@@ -70,4 +70,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/googlenet-v4-tf/README.md
+++ b/models/public/googlenet-v4-tf/README.md
@@ -81,8 +81,8 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://github.com/tensorflow/models/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.
 
 The original model uses the TF-Slim library, which is distributed under the
 [Apache License, Version 2.0](https://github.com/google-research/tf-slim/blob/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TFSlim.txt](../licenses/APACHE-2.0-TFSlim.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TFSlim.txt`.

--- a/models/public/hbonet-0.25/README.md
+++ b/models/public/hbonet-0.25/README.md
@@ -70,4 +70,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/d-li14/HBONet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/hbonet-0.5/README.md
+++ b/models/public/hbonet-0.5/README.md
@@ -70,4 +70,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/d-li14/HBONet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/hbonet-1.0/README.md
+++ b/models/public/hbonet-1.0/README.md
@@ -70,4 +70,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/d-li14/HBONet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/human-pose-estimation-3d-0001/README.md
+++ b/models/public/human-pose-estimation-3d-0001/README.md
@@ -54,6 +54,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/opencv/openvino_training_extensions/develop/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/i3d-rgb-tf/README.md
+++ b/models/public/i3d-rgb-tf/README.md
@@ -22,7 +22,7 @@ Originally redistributed as a checkpoint file, was converted to frozen graph.
     tensorflow-probability==0.4.0
     dm-sonnet==1.26
     ```
-1. Copy [script](./freeze.py) to root directory of original repository and run it:
+1. Copy `<omz_dir>/models/public/i3d-rgb-tf/freeze.py` script to root directory of original repository and run it:
     ```
     python freeze.py
     ```
@@ -104,4 +104,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 ## Legal Information
 
 The original model is distributed under the
-[Apache License, Version 2.0](https://raw.githubusercontent.com/deepmind/kinetics-i3d/0667e889a5904b4dc122e0ded4c332f49f8df42c/LICENSE). A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+[Apache License, Version 2.0](https://raw.githubusercontent.com/deepmind/kinetics-i3d/0667e889a5904b4dc122e0ded4c332f49f8df42c/LICENSE). A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/inception-resnet-v2-tf/README.md
+++ b/models/public/inception-resnet-v2-tf/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/license-plate-recognition-barrier-0007/README.md
+++ b/models/public/license-plate-recognition-barrier-0007/README.md
@@ -225,6 +225,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 ## Legal Information
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/opencv/openvino_training_extensions/develop/LICENSE).
-A copy of the license is provided in [APACHE-2.0](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/README.md
+++ b/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/README.md
@@ -91,4 +91,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mask_rcnn_inception_v2_coco/README.md
+++ b/models/public/mask_rcnn_inception_v2_coco/README.md
@@ -97,4 +97,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mask_rcnn_resnet101_atrous_coco/README.md
+++ b/models/public/mask_rcnn_resnet101_atrous_coco/README.md
@@ -91,4 +91,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mask_rcnn_resnet50_atrous_coco/README.md
+++ b/models/public/mask_rcnn_resnet50_atrous_coco/README.md
@@ -92,4 +92,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mixnet-l/README.md
+++ b/models/public/mixnet-l/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/tpu/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-TPU.txt](../licenses/APACHE-2.0-TF-TPU.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-TPU.txt`.

--- a/models/public/mobilenet-v1-0.25-128/README.md
+++ b/models/public/mobilenet-v1-0.25-128/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v1-0.50-160/README.md
+++ b/models/public/mobilenet-v1-0.50-160/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v1-0.50-224/README.md
+++ b/models/public/mobilenet-v1-0.50-224/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v1-1.0-224-tf/README.md
+++ b/models/public/mobilenet-v1-1.0-224-tf/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v2-1.0-224/README.md
+++ b/models/public/mobilenet-v2-1.0-224/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v2-1.4-224/README.md
+++ b/models/public/mobilenet-v2-1.4-224/README.md
@@ -76,4 +76,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v3-large-1.0-224-tf/README.md
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/README.md
@@ -84,4 +84,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mobilenet-v3-small-1.0-224-tf/README.md
+++ b/models/public/mobilenet-v3-small-1.0-224-tf/README.md
@@ -84,4 +84,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/mozilla-deepspeech-0.6.1/README.md
+++ b/models/public/mozilla-deepspeech-0.6.1/README.md
@@ -41,7 +41,7 @@ Increasing beam_width improves WER metric and slows down decoding.  Speech Recog
     - `T` - context frames: along with the current frame, the network expects 9 preceding frames and 9 succeeding frames. The absent context frames are filled with zeros.
     - `C` - 26 MFCC coefficients per each frame
 
-    See [`accuracy-check.yml`](accuracy-check.yml) for all audio preprocessing and feature extraction parameters.
+    See `<omz_dir>/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml` for all audio preprocessing and feature extraction parameters.
 
  2. Number of audio frames, INT32 value, name: `input_lengths`, shape `1`.
 
@@ -59,7 +59,7 @@ Chunk processing order must be from early to late audio positions.
     - `T` - context frames: along with the current frame, the network expects 9 preceding frames and 9 succeeding frames. The absent context frames are filled with zeros.
     - `C` - 26 MFCC coefficients in each frame
 
-    See [`accuracy-check.yml`](accuracy-check.yml) for all audio preprocessing and feature extraction parameters.
+    See `<omz_dir>/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml` for all audio preprocessing and feature extraction parameters.
 
  2. LSTM in-state and input vectors. Names: `previous_state_c` and `previous_state_h`, shapes: `1, 2048`, format: `B, C`.
 
@@ -121,4 +121,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Mozilla Public License, Version 2.0](https://raw.githubusercontent.com/mozilla/DeepSpeech/master/LICENSE).
-A copy of the license is provided in [MPL-2.0-Mozilla-Deepspeech.txt](../licenses/MPL-2.0-Mozilla-Deepspeech.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/MPL-2.0-Mozilla-Deepspeech.txt`.

--- a/models/public/mozilla-deepspeech-0.8.2/README.md
+++ b/models/public/mozilla-deepspeech-0.8.2/README.md
@@ -42,7 +42,7 @@ Increasing beam_width improves WER metric and slows down decoding. Speech Recogn
     - `T` - context frames: along with the current frame, the network expects 9 preceding frames and 9 succeeding frames. The absent context frames are filled with zeros.
     - `C` - 26 MFCC coefficients per each frame
 
-    See [`accuracy-check.yml`](accuracy-check.yml) for all audio preprocessing and feature extraction parameters.
+    See `<omz_dir>/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml` for all audio preprocessing and feature extraction parameters.
 
  2. Number of audio frames, INT32 value, name: `input_lengths`, shape `1`.
 
@@ -62,7 +62,7 @@ Chunk processing order must be from early to late audio positions.
     - `T` - context frames: along with the current frame, the network expects 9 preceding frames and 9 succeeding frames. The absent context frames are filled with zeros.
     - `C` - 26 MFCC coefficients in each frame
 
-    See [`accuracy-check.yml`](accuracy-check.yml) for all audio preprocessing and feature extraction parameters.
+    See `<omz_dir>/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml` for all audio preprocessing and feature extraction parameters.
 
  2. LSTM in-state vector, name: `previous_state_c`, shape: `1, 2048`, format: `B, C`.
 
@@ -125,4 +125,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Mozilla Public License, Version 2.0](https://raw.githubusercontent.com/mozilla/DeepSpeech/master/LICENSE).
-A copy of the license is provided in [MPL-2.0-Mozilla-Deepspeech.txt](../licenses/MPL-2.0-Mozilla-Deepspeech.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/MPL-2.0-Mozilla-Deepspeech.txt`.

--- a/models/public/nfnet-f0/README.md
+++ b/models/public/nfnet-f0/README.md
@@ -87,4 +87,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/rwightman/pytorch-image-models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-PyTorch-Image-Models.txt](../licenses/APACHE-2.0-PyTorch-Image-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-PyTorch-Image-Models.txt`.

--- a/models/public/pelee-coco/README.md
+++ b/models/public/pelee-coco/README.md
@@ -91,6 +91,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/Robert-JunWang/Pelee/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/pspnet-pytorch/README.md
+++ b/models/public/pspnet-pytorch/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/open-mmlab/mmsegmentation/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-MMSegmentation-Models.txt](../licenses/APACHE-2.0-MMSegmentation-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-MMSegmentation-Models.txt`.

--- a/models/public/quartznet-15x5-en/README.md
+++ b/models/public/quartznet-15x5-en/README.md
@@ -48,7 +48,7 @@ Per-frame probabilities (after LogSoftmax) for every symbol in the alphabet, nam
 - C - alphabet size, including the CTC blank symbol
 
 The per-frame probabilities are to be decoded with a CTC decoder.
-The alphabet is: 0 = space, 1...26 = "a" to "z", 27 = apostrophe, 28 = CTC blank symbol. Example is provided [here](../../../demos/speech_recognition_deepspeech_demo/python/default_alphabet_example.conf).
+The alphabet is: 0 = space, 1...26 = "a" to "z", 27 = apostrophe, 28 = CTC blank symbol. Example is provided at `<omz_dir>/demos/speech_recognition_deepspeech_demo/python/default_alphabet_example.conf`.
 
 #### Converted model
 
@@ -72,4 +72,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/NVIDIA/NeMo/main/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/resnest-50-pytorch/README.md
+++ b/models/public/resnest-50-pytorch/README.md
@@ -82,6 +82,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/zhanghang1989/ResNeSt/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/resnet-50-caffe2/README.md
+++ b/models/public/resnet-50-caffe2/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/facebookarchive/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/retinanet-tf/README.md
+++ b/models/public/retinanet-tf/README.md
@@ -106,4 +106,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/fizyr/keras-retinanet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/rfcn-resnet101-coco-tf/README.md
+++ b/models/public/rfcn-resnet101-coco-tf/README.md
@@ -88,4 +88,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/se-inception/README.md
+++ b/models/public/se-inception/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/se-resnet-101/README.md
+++ b/models/public/se-resnet-101/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/se-resnet-152/README.md
+++ b/models/public/se-resnet-152/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/se-resnet-50/README.md
+++ b/models/public/se-resnet-50/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/se-resnext-101/README.md
+++ b/models/public/se-resnext-101/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/se-resnext-50/README.md
+++ b/models/public/se-resnext-50/README.md
@@ -79,4 +79,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/hujie-frank/SENet/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-SENet.txt](../licenses/APACHE-2.0-SENet.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-SENet.txt`.

--- a/models/public/single-human-pose-estimation-0001/README.md
+++ b/models/public/single-human-pose-estimation-0001/README.md
@@ -64,6 +64,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 ## Legal Information
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/opencv/openvino_training_extensions/develop/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/squeezenet1.1-caffe2/README.md
+++ b/models/public/squeezenet1.1-caffe2/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/facebookarchive/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/ssd-resnet34-1200-onnx/README.md
+++ b/models/public/ssd-resnet34-1200-onnx/README.md
@@ -80,4 +80,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/mlcommons/inference/master/LICENSE.md).
-A copy of the license is provided in [APACHE-2.0-MLPerf.txt](../licenses/APACHE-2.0-MLPerf.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-MLPerf.txt`.

--- a/models/public/ssd_mobilenet_v1_coco/README.md
+++ b/models/public/ssd_mobilenet_v1_coco/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/ssd_mobilenet_v1_fpn_coco/README.md
+++ b/models/public/ssd_mobilenet_v1_fpn_coco/README.md
@@ -84,4 +84,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/ssd_mobilenet_v2_coco/README.md
+++ b/models/public/ssd_mobilenet_v2_coco/README.md
@@ -89,4 +89,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/ssd_resnet50_v1_fpn_coco/README.md
+++ b/models/public/ssd_resnet50_v1_fpn_coco/README.md
@@ -86,4 +86,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/ssdlite_mobilenet_v2/README.md
+++ b/models/public/ssdlite_mobilenet_v2/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/tensorflow/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0-TF-Models.txt](../licenses/APACHE-2.0-TF-Models.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0-TF-Models.txt`.

--- a/models/public/text-recognition-resnet-fc/README.md
+++ b/models/public/text-recognition-resnet-fc/README.md
@@ -49,7 +49,7 @@ The network output decoding process is pretty easy: get the argmax on `L` dimens
 
 ## Use text-detection demo
 
-Model is supported by [text-detection c++ demo](../../../demos/text_detection_demo/cpp/main.cpp). In order to use this model in the demo, user should pass the following options:
+Model is supported by text-detection c++ demo(`<omz_dir>/demos/text_detection_demo/cpp/main.cpp`). In order to use this model in the demo, user should pass the following options:
 ```
   -tr_pt_first
   -dt "simple"
@@ -61,6 +61,6 @@ For more information, please, see documentation of the demo.
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://github.com/Media-Smart/vedastr/blob/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/vehicle-license-plate-detection-barrier-0123/README.md
+++ b/models/public/vehicle-license-plate-detection-barrier-0123/README.md
@@ -94,6 +94,6 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 ## Legal Information
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/opencv/openvino_training_extensions/develop/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.
 
 [*] Other names and brands may be claimed as the property of others.

--- a/models/public/vgg16/README.md
+++ b/models/public/vgg16/README.md
@@ -83,4 +83,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode.txt).
-A copy of the license is provided in [CC-BY-4.0.txt](../licenses/CC-BY-4.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/CC-BY-4.0.txt`.

--- a/models/public/vgg19-caffe2/README.md
+++ b/models/public/vgg19-caffe2/README.md
@@ -82,4 +82,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Apache License, Version 2.0](https://raw.githubusercontent.com/facebookarchive/models/master/LICENSE).
-A copy of the license is provided in [APACHE-2.0.txt](../licenses/APACHE-2.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/APACHE-2.0.txt`.

--- a/models/public/vgg19/README.md
+++ b/models/public/vgg19/README.md
@@ -83,4 +83,4 @@ python3 <omz_dir>/tools/downloader/converter.py --name <model_name>
 
 The original model is distributed under the
 [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode.txt).
-A copy of the license is provided in [CC-BY-4.0.txt](../licenses/CC-BY-4.0.txt).
+A copy of the license is provided in `<omz_dir>/models/public/licenses/CC-BY-4.0.txt`.

--- a/tools/accuracy_checker/README.md
+++ b/tools/accuracy_checker/README.md
@@ -196,7 +196,7 @@ all required preprocessing and postprocessing/filtering steps,
 and metrics that will be used for evaluation.
 
 If your dataset data is a well-known competition problem (COCO, Pascal VOC, and others) and/or can be potentially reused for other models
-it is reasonable to declare it in some global configuration file ([definition file](dataset_definitions.yml)). This way in your local configuration file you can provide only
+it is reasonable to declare it in some global configuration file (`<omz_dir>/data/dataset_definitions.yml`). This way in your local configuration file you can provide only
 `name` and all required steps will be picked from global one. To pass path to this global configuration use `--definition` argument of CLI.
 
 If you want to evaluate models using prepared config files and well-known datasets, you need to organize folders with validation datasets in a certain way. More detailed information about dataset preparation you can find in [Dataset Preparation Guide](../../data/datasets.md).

--- a/tools/accuracy_checker/configs/README.md
+++ b/tools/accuracy_checker/configs/README.md
@@ -48,7 +48,7 @@ Predefined configuration file `accuracy-check.yml` for each Open Model Zoo model
 
 Example:
 
-[alexnet.yml](alexnet.yml) is a link for configuration file [accuracy-check.yml](../../../models/public/alexnet/accuracy-check.yml) for [alexnet](../../../models/public/alexnet/README.md) model.
+`<omz_dir>/tools/accuracy_checker/configs/alexnet.yml` is a link for configuration file at `<omz_dir>/models/public/alexnet/accuracy-check.yml` for [alexnet](../../../models/public/alexnet/README.md) model.
 
 ## Options
 

--- a/tools/accuracy_checker/configs/README.md
+++ b/tools/accuracy_checker/configs/README.md
@@ -48,7 +48,7 @@ Predefined configuration file `accuracy-check.yml` for each Open Model Zoo model
 
 Example:
 
-`<omz_dir>/tools/accuracy_checker/configs/alexnet.yml` is a link for configuration file at `<omz_dir>/models/public/alexnet/accuracy-check.yml` for [alexnet](../../../models/public/alexnet/README.md) model.
+`<omz_dir>/tools/accuracy_checker/configs/alexnet.yml` is a link for configuration file `<omz_dir>/models/public/alexnet/accuracy-check.yml` for [alexnet](../../../models/public/alexnet/README.md) model.
 
 ## Options
 


### PR DESCRIPTION
Also all relative links to non-markdown files in documentation files were replaced by `<omz_dir>/..` ones.