### PR TITLE
Update formula-recognition-demo docs.

### DIFF
--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -64,6 +64,12 @@ Ubuntu:
 `apt-get update && apt-get install texlive`
 MacOS:
 `brew install texlive`
+
+If you face the `RuntimeError: dvipng is not installed` error, install it via
+`apt-get update && apt-get install dvipng`.
+You might also face the problem of missing `standalone.cls` file, it could be fixed with:
+`apt-get install texlive-latex-extra`.
+
 > Note: Other LaTeX systems should also work.
 
 ### Interactive mode

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -65,7 +65,7 @@ Ubuntu:
 MacOS:
 `brew install texlive`
 
-If you face the `RuntimeError: dvipng is not installed` error, you need to install this library. For Linux you can do it via
+If you face the `RuntimeError: dvipng is not installed` error, you need to install this library. For Linux, you can do it via
 `apt-get update && apt-get install dvipng`.
 You might also face the missing `standalone.cls` file problem, which could be fixed with the installation of `texlive-latex-extra` package. For Linux, it can be done using this command:
 `apt-get install texlive-latex-extra`.

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -67,7 +67,7 @@ MacOS:
 
 If you face the `RuntimeError: dvipng is not installed` error, you need to install this library. For Linux you can do it via
 `apt-get update && apt-get install dvipng`.
-You might also face the problem of missing `standalone.cls` file, it could be fixed with installation `texlive-latex-extra` package. For Linux it can be done using this command :
+You might also face the missing `standalone.cls` file problem, which could be fixed with the installation of `texlive-latex-extra` package. For Linux, it can be done using this command:
 `apt-get install texlive-latex-extra`.
 
 > Note: Other LaTeX systems should also work.

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -65,9 +65,9 @@ Ubuntu:
 MacOS:
 `brew install texlive`
 
-If you face the `RuntimeError: dvipng is not installed` error, install it via
+If you face the `RuntimeError: dvipng is not installed` error, you need to install this library. For Linux you can do it via
 `apt-get update && apt-get install dvipng`.
-You might also face the problem of missing `standalone.cls` file, it could be fixed with:
+You might also face the problem of missing `standalone.cls` file, it could be fixed with installation `texlive-latex-extra` package. For Linux it can be done using this command :
 `apt-get install texlive-latex-extra`.
 
 > Note: Other LaTeX systems should also work.


### PR DESCRIPTION
In some cases, `dvi-png` is not included in texlive distribution and should be installed separately. Also, `standalone.cls` may be required (not included in texlive by default). It is installed as part of the texlive-extra package.