### PR TITLE
Fix test case for cpp smart classroom demo

### DIFF
--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -391,7 +391,7 @@ NATIVE_DEMOS = [
         ],
     )),
 
-    CppDemo(name='smart_classroom_demo', implementation='cpp_gapi',
+    CppDemo(name='smart_classroom_demo',
             device_keys=['-d_act', '-d_fd', '-d_lm', '-d_reid'],
             test_cases=combine_cases(
         TestCase(options={'-no_show': None,


### PR DESCRIPTION
cpp smart classroom demo hasn't been tested since merging gapi version of this demo due to changes in [cases.py](https://github.com/openvinotoolkit/open_model_zoo/blob/develop/demos/tests/cases.py). In both cases were tested cpp_gapi demo ([here](https://github.com/openvinotoolkit/open_model_zoo/blob/d488c3b5705383de38eb20b51ba83b02f82ed6da/demos/tests/cases.py#L394) and [here](https://github.com/openvinotoolkit/open_model_zoo/blob/d488c3b5705383de38eb20b51ba83b02f82ed6da/demos/tests/cases.py#L428)).