### PR TITLE
fix object_detection_demo work on hddl

### DIFF
--- a/demos/common/cpp/pipelines/include/pipelines/requests_pool.h
+++ b/demos/common/cpp/pipelines/include/pipelines/requests_pool.h
@@ -28,6 +28,7 @@
 class RequestsPool {
 public:
     RequestsPool(InferenceEngine::ExecutableNetwork& execNetwork, unsigned int size);
+    ~RequestsPool();
 
     /// Returns idle request from the pool. Returned request is automatically marked as In Use (this status will be reset after request processing completion)
     /// This function is thread safe as long as request is used only until setRequestIdle call

--- a/demos/common/cpp/pipelines/src/async_pipeline.cpp
+++ b/demos/common/cpp/pipelines/src/async_pipeline.cpp
@@ -107,9 +107,9 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
             condVar.notify_one();
     });
 
-        inputFrameId++;
-        if (inputFrameId < 0)
-            inputFrameId = 0;
+    inputFrameId++;
+    if (inputFrameId < 0)
+        inputFrameId = 0;
 
     request->StartAsync();
 

--- a/demos/common/cpp/pipelines/src/async_pipeline.cpp
+++ b/demos/common/cpp/pipelines/src/async_pipeline.cpp
@@ -74,8 +74,7 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
     preprocessMetrics.update(startTime);
 
     request->SetCompletionCallback(
-        [this, frameID, request, internalModelData, metaData, startTime]()
-        {
+        [this, frameID, request, internalModelData, metaData, startTime]() {
             {
                 const std::lock_guard<std::mutex> lock(mtx);
                 inferenceMetrics.update(startTime);

--- a/demos/common/cpp/pipelines/src/async_pipeline.cpp
+++ b/demos/common/cpp/pipelines/src/async_pipeline.cpp
@@ -105,7 +105,7 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
                 }
             }
             condVar.notify_one();
-        });
+    });
 
         inputFrameId++;
         if (inputFrameId < 0)

--- a/demos/common/cpp/pipelines/src/async_pipeline.cpp
+++ b/demos/common/cpp/pipelines/src/async_pipeline.cpp
@@ -47,12 +47,16 @@ AsyncPipeline::~AsyncPipeline() {
 void AsyncPipeline::waitForData(bool shouldKeepOrder) {
     std::unique_lock<std::mutex> lock(mtx);
 
-    condVar.wait(lock, [&] {return callbackException != nullptr ||
-        requestsPool->isIdleRequestAvailable() ||
-        (shouldKeepOrder ?
-            completedInferenceResults.find(outputFrameId) != completedInferenceResults.end() :
-            !completedInferenceResults.empty());
-    });
+    condVar.wait(
+        lock,
+        [&]()
+        {
+            return callbackException != nullptr ||
+                   requestsPool->isIdleRequestAvailable() ||
+                   (shouldKeepOrder ?
+                       completedInferenceResults.find(outputFrameId) != completedInferenceResults.end() :
+                       !completedInferenceResults.empty());
+        });
 
     if (callbackException)
         std::rethrow_exception(callbackException);
@@ -70,12 +74,11 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
     preprocessMetrics.update(startTime);
 
     request->SetCompletionCallback(
-        [this, frameID, request, internalModelData, metaData, startTime] {
-            request->SetCompletionCallback([]{});
-
+        [this, frameID, request, internalModelData, metaData, startTime]()
+        {
             {
-                std::lock_guard<std::mutex> lock(mtx);
-                this->inferenceMetrics.update(startTime);
+                const std::lock_guard<std::mutex> lock(mtx);
+                inferenceMetrics.update(startTime);
                 try {
                     InferenceResult result;
 
@@ -87,28 +90,27 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
                     {
                         auto blobPtr = request->GetBlob(outName);
 
-                        if(Precision::I32 == blobPtr->getTensorDesc().getPrecision())
+                        if (Precision::I32 == blobPtr->getTensorDesc().getPrecision())
                             result.outputsData.emplace(outName, std::make_shared<TBlob<int>>(*as<TBlob<int>>(blobPtr)));
                         else
                             result.outputsData.emplace(outName, std::make_shared<TBlob<float>>(*as<TBlob<float>>(blobPtr)));
                     }
 
                     completedInferenceResults.emplace(frameID, result);
-                    this->requestsPool->setRequestIdle(request);
+                    requestsPool->setRequestIdle(request);
                 }
                 catch (...) {
-                    if (!this->callbackException) {
-                        this->callbackException = std::current_exception();
+                    if (!callbackException) {
+                        callbackException = std::current_exception();
                     }
                 }
             }
-
             condVar.notify_one();
-    });
+        });
 
-    inputFrameId++;
-    if (inputFrameId < 0)
-        inputFrameId = 0;
+        inputFrameId++;
+        if (inputFrameId < 0)
+            inputFrameId = 0;
 
     request->StartAsync();
 
@@ -131,7 +133,7 @@ std::unique_ptr<ResultBase> AsyncPipeline::getResult(bool shouldKeepOrder) {
 InferenceResult AsyncPipeline::getInferenceResult(bool shouldKeepOrder) {
     InferenceResult retVal;
     {
-        std::lock_guard<std::mutex> lock(mtx);
+        const std::lock_guard<std::mutex> lock(mtx);
 
         const auto& it = shouldKeepOrder ?
             completedInferenceResults.find(outputFrameId) :

--- a/demos/common/cpp/pipelines/src/requests_pool.cpp
+++ b/demos/common/cpp/pipelines/src/requests_pool.cpp
@@ -23,6 +23,13 @@ RequestsPool::RequestsPool(InferenceEngine::ExecutableNetwork& execNetwork, unsi
     }
 }
 
+RequestsPool::~RequestsPool() {
+    // Setting empty callback to free resources allocated for previously assigned lambdas
+    for (auto& pair : requests) {
+        pair.first->SetCompletionCallback([]{});
+    }
+}
+
 InferenceEngine::InferRequest::Ptr RequestsPool::getIdleRequest() {
     std::lock_guard<std::mutex> lock(mtx);
 


### PR DESCRIPTION
Fix for [issue](https://community.intel.com/t5/forums/forumtopicpage/board-id/distribution-openvino-toolkit/message-id/24012#M24012) reported on user forum (internal id CVS-59597)
Free lambda callbacks on requests pool destruction because callback cleanup does not work from callback itself for HDDL
sync processing of tail (in main.cpp) with segmentation demo
