### PR TITLE
Change how presenter.reportMeans() is printed in python demos.

### DIFF
--- a/demos/action_recognition_demo/python/action_recognition_demo.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo.py
@@ -123,7 +123,9 @@ def main():
     cap = open_images_capture(args.input, args.loop)
     run_pipeline(cap, args.architecture_type, models, result_presenter.render_frame, args.raw_output_message,
                  seq_size=seq_size, fps=cap.fps())
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/colorization_demo/python/colorization_demo.py
+++ b/demos/colorization_demo/python/colorization_demo.py
@@ -153,4 +153,6 @@ if __name__ == '__main__':
                 break
             presenter.handleKey(key)
         original_frame = cap.read()
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -176,7 +176,8 @@ def main():
             break
 
     metrics.log_total()
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/face_recognition_demo/python/face_recognition_demo.py
+++ b/demos/face_recognition_demo/python/face_recognition_demo.py
@@ -275,7 +275,8 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
@@ -248,7 +248,9 @@ def main():
         samples_library.release()
     visualizer.release()
     video_stream.release()
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
+++ b/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
@@ -180,4 +180,6 @@ if __name__ == '__main__':
                 else:
                     delay = 1
         frame = cap.read()
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -279,7 +279,8 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/image_retrieval_demo/python/image_retrieval_demo.py
+++ b/demos/image_retrieval_demo/python/image_retrieval_demo.py
@@ -175,7 +175,9 @@ def main():
 
         if key == 27:
             break
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
     if positions:
         compute_metrics(positions)

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
@@ -221,7 +221,8 @@ def main():
             presenter.handleKey(key)
         frame = cap.read()
 
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
     cv2.destroyAllWindows()
 
 

--- a/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
@@ -184,7 +184,9 @@ def run(params, config, capture, detector, reid):
         print('\rProcessing frame: {}, fps = {} (avg_fps = {:.3})'.format(
                             frame_number, fps, 1. / avg_latency.get()), end="")
         prev_frames, frames = frames, prev_frames
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
     thread_body.process = False
     frames_thread.join()

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -338,7 +338,8 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/place_recognition_demo/python/place_recognition_demo.py
+++ b/demos/place_recognition_demo/python/place_recognition_demo.py
@@ -131,7 +131,8 @@ def main():
         if key == 27:
             break
 
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -279,7 +279,8 @@ def main():
             key = cv2.waitKey(1)
 
     metrics.log_total()
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':

--- a/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
+++ b/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
@@ -105,7 +105,9 @@ def run_demo(args):
                 break
             presenter.handleKey(key)
         frame = cap.read()
-    print(presenter.reportMeans())
+
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == "__main__":

--- a/demos/text_spotting_demo/python/text_spotting_demo.py
+++ b/demos/text_spotting_demo/python/text_spotting_demo.py
@@ -352,7 +352,8 @@ def main():
 
         frame = cap.read()
 
-    print(presenter.reportMeans())
+    for rep in presenter.reportMeans():
+        log.info(rep)
     cv2.destroyAllWindows()
 
 

--- a/demos/whiteboard_inpainting_demo/python/whiteboard_inpainting_demo.py
+++ b/demos/whiteboard_inpainting_demo/python/whiteboard_inpainting_demo.py
@@ -193,7 +193,8 @@ def main():
         start = time.time()
         frame = cap.read()
 
-    presenter.reportMeans()
+    for rep in presenter.reportMeans():
+        log.info(rep)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In PR #2547 cpp implementation of `reportMeans()` function was changed to allow printing with `[ INFO ]`  prefix on each new line:
```
[ INFO ] Resources usage:
[ INFO ]        Mean core utilization: 99.7% 99.4% 99.7% 99.7%
[ INFO ]        Mean CPU utilization: 99.6%
[ INFO ]        Memory mean usage: 8.4 GiB
[ INFO ]        Mean swap usage: 0.2 GiB
```
This PR supports these changes in python