### PR TITLE
Added checks for models references in documentation files

### DIFF
--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -174,11 +174,20 @@ def add_model_pages(output_root, parent_element, group, group_title):
         id=f'omz_models_group_{group}', path=f'models/{group}/index.md')
 
     task_type_elements = {}
+    device_support_path = OMZ_ROOT / 'models' / group / 'device_support.md'
+
+    with (device_support_path).open('r', encoding="utf-8") as device_support_file:
+        raw_device_support = device_support_file.read()
 
     for md_path in sorted(OMZ_ROOT.glob(f'models/{group}/*/**/*.md')):
         md_path_rel = md_path.relative_to(OMZ_ROOT)
 
         model_name = md_path_rel.parts[2]
+
+        device_support_path_rel = device_support_path.relative_to(OMZ_ROOT)
+
+        if model_name not in raw_device_support:
+            raise RuntimeError(f'{device_support_path_rel}: missing "{model_name}" model.')
 
         expected_md_path = Path('models', group, model_name, 'README.md')
 

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -187,7 +187,7 @@ def add_model_pages(output_root, parent_element, group, group_title):
         device_support_path_rel = device_support_path.relative_to(OMZ_ROOT)
 
         if model_name not in raw_device_support:
-            raise RuntimeError(f'{device_support_path_rel}: missing "{model_name}" model.')
+            raise RuntimeError(f'{device_support_path_rel}: "{model_name}" model reference is missing.')
 
         expected_md_path = Path('models', group, model_name, 'README.md')
 
@@ -295,20 +295,20 @@ def main():
         md_path_rel = md_path.relative_to(OMZ_ROOT)
 
         with (md_path.parent / 'models.lst').open('r', encoding="utf-8") as models_lst:
-            raw_models_lines = models_lst.readlines()
+            models_lines = models_lst.readlines()
 
         with (md_path).open('r', encoding="utf-8") as demo_readme:
-            raw_readme_lines = demo_readme.read()
+            raw_demo_readme = demo_readme.read()
 
-        for line in raw_models_lines:
-            if line.startswith('#'):
+        for model_line in models_lines:
+            if model_line.startswith('#'):
                 continue
 
-            line = line.replace('\n', '')
-            regex_line = line.replace('?', '.').replace('*', '.*')
+            model_line = model_line.rstrip('\n')
+            regex_line = model_line.replace('?', '.').replace('*', '.*')
 
-            if not re.search(regex_line, raw_readme_lines):
-                raise RuntimeError(f'{md_path_rel}: model reference "{line}" is missing. '
+            if not re.search(regex_line, raw_demo_readme):
+                raise RuntimeError(f'{md_path_rel}: "{model_line}" model reference is missing. '
                     'Add it to README.md or update models.lst file.')
 
         # <name>_<implementation>

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -285,6 +285,23 @@ def main():
     ]:
         md_path_rel = md_path.relative_to(OMZ_ROOT)
 
+        with (md_path.parent / 'models.lst').open('r', encoding="utf-8") as models_lst:
+            raw_models_lines = models_lst.readlines()
+
+        with (md_path).open('r', encoding="utf-8") as demo_readme:
+            raw_readme_lines = demo_readme.read()
+
+        for line in raw_models_lines:
+            if line.startswith('#'):
+                continue
+
+            line = line.replace('\n', '')
+            regex_line = line.replace('?', '.').replace('*', '.*')
+
+            if not re.search(regex_line, raw_readme_lines):
+                raise RuntimeError(f'{md_path_rel}: model reference "{line}" is missing. '
+                    'Add it to README.md or update models.lst file.')
+
         # <name>_<implementation>
         demo_id = '_'.join(md_path_rel.parts[1:3])
 

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -176,7 +176,7 @@ def add_model_pages(output_root, parent_element, group, group_title):
     task_type_elements = {}
     device_support_path = OMZ_ROOT / 'models' / group / 'device_support.md'
 
-    with (device_support_path).open('r', encoding="utf-8") as device_support_file:
+    with device_support_path.open('r', encoding="utf-8") as device_support_file:
         raw_device_support = device_support_file.read()
 
     device_support_lines = re.findall(r'^\|\s\S+\s\|', raw_device_support, re.MULTILINE)

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -326,7 +326,7 @@ def main():
 
             if not re.search(regex_line, raw_demo_readme):
                 raise RuntimeError(f'{md_path_rel}: "{model_line}" model reference is missing. '
-                    'Add it to README.md or update models.lst file.')
+                                   'Add it to README.md or update models.lst file.')
 
         # <name>_<implementation>
         demo_id = '_'.join(md_path_rel.parts[1:3])

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -322,7 +322,7 @@ def main():
                 continue
 
             model_line = model_line.rstrip('\n')
-            regex_line = model_line.replace('?', '.').replace('*', '[^\s]+')
+            regex_line = model_line.replace('?', '.').replace('*', '\S+')
 
             if not re.search(regex_line, raw_demo_readme):
                 raise RuntimeError(f'{md_path_rel}: "{model_line}" model reference is missing. '

--- a/ci/prepare-documentation.py
+++ b/ci/prepare-documentation.py
@@ -322,7 +322,7 @@ def main():
                 continue
 
             model_line = model_line.rstrip('\n')
-            regex_line = model_line.replace('?', '.').replace('*', '\S+')
+            regex_line = model_line.replace('?', r'.').replace('*', r'\S+')
 
             if not re.search(regex_line, raw_demo_readme):
                 raise RuntimeError(f'{md_path_rel}: "{model_line}" model reference is missing. '

--- a/demos/classification_demo/cpp/README.md
+++ b/demos/classification_demo/cpp/README.md
@@ -62,6 +62,7 @@ python3 <omz_dir>/tools/downloader/converter.py --list models.lst
 * hbonet-0.5
 * hbonet-1.0
 * inception-resnet-v2-tf
+* mixnet-l
 * mobilenet-v1-0.25-128
 * mobilenet-v1-0.50-160
 * mobilenet-v1-0.50-224

--- a/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
+++ b/demos/multi_channel_object_detection_demo_yolov3/cpp/README.md
@@ -33,6 +33,7 @@ python3 <omz_dir>/tools/downloader/converter.py --list models.lst
 
 ### Supported Models
 
+* person-vehicle-bike-detection-crossroad-yolov3-1020
 * yolo-v3-tf
 * yolo-v3-tiny-tf
 

--- a/demos/object_detection_demo/cpp/README.md
+++ b/demos/object_detection_demo/cpp/README.md
@@ -103,8 +103,8 @@ python3 <omz_dir>/tools/downloader/converter.py --list models.lst
   - person-vehicle-bike-detection-2004
   - product-detection-0001
   - rfcn-resnet101-coco-tf
-  - retinanet-tf
   - retinaface-resnet50-pytorch
+  - retinanet-tf
   - ssd300
   - ssd512
   - ssd-resnet34-1200-onnx

--- a/demos/object_detection_demo/cpp/README.md
+++ b/demos/object_detection_demo/cpp/README.md
@@ -104,6 +104,7 @@ python3 <omz_dir>/tools/downloader/converter.py --list models.lst
   - product-detection-0001
   - rfcn-resnet101-coco-tf
   - retinanet-tf
+  - retinaface-resnet50-pytorch
   - ssd300
   - ssd512
   - ssd-resnet34-1200-onnx

--- a/demos/text_detection_demo/cpp/README.md
+++ b/demos/text_detection_demo/cpp/README.md
@@ -114,7 +114,7 @@ For example, use the following command line command to run the application:
   -tr_o_blb_nm "logits"
 ```
 
-For `text-recognition-resnet-fc` and `text-recognition-0015` you should use `simple` decoder (`text-recognition-0015-decoder`) for `-dt` option. For other models use `ctc` decoder (default decoder). In case of `text-recognition-0015` model, specify path to `text-recognition-0015-encoder` models for `-m_tr` key and decoder part will be found automatically as shown on example below:
+For `text-recognition-resnet-fc` and `text-recognition-0015` you should use `simple` decoder for `-dt` option. For other models use `ctc` decoder (default decoder). In case of `text-recognition-0015` model, specify path to `text-recognition-0015-encoder` models for `-m_tr` key and decoder part (`text-recognition-0015-decoder`) will be found automatically as shown on example below:
 
 ```sh
 ./text_detection_demo \

--- a/demos/text_detection_demo/cpp/README.md
+++ b/demos/text_detection_demo/cpp/README.md
@@ -114,7 +114,7 @@ For example, use the following command line command to run the application:
   -tr_o_blb_nm "logits"
 ```
 
-For `text-recognition-resnet-fc` and `text-recognition-0015` you should use `simple` decoder for `-dt` option. For other models use `ctc` decoder (default decoder). In case of `text-recognition-0015` model, specify path to `text-recognition-0015-encoder` models for `-m_tr` key and decoder part will be found automatically as shown on example below:
+For `text-recognition-resnet-fc` and `text-recognition-0015` you should use `simple` decoder (`text-recognition-0015-decoder`) for `-dt` option. For other models use `ctc` decoder (default decoder). In case of `text-recognition-0015` model, specify path to `text-recognition-0015-encoder` models for `-m_tr` key and decoder part will be found automatically as shown on example below:
 
 ```sh
 ./text_detection_demo \


### PR DESCRIPTION
checks for each model (or part of composite model) reference existence:
- in `device_support.md` files (based on models folders names)
- in demos `README.md` files (based on `models.lst` files content)