### PR TITLE
Python demos: performance metrics unification

### DIFF
--- a/demos/3d_segmentation_demo/python/README.md
+++ b/demos/3d_segmentation_demo/python/README.md
@@ -116,6 +116,9 @@ python3 3d_segmentation_demo.py -i <path_to_nifti_images> -m <path_to_model>/bra
 ## Demo Output
 
 The demo outputs a multipage TIFF image and a NIFTI archive.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/colorization_demo/python/README.md
+++ b/demos/colorization_demo/python/README.md
@@ -87,6 +87,11 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 ## Demo Output
 
 The demo uses OpenCV to display the colorized frame.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/colorization_demo/python/colorization_demo.py
+++ b/demos/colorization_demo/python/colorization_demo.py
@@ -89,11 +89,6 @@ if __name__ == '__main__':
 
     _, _, h_in, w_in = input_shape
 
-    start_time = perf_counter()
-    original_frame = cap.read()
-    if original_frame is None:
-        raise RuntimeError("Can't read an image from the input")
-
     frames_processed = 0
     imshow_size = (640, 480)
     graph_size = (imshow_size[0] // 2, imshow_size[1] // 4)
@@ -104,6 +99,11 @@ if __name__ == '__main__':
     if args.output and not video_writer.open(args.output, cv.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), (imshow_size[0] * 2, imshow_size[1] * 2)):
         raise RuntimeError("Can't open video writer")
+
+    start_time = perf_counter()
+    original_frame = cap.read()
+    if original_frame is None:
+        raise RuntimeError("Can't read an image from the input")
 
     while original_frame is not None:
         (h_orig, w_orig) = original_frame.shape[:2]

--- a/demos/colorization_demo/python/colorization_demo.py
+++ b/demos/colorization_demo/python/colorization_demo.py
@@ -19,6 +19,7 @@ from openvino.inference_engine import IECore, get_version
 import cv2 as cv
 import numpy as np
 import logging as log
+from time import perf_counter
 import sys
 from argparse import ArgumentParser, SUPPRESS
 from pathlib import Path
@@ -26,6 +27,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -87,6 +89,7 @@ if __name__ == '__main__':
 
     _, _, h_in, w_in = input_shape
 
+    start_time = perf_counter()
     original_frame = cap.read()
     if original_frame is None:
         raise RuntimeError("Can't read an image from the input")
@@ -95,6 +98,7 @@ if __name__ == '__main__':
     imshow_size = (640, 480)
     graph_size = (imshow_size[0] // 2, imshow_size[1] // 4)
     presenter = monitors.Presenter(args.utilization_monitors, imshow_size[1] * 2 - graph_size[1], graph_size)
+    metrics = PerformanceMetrics()
 
     video_writer = cv.VideoWriter()
     if args.output and not video_writer.open(args.output, cv.VideoWriter_fourcc(*'MJPG'),
@@ -141,6 +145,8 @@ if __name__ == '__main__':
                     cv.hconcat([lab_image, colorize_image])]
         final_image = cv.vconcat(ir_image)
 
+        metrics.update(start_time, final_image)
+
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
             video_writer.write(final_image)
@@ -152,5 +158,8 @@ if __name__ == '__main__':
             if key in {ord("q"), ord("Q"), 27}:
                 break
             presenter.handleKey(key)
+        start_time = perf_counter()
         original_frame = cap.read()
+
+    metrics.log_total()
     print(presenter.reportMeans())

--- a/demos/common/python/performance_metrics.py
+++ b/demos/common/python/performance_metrics.py
@@ -41,7 +41,7 @@ class PerformanceMetrics:
         self.total_statistic = Statistic()
         self.last_update_time = None
 
-    def update(self, last_request_start_time, frame, position=(15, 30),
+    def update(self, last_request_start_time, frame, draw_metrics=True, position=(15, 30),
                font_scale=0.75, color=(200, 10, 10), thickness=2):
         current_time = perf_counter()
 
@@ -62,10 +62,10 @@ class PerformanceMetrics:
 
         # Draw performance stats over frame
         current_latency, current_fps = self.get_last()
-        if current_latency is not None:
+        if current_latency is not None and draw_metrics:
             put_highlighted_text(frame, "Latency: {:.1f} ms".format(current_latency * 1e3),
                                  position, cv2.FONT_HERSHEY_COMPLEX, font_scale, color, thickness)
-        if current_fps is not None:
+        if current_fps is not None and draw_metrics:
             put_highlighted_text(frame, "FPS: {:.1f}".format(current_fps),
                                  (position[0], position[1]+30), cv2.FONT_HERSHEY_COMPLEX, font_scale, color, thickness)
 

--- a/demos/deblurring_demo/python/README.md
+++ b/demos/deblurring_demo/python/README.md
@@ -113,6 +113,11 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 ## Demo Output
 
 The demo uses OpenCV to display the resulting images together with source images.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -78,6 +78,11 @@ def main():
     args = build_argparser().parse_args()
 
     cap = open_images_capture(args.input, args.loop)
+    next_frame_id = 1
+    next_frame_id_to_show = 0
+
+    metrics = PerformanceMetrics()
+    video_writer = cv2.VideoWriter()
 
     log.info('OpenVINO Inference Engine')
     log.info('\tbuild: {}'.format(get_version()))
@@ -100,13 +105,9 @@ def main():
     log_runtime_settings(pipeline.exec_net, args.device)
 
     pipeline.submit_data(frame, 0, {'frame': frame, 'start_time': start_time})
-    next_frame_id = 1
-    next_frame_id_to_show = 0
 
-    metrics = PerformanceMetrics()
     presenter = monitors.Presenter(args.utilization_monitors, 55,
                                    (round(frame.shape[1] / 4), round(frame.shape[0] / 8)))
-    video_writer = cv2.VideoWriter()
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), (2 * frame.shape[1], frame.shape[0])):
         raise RuntimeError("Can't open video writer")

--- a/demos/face_detection_mtcnn_demo/python/README.md
+++ b/demos/face_detection_mtcnn_demo/python/README.md
@@ -100,7 +100,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display found faces' boundary, feature points and current inference performance.
+The application uses OpenCV to display found faces' boundary and feature points.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ![example](./test.jpg)
 

--- a/demos/face_detection_mtcnn_demo/python/face_detection_mtcnn_demo.py
+++ b/demos/face_detection_mtcnn_demo/python/face_detection_mtcnn_demo.py
@@ -177,7 +177,6 @@ def main():
         # Pnet stage
         # *************************************
 
-        t0 = cv2.getTickCount()
         pnet_res = []
         for i, scale in enumerate(scales):
             hs = int(oh*scale)

--- a/demos/face_detection_mtcnn_demo/python/face_detection_mtcnn_demo.py
+++ b/demos/face_detection_mtcnn_demo/python/face_detection_mtcnn_demo.py
@@ -258,9 +258,7 @@ def main():
             for i in range(5, 15, 2):
                 cv2.circle(origin_image, (int(rectangle[i+0]), int(rectangle[i+1])), 2, (0, 255, 0))
 
-        infer_time = (cv2.getTickCount() - t0) / cv2.getTickFrequency()  # Record infer time
-        cv2.putText(origin_image, 'summary: {:.1f} FPS'.format(1.0 / infer_time),
-                    (5, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 200))
+        metrics.update(start_time, origin_image)
 
         if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id <= args.output_limit):
             video_writer.write(origin_image)
@@ -271,8 +269,6 @@ def main():
             if key in {ord('q'), ord('Q'), 27}:
                 break
             presenter.handleKey(key)
-
-        metrics.update(start_time, origin_image)
 
     metrics.log_total()
 

--- a/demos/face_recognition_demo/python/README.md
+++ b/demos/face_recognition_demo/python/README.md
@@ -242,7 +242,11 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 ## Demo output
 
 The demo uses OpenCV window to display the resulting video frame and detections.
-If specified, it also writes output to a file. It outputs logs to the terminal.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See also
 

--- a/demos/gesture_recognition_demo/python/README.md
+++ b/demos/gesture_recognition_demo/python/README.md
@@ -135,7 +135,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display gesture recognition result and current inference performance.
+The application uses OpenCV to display gesture recognition result.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
@@ -17,7 +17,7 @@
 
 import logging as log
 import sys
-import time
+from time import perf_counter
 import json
 import os
 import multiprocessing
@@ -37,6 +37,7 @@ from gesture_recognition_demo.visualizer import Visualizer
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
                              'common/python'))
 import monitors
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -129,6 +130,7 @@ def main():
     video_stream = VideoStream(args.input, ACTION_NET_INPUT_FPS, action_recognizer.input_length)
     video_stream.start()
 
+    metrics = PerformanceMetrics()
     visualizer = Visualizer(VISUALIZER_TRG_FPS)
     visualizer.register_window('Demo')
     presenter = monitors.Presenter(args.utilization_monitors)
@@ -152,8 +154,8 @@ def main():
 
     frames_processed = 0
 
-    start_time = time.perf_counter()
     while True:
+        start_time = perf_counter()
         frame = video_stream.get_live_frame()
         batch = video_stream.get_batch()
         if frame is None or batch is None:
@@ -190,14 +192,8 @@ def main():
                 if action_class_score > args.action_threshold:
                     last_caption = 'Last gesture: {} '.format(action_class_label)
 
-        end_time = time.perf_counter()
-        elapsed_time = end_time - start_time
-        start_time = end_time
         presenter.drawGraphs(frame)
-        if active_object_id >= 0:
-            current_fps = 1.0 / elapsed_time
-            cv2.putText(frame, 'FPS: {:.2f}'.format(current_fps), (10, 40),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+        metrics.update(start_time, frame)
 
         if detections is not None:
             tracker_labels = {det.id for det in detections}
@@ -248,6 +244,8 @@ def main():
         samples_library.release()
     visualizer.release()
     video_stream.release()
+
+    metrics.log_total()
     print(presenter.reportMeans())
 
 

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo.py
@@ -193,7 +193,6 @@ def main():
                     last_caption = 'Last gesture: {} '.format(action_class_label)
 
         presenter.drawGraphs(frame)
-        metrics.update(start_time, frame)
 
         if detections is not None:
             tracker_labels = {det.id for det in detections}
@@ -210,6 +209,9 @@ def main():
         if last_caption is not None:
             cv2.putText(frame, last_caption, (10, frame.shape[0] - 10),
                         cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
+
+        metrics.update(start_time, frame)
+
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
             video_writer.write(frame)

--- a/demos/handwritten_text_recognition_demo/python/README.md
+++ b/demos/handwritten_text_recognition_demo/python/README.md
@@ -104,7 +104,10 @@ python handwritten_text_recognition_demo.py \
 
 ## Demo Output
 
-The application uses the terminal to show resulting recognition text and inference performance.
+The application uses the terminal to show resulting recognition text.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
+++ b/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
@@ -106,17 +106,13 @@ def main():
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
     # Start sync inference
-    total_latency = 0
-
+    start_time = perf_counter()
     for i in range(args.number_iter):
-        start_time = perf_counter()
         preds = exec_net.infer(inputs={input_blob: input_image})
         preds = preds[out_blob]
         result = codec.decode(preds)
         print(result)
-        total_latency += perf_counter() - start_time
-
-    total_latency = (total_latency / args.number_iter + preprocessing_total_time) * 1e3
+    total_latency = ((perf_counter() - start_time) / args.number_iter + preprocessing_total_time) * 1e3
     log.info("Metrics report:")
     log.info("\tLatency: {:.1f} ms".format(total_latency))
 

--- a/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
+++ b/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
@@ -15,7 +15,7 @@
 
 import os
 import sys
-import time
+from time import perf_counter
 import logging as log
 from argparse import ArgumentParser, SUPPRESS
 from pathlib import Path
@@ -95,7 +95,9 @@ def main():
     input_batch_size, input_channel, input_height, input_width= net.input_info[input_blob].input_data.shape
 
     # Read and pre-process input image (NOTE: one image only)
+    preprocessing_start_time = perf_counter()
     input_image = preprocess_input(args.input, height=input_height, width=input_width)[None, :, :, :]
+    preprocessing_total_time = perf_counter() - preprocessing_start_time
     assert input_batch_size == input_image.shape[0], "The net's input batch size should equal the input image's batch size "
     assert input_channel == input_image.shape[1], "The net's input channel should equal the input image's channel"
 
@@ -104,15 +106,19 @@ def main():
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
     # Start sync inference
-    infer_time = []
+    total_latency = 0
+
     for i in range(args.number_iter):
-        t0 = time.time()
+        start_time = perf_counter()
         preds = exec_net.infer(inputs={input_blob: input_image})
         preds = preds[out_blob]
         result = codec.decode(preds)
         print(result)
-        infer_time.append((time.time() - t0) * 1000)
-    log.info("Average throughput: {} ms".format(np.average(np.asarray(infer_time))))
+        total_latency += perf_counter() - start_time
+
+    total_latency = (total_latency / args.number_iter + preprocessing_total_time) * 1e3
+    log.info("Metrics report:")
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
 
     sys.exit()
 

--- a/demos/human_pose_estimation_3d_demo/python/README.md
+++ b/demos/human_pose_estimation_3d_demo/python/README.md
@@ -117,7 +117,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display found poses and current inference performance.
+The application uses OpenCV to display estimated poses.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
+++ b/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
@@ -17,6 +17,7 @@ import sys
 import logging as log
 from argparse import ArgumentParser, SUPPRESS
 from pathlib import Path
+from time import perf_counter
 
 import cv2
 import numpy as np
@@ -28,6 +29,7 @@ from modules.parse_poses import parse_poses
 sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -97,10 +99,13 @@ if __name__ == '__main__':
     t = np.array(extrinsics['t'], dtype=np.float32)
 
     is_video = cap.get_type() in ('VIDEO', 'CAMERA')
+
+    start_time = perf_counter()
     frame = cap.read()
     if frame is None:
         raise RuntimeError("Can't read an image from the input")
 
+    metrics = PerformanceMetrics()
     video_writer = cv2.VideoWriter()
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), (frame.shape[1], frame.shape[0])):
@@ -141,13 +146,7 @@ if __name__ == '__main__':
 
         presenter.drawGraphs(frame)
         draw_poses(frame, poses_2d)
-        current_time = (cv2.getTickCount() - current_time) / cv2.getTickFrequency()
-        if mean_time == 0:
-            mean_time = current_time
-        else:
-            mean_time = mean_time * 0.95 + current_time * 0.05
-        cv2.putText(frame, 'FPS: {}'.format(int(1 / mean_time * 10) / 10),
-                    (40, 80), cv2.FONT_HERSHEY_COMPLEX, 1, (0, 0, 255))
+        metrics.update(start_time, frame)
 
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
@@ -179,5 +178,8 @@ if __name__ == '__main__':
                     break
                 else:
                     delay = 1
+        start_time = perf_counter()
         frame = cap.read()
+
+    metrics.log_total()
     print(presenter.reportMeans())

--- a/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
+++ b/demos/human_pose_estimation_3d_demo/python/human_pose_estimation_3d_demo.py
@@ -100,17 +100,6 @@ if __name__ == '__main__':
 
     is_video = cap.get_type() in ('VIDEO', 'CAMERA')
 
-    start_time = perf_counter()
-    frame = cap.read()
-    if frame is None:
-        raise RuntimeError("Can't read an image from the input")
-
-    metrics = PerformanceMetrics()
-    video_writer = cv2.VideoWriter()
-    if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
-                                             cap.fps(), (frame.shape[1], frame.shape[0])):
-        raise RuntimeError("Can't open video writer")
-
     base_height = args.height_size
     fx = args.fx
 
@@ -121,6 +110,17 @@ if __name__ == '__main__':
     space_code = 32
     mean_time = 0
     presenter = monitors.Presenter(args.utilization_monitors, 0)
+    metrics = PerformanceMetrics()
+    video_writer = cv2.VideoWriter()
+
+    start_time = perf_counter()
+    frame = cap.read()
+    if frame is None:
+        raise RuntimeError("Can't read an image from the input")
+
+    if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
+                                             cap.fps(), (frame.shape[1], frame.shape[0])):
+        raise RuntimeError("Can't open video writer")
 
     while frame is not None:
         current_time = cv2.getTickCount()

--- a/demos/human_pose_estimation_demo/python/README.md
+++ b/demos/human_pose_estimation_demo/python/README.md
@@ -148,8 +148,8 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 The demo uses OpenCV to display the resulting frame with estimated poses.
 The demo reports
 
-* **FPS**: average rate of video frame processing (frames per second)
-* **Latency**: average time required to process one frame (from reading the frame to displaying the results)
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
 You can use both of these metrics to measure application-level performance.
 
 ## See Also

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -167,6 +167,11 @@ def main():
     args = build_argparser().parse_args()
 
     cap = open_images_capture(args.input, args.loop)
+    next_frame_id = 1
+    next_frame_id_to_show = 0
+
+    metrics = PerformanceMetrics()
+    video_writer = cv2.VideoWriter()
 
     log.info('OpenVINO Inference Engine')
     log.info('\tbuild: {}'.format(get_version()))
@@ -189,10 +194,7 @@ def main():
     log_runtime_settings(hpe_pipeline.exec_net, args.device)
 
     hpe_pipeline.submit_data(frame, 0, {'frame': frame, 'start_time': start_time})
-    next_frame_id = 1
-    next_frame_id_to_show = 0
 
-    metrics = PerformanceMetrics()
     output_transform = models.OutputTransform(frame.shape[:2], args.output_resolution)
     if args.output_resolution:
         output_resolution = output_transform.new_resolution
@@ -200,7 +202,6 @@ def main():
         output_resolution = (frame.shape[1], frame.shape[0])
     presenter = monitors.Presenter(args.utilization_monitors, 55,
                                    (round(output_resolution[0] / 4), round(output_resolution[1] / 8)))
-    video_writer = cv2.VideoWriter()
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'), cap.fps(),
             output_resolution):
         raise RuntimeError("Can't open video writer")

--- a/demos/image_inpainting_demo/python/README.md
+++ b/demos/image_inpainting_demo/python/README.md
@@ -110,7 +110,10 @@ If Backpace, C or R keys are pressed while demo is showing original image, demo 
 
 ## Demo Output
 
-In auto mode this demo uses OpenCV to display the resulting image and image with mask applied and reports performance in the format of summary inference FPS. Processed image can be also written to file.
+In auto mode the demo uses OpenCV to display the resulting image and image with mask applied. Processed image can be also written to file.
+In auto mode the demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 In interactive mode this demo provides interactive means to apply mask and see the result of processing instantly (see hotkeys above).
 

--- a/demos/image_inpainting_demo/python/image_inpainting_demo.py
+++ b/demos/image_inpainting_demo/python/image_inpainting_demo.py
@@ -108,12 +108,13 @@ def inpaint_auto(img, inpainting_processor, args):
     #--- Inpaint and show results
     output_image = inpainting_processor.process(masked_image, mask)
     concat_imgs = np.hstack((masked_image, output_image))
+    total_latency = (perf_counter() - start_time) * 1e3
     cv2.putText(concat_imgs, 'original', (5, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
     cv2.putText(concat_imgs, 'result', (concat_imgs.shape[1] - 5 - cv2.getTextSize('result', cv2.FONT_HERSHEY_COMPLEX, 0.5, 1)[0][0], 15),
                 cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
-    total_latency = (perf_counter() - start_time) * 1e3
+    cv2.putText(concat_imgs, 'Latency: {:.1f} ms'.format(total_latency), (5, 35), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 200))
     log.info("Metrics report:")
-    log.info("Latency: {:.1f} ms".format(total_latency))
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
     return concat_imgs, output_image
 
 def main():

--- a/demos/image_inpainting_demo/python/image_inpainting_demo.py
+++ b/demos/image_inpainting_demo/python/image_inpainting_demo.py
@@ -108,10 +108,10 @@ def inpaint_auto(img, inpainting_processor, args):
     #--- Inpaint and show results
     output_image = inpainting_processor.process(masked_image, mask)
     concat_imgs = np.hstack((masked_image, output_image))
-    total_latency = (perf_counter() - start_time) * 1e3
     cv2.putText(concat_imgs, 'original', (5, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
     cv2.putText(concat_imgs, 'result', (concat_imgs.shape[1] - 5 - cv2.getTextSize('result', cv2.FONT_HERSHEY_COMPLEX, 0.5, 1)[0][0], 15),
                 cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
+    total_latency = (perf_counter() - start_time) * 1e3
     log.info("Metrics report:")
     log.info("Latency: {:.1f} ms".format(total_latency))
     return concat_imgs, output_image

--- a/demos/image_inpainting_demo/python/image_inpainting_demo.py
+++ b/demos/image_inpainting_demo/python/image_inpainting_demo.py
@@ -110,7 +110,7 @@ def inpaint_auto(img, inpainting_processor, args):
     concat_imgs = np.hstack((masked_image, output_image))
     total_latency = (perf_counter() - start_time) * 1e3
     cv2.putText(concat_imgs, 'original', (5, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
-    cv2.putText(concat_imgs, 'result',(concat_imgs.shape[1] - 5 - cv2.getTextSize('result', cv2.FONT_HERSHEY_COMPLEX, 0.5, 1)[0][0], 15),
+    cv2.putText(concat_imgs, 'result', (concat_imgs.shape[1] - 5 - cv2.getTextSize('result', cv2.FONT_HERSHEY_COMPLEX, 0.5, 1)[0][0], 15),
                 cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 100))
     log.info("Metrics report:")
     log.info("Latency: {:.1f} ms".format(total_latency))

--- a/demos/image_inpainting_demo/python/inpainting.py
+++ b/demos/image_inpainting_demo/python/inpainting.py
@@ -11,7 +11,6 @@
  limitations under the License.
 """
 
-import cv2
 import numpy as np
 
 
@@ -27,7 +26,6 @@ class ImageInpainting:
 
         self._ie = ie
         self._exec_model = self._ie.load_network(model, device)
-        self.infer_time = -1
 
         _, channels, input_height, input_width = model.input_info[self._input_layer_names[0]].input_data.shape
         assert channels == 3, "Expected 3-channel input"
@@ -41,9 +39,7 @@ class ImageInpainting:
 
 
     def infer(self, image, mask):
-        t0 = cv2.getTickCount()
         output = self._exec_model.infer(inputs={self._input_layer_names[0]: image, self._input_layer_names[1]: mask})
-        self.infer_time = (cv2.getTickCount() - t0) / cv2.getTickFrequency()
         return output[self._output_layer_name]
 
 

--- a/demos/image_retrieval_demo/python/README.md
+++ b/demos/image_retrieval_demo/python/README.md
@@ -122,7 +122,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display gallery searching result and current inference performance.
+The application uses OpenCV to display gallery searching result.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/instance_segmentation_demo/python/README.md
+++ b/demos/instance_segmentation_demo/python/README.md
@@ -143,7 +143,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display resulting instance segmentation masks and current inference performance.
+The application uses OpenCV to display resulting instance segmentation masks.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
@@ -17,7 +17,7 @@
 
 import logging as log
 import sys
-import time
+from time import perf_counter
 from argparse import ArgumentParser, SUPPRESS
 from pathlib import Path
 
@@ -33,6 +33,7 @@ from instance_segmentation_demo.visualizer import Visualizer
 
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -121,6 +122,7 @@ def main():
     exec_net = ie.load_network(network=net, device_name=args.device, num_requests=2)
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
+    start_time = perf_counter()
     frame = cap.read()
     if frame is None:
         raise RuntimeError("Can't read an image from the input")
@@ -137,6 +139,7 @@ def main():
 
     frames_processed = 0
     out_frame_size = (frame.shape[1], frame.shape[0])
+    metrics = PerformanceMetrics()
     presenter = monitors.Presenter(args.utilization_monitors, 45,
                 (round(out_frame_size[0] / 4), round(out_frame_size[1] / 8)))
     visualizer = Visualizer(class_labels, show_boxes=args.show_boxes, show_scores=args.show_scores)
@@ -144,8 +147,6 @@ def main():
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), out_frame_size):
         raise RuntimeError("Can't open video writer")
-
-    render_time = 0
 
     while frame is not None:
         if args.no_keep_aspect_ratio:
@@ -169,19 +170,14 @@ def main():
         input_image_info = np.asarray([[input_image_size[0], input_image_size[1], 1]], dtype=np.float32)
 
         # Run the net.
-        inf_start = time.time()
         feed_dict = {image_input: input_image}
         if image_info_input:
             feed_dict[image_info_input] = input_image_info
         outputs = exec_net.infer(feed_dict)
-        inf_end = time.time()
-        det_time = inf_end - inf_start
 
         # Parse detection results of the current request
         scores, classes, boxes, masks = postprocessor(
             outputs, scale_x, scale_y, *frame.shape[:2], h, w, args.prob_threshold)
-
-        render_start = time.time()
 
         if len(boxes) and args.raw_output_message:
             log.debug('  -------------------------- Frame # {} --------------------------  '.format(frames_processed))
@@ -197,11 +193,7 @@ def main():
         # Visualize masks.
         frame = visualizer(frame, boxes, classes, scores, presenter, masks, masks_tracks_ids)
 
-        # Draw performance stats.
-        inf_time_message = 'Inference time: {:.3f} ms'.format(det_time * 1000)
-        render_time_message = 'OpenCV rendering time: {:.3f} ms'.format(render_time * 1000)
-        cv2.putText(frame, inf_time_message, (15, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (200, 10, 10), 1)
-        cv2.putText(frame, render_time_message, (15, 30), cv2.FONT_HERSHEY_COMPLEX, 0.5, (10, 10, 200), 1)
+        metrics.update(start_time, frame)
 
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
@@ -210,8 +202,6 @@ def main():
         if not args.no_show:
             # Show resulting image.
             cv2.imshow('Results', frame)
-        render_end = time.time()
-        render_time = render_end - render_start
 
         if not args.no_show:
             key = cv2.waitKey(delay)
@@ -219,10 +209,11 @@ def main():
             if key == esc_code:
                 break
             presenter.handleKey(key)
+        start_time = perf_counter()
         frame = cap.read()
 
+    metrics.log_total()
     print(presenter.reportMeans())
-    cv2.destroyAllWindows()
 
 
 if __name__ == '__main__':

--- a/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
+++ b/demos/instance_segmentation_demo/python/instance_segmentation_demo.py
@@ -122,11 +122,6 @@ def main():
     exec_net = ie.load_network(network=net, device_name=args.device, num_requests=2)
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
-    start_time = perf_counter()
-    frame = cap.read()
-    if frame is None:
-        raise RuntimeError("Can't read an image from the input")
-
     if args.no_track:
         tracker = None
     else:
@@ -138,12 +133,18 @@ def main():
         delay = int(cap.get_type() in ('VIDEO', 'CAMERA'))
 
     frames_processed = 0
-    out_frame_size = (frame.shape[1], frame.shape[0])
     metrics = PerformanceMetrics()
-    presenter = monitors.Presenter(args.utilization_monitors, 45,
-                (round(out_frame_size[0] / 4), round(out_frame_size[1] / 8)))
     visualizer = Visualizer(class_labels, show_boxes=args.show_boxes, show_scores=args.show_scores)
     video_writer = cv2.VideoWriter()
+
+    start_time = perf_counter()
+    frame = cap.read()
+    if frame is None:
+        raise RuntimeError("Can't read an image from the input")
+
+    out_frame_size = (frame.shape[1], frame.shape[0])
+    presenter = monitors.Presenter(args.utilization_monitors, 45,
+                (round(out_frame_size[0] / 4), round(out_frame_size[1] / 8)))
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), out_frame_size):
         raise RuntimeError("Can't open video writer")

--- a/demos/machine_translation_demo/python/README.md
+++ b/demos/machine_translation_demo/python/README.md
@@ -83,6 +83,9 @@ python3 ./machine_translation_demo \
 ## Demo Output
 
 The application outputs translated sentences from source to target language.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/machine_translation_demo/python/machine_translation_demo.py
+++ b/demos/machine_translation_demo/python/machine_translation_demo.py
@@ -16,7 +16,7 @@ import argparse
 import itertools
 import logging as log
 import sys
-import time
+from time import perf_counter
 from pathlib import Path
 
 import numpy as np
@@ -231,6 +231,8 @@ def main(args):
     if args.output:
         open(args.output, 'w').close()
 
+    total_latency = 0
+
     def sentences():
         if input_data:
             for sentence in input_data:
@@ -248,17 +250,18 @@ def main(args):
             break
 
         try:
-            start = time.perf_counter()
+            start_time = perf_counter()
             translation = model(sentence)
-            stop = time.perf_counter()
+            total_latency += perf_counter() - start_time
             print(translation)
-            log.info("time: {} s.".format(stop - start))
             if args.output:
                 with open(args.output, 'a', encoding='utf8') as f:
                     print(translation, file=f)
         except Exception:
             log.error("an error occurred", exc_info=True)
 
+    log.info("Metrics report:")
+    log.info("\tLatency: {:.1f} ms".format(total_latency * 1e3))
 
 if __name__ == "__main__":
     args = build_argparser().parse_args()

--- a/demos/machine_translation_demo/python/machine_translation_demo.py
+++ b/demos/machine_translation_demo/python/machine_translation_demo.py
@@ -231,8 +231,6 @@ def main(args):
     if args.output:
         open(args.output, 'w').close()
 
-    total_latency = 0
-
     def sentences():
         if input_data:
             for sentence in input_data:
@@ -244,15 +242,14 @@ def main(args):
             while True:
                 yield input("> ")
 
+    start_time = perf_counter()
     # loop on user's or prepared questions
     for sentence in sentences():
         if not sentence.strip():
             break
 
         try:
-            start_time = perf_counter()
             translation = model(sentence)
-            total_latency += perf_counter() - start_time
             print(translation)
             if args.output:
                 with open(args.output, 'a', encoding='utf8') as f:
@@ -260,8 +257,9 @@ def main(args):
         except Exception:
             log.error("an error occurred", exc_info=True)
 
+    total_latency = (perf_counter() - start_time) * 1e3
     log.info("Metrics report:")
-    log.info("\tLatency: {:.1f} ms".format(total_latency * 1e3))
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
 
 if __name__ == "__main__":
     args = build_argparser().parse_args()

--- a/demos/monodepth_demo/python/README.md
+++ b/demos/monodepth_demo/python/README.md
@@ -68,6 +68,9 @@ Running the application with the empty list of options yields the usage message 
 ## Demo Output
 
 The application outputs are the floating disparity map (PFM) as well as a color-coded version (PNG).
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/monodepth_demo/python/monodepth_demo.py
+++ b/demos/monodepth_demo/python/monodepth_demo.py
@@ -47,6 +47,10 @@ def main():
     out_blob = next(iter(net.outputs))
     net.batch_size = 1
 
+    # loading model to the plugin
+    exec_net = ie.load_network(network=net, device_name=args.device)
+    log.info('The model {} is loaded to {}'.format(args.model, args.device))
+
     # read and pre-process input image
     _, _, height, width = net.input_info[input_blob].input_data.shape
 
@@ -64,10 +68,6 @@ def main():
     image = image.astype(np.float32)
     image = image.transpose((2, 0, 1))
     image_input = np.expand_dims(image, 0)
-
-    # loading model to the plugin
-    exec_net = ie.load_network(network=net, device_name=args.device)
-    log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
     # start sync inference
     res = exec_net.infer(inputs={input_blob: image_input})

--- a/demos/monodepth_demo/python/monodepth_demo.py
+++ b/demos/monodepth_demo/python/monodepth_demo.py
@@ -3,6 +3,7 @@
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
+from time import perf_counter
 
 import cv2
 import numpy as np
@@ -49,6 +50,7 @@ def main():
     # read and pre-process input image
     _, _, height, width = net.input_info[input_blob].input_data.shape
 
+    start_time = perf_counter()
     image = cv2.imread(args.input, cv2.IMREAD_COLOR)
     (input_height, input_width) = image.shape[:-1]
 
@@ -85,6 +87,9 @@ def main():
     else:
         disp.fill(0.5)
 
+    total_latency = (perf_counter() - start_time) * 1e3
+    log.info("Metrics report:")
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
     # pfm
     out = 'disp.pfm'
     cv2.imwrite(out, disp)

--- a/demos/multi_camera_multi_target_tracking_demo/python/README.md
+++ b/demos/multi_camera_multi_target_tracking_demo/python/README.md
@@ -189,6 +189,12 @@ Such file with detections can be saved from the demo. Specify the argument `--sa
 ## Demo Output
 
 The demo displays bounding boxes of tracked objects and unique IDs of those objects.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
+
 To save output video with the result please use the option  `--output_video`,
 to change configuration parameters please open the `configs/person.py` (or `configs/vehicle.py` for vehicle tracking demo) file and edit it.
 

--- a/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
@@ -36,6 +36,7 @@ from openvino.inference_engine import IECore, get_version
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
                              'common/python'))
 import monitors
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -124,6 +125,7 @@ def run(params, config, capture, detector, reid):
 
     prev_frames = thread_body.frames_queue.get()
     detector.run_async(prev_frames, frame_number)
+    metrics = PerformanceMetrics()
     presenter = monitors.Presenter(params.utilization_monitors, 0)
 
     while thread_body.process:
@@ -132,7 +134,7 @@ def run(params, config, capture, detector, reid):
             if key == 27:
                 break
             presenter.handleKey(key)
-        start = time.perf_counter()
+        start_time = time.perf_counter()
         try:
             frames = thread_body.frames_queue.get_nowait()
             frames_read = True
@@ -156,12 +158,9 @@ def run(params, config, capture, detector, reid):
         tracker.process(prev_frames, all_detections, all_masks)
         tracked_objects = tracker.get_tracked_objects()
 
-        latency = max(time.perf_counter() - start, sys.float_info.epsilon)
-        avg_latency.update(latency)
-        fps = round(1. / latency, 1)
-
-        vis = visualize_multicam_detections(prev_frames, tracked_objects, fps,
+        vis = visualize_multicam_detections(prev_frames, tracked_objects,
                                             **vars(config.visualization_config))
+        metrics.update(start_time, vis)
         presenter.drawGraphs(vis)
         if not params.no_show:
             cv.imshow(win_name, vis)
@@ -181,9 +180,9 @@ def run(params, config, capture, detector, reid):
         if set_output_params and output_video:
             output_video.write(cv.resize(vis, video_output_size))
 
-        print('\rProcessing frame: {}, fps = {} (avg_fps = {:.3})'.format(
-                            frame_number, fps, 1. / avg_latency.get()), end="")
         prev_frames, frames = frames, prev_frames
+
+    metrics.log_total()
     print(presenter.reportMeans())
 
     thread_body.process = False

--- a/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/multi_camera_multi_target_tracking_demo.py
@@ -28,7 +28,7 @@ import cv2 as cv
 from utils.network_wrappers import Detector, VectorCNN, MaskRCNN, DetectionsFromFileReader
 from mc_tracker.mct import MultiCameraTracker
 from utils.analyzer import save_embeddings
-from utils.misc import read_py_config, check_pressed_keys, AverageEstimator
+from utils.misc import read_py_config, check_pressed_keys
 from utils.video import MulticamCapture, NormalizerCLAHE
 from utils.visualization import visualize_multicam_detections, get_target_size
 from openvino.inference_engine import IECore, get_version
@@ -101,7 +101,6 @@ class FramesThreadBody:
 def run(params, config, capture, detector, reid):
     win_name = 'Multi camera tracking'
     frame_number = 0
-    avg_latency = AverageEstimator()
     output_detections = [[] for _ in range(capture.get_num_sources())]
     key = -1
 

--- a/demos/multi_camera_multi_target_tracking_demo/python/utils/visualization.py
+++ b/demos/multi_camera_multi_target_tracking_demo/python/utils/visualization.py
@@ -64,7 +64,7 @@ def get_target_size(frame_sizes, vis=None, max_window_size=(1920, 1080), stack_f
     return target_width, target_height
 
 
-def visualize_multicam_detections(frames, all_objects, fps='', show_all_detections=True,
+def visualize_multicam_detections(frames, all_objects, show_all_detections=True,
                                   max_window_size=(1920, 1080), stack_frames='vertical'):
     assert len(frames) == len(all_objects)
     assert stack_frames in ['vertical', 'horizontal']
@@ -81,12 +81,7 @@ def visualize_multicam_detections(frames, all_objects, fps='', show_all_detectio
 
     target_width, target_height = get_target_size(frames, vis, max_window_size, stack_frames)
 
-    vis = cv.resize(vis, (target_width, target_height))
-
-    label_size, base_line = cv.getTextSize(str(fps), cv.FONT_HERSHEY_SIMPLEX, 1, 2)
-    cv.putText(vis, str(fps), (base_line*2, base_line*3),
-               cv.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 0), 2)
-    return vis
+    return cv.resize(vis, (target_width, target_height))
 
 
 def plot_timeline(sct_id, last_frame_num, tracks, save_path='', name='', show_online=False):

--- a/demos/noise_suppression_demo/python/README.md
+++ b/demos/noise_suppression_demo/python/README.md
@@ -69,13 +69,9 @@ The model is also required demo arguments.
 
 ## Demo Outputs
 The application outputs cleaned wave to output file.
+The demo reports
 
-## Demo Performance
-Even though the demo reports inference performance (by measuring wall-clock time for individual inference calls),
-it is only baseline performance.
-Please use the full-blown [Benchmark C++ Sample](https://docs.openvinotoolkit.org/latest/_inference_engine_samples_benchmark_app_README.html)
-for any actual performance measurements.
-
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 * [Open Model Zoo Demos](../../README.md)

--- a/demos/noise_suppression_demo/python/noise_suppression_demo.py
+++ b/demos/noise_suppression_demo/python/noise_suppression_demo.py
@@ -104,7 +104,6 @@ def main():
 
     samples_out = []
     while sample_inp is not None and sample_inp.shape[0] > 0:
-        start_time = perf_counter()
         if sample_inp.shape[0] > input_size:
             input = sample_inp[:input_size]
             sample_inp = sample_inp[input_size:]

--- a/demos/noise_suppression_demo/python/noise_suppression_demo.py
+++ b/demos/noise_suppression_demo/python/noise_suppression_demo.py
@@ -96,9 +96,8 @@ def main():
     ie_encoder_exec = ie.load_network(network=ie_encoder, device_name=args.device)
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
 
-    preprocessing_start_time = perf_counter()
+    start_time = perf_counter()
     sample_inp = wav_read(args.input)
-    total_latency = perf_counter() - preprocessing_start_time
 
     input_size = input_shapes["input"][1]
     res = None
@@ -135,11 +134,11 @@ def main():
         infer_request_ptr.infer()
         res = infer_request_ptr.output_blobs
 
-        total_latency += perf_counter() - start_time
         samples_out.append(res["output"].buffer.squeeze(0))
 
+    total_latency = (perf_counter() - start_time) * 1e3
     log.info("Metrics report:")
-    log.info("\tLatency: {:.1f} ms".format(total_latency * 1e3))
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
     sample_out = np.concatenate(samples_out, 0)
     wav_write(args.output, sample_out)
 

--- a/demos/place_recognition_demo/python/README.md
+++ b/demos/place_recognition_demo/python/README.md
@@ -117,7 +117,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display gallery searching result and current inference performance.
+The application uses OpenCV to display gallery searching result.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/place_recognition_demo/python/place_recognition_demo.py
+++ b/demos/place_recognition_demo/python/place_recognition_demo.py
@@ -18,7 +18,7 @@
 import logging as log
 from pathlib import Path
 import sys
-import time
+from time import perf_counter
 from argparse import ArgumentParser, SUPPRESS
 
 import cv2
@@ -31,6 +31,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
 
@@ -79,9 +80,9 @@ def build_argparser():
 def time_elapsed(func, *args):
     """ Auxiliary function that helps to measure elapsed time. """
 
-    start_time = time.perf_counter()
+    start_time = perf_counter()
     res = func(*args)
-    elapsed = time.perf_counter() - start_time
+    elapsed = perf_counter() - start_time
     return elapsed, res
 
 
@@ -99,8 +100,10 @@ def main():
     frames_processed = 0
     presenter = monitors.Presenter(args.utilization_monitors, 0)
     video_writer = cv2.VideoWriter()
+    metrics = PerformanceMetrics()
 
     while True:
+        start_time = perf_counter()
         frame = cap.read()
 
         if frame is None:
@@ -119,6 +122,7 @@ def main():
                                np.mean(compute_embeddings_times), np.mean(search_in_gallery_times),
                                imshow_delay=3, presenter=presenter, no_show=args.no_show)
 
+        metrics.update(start_time, image, draw_metrics=False)
         if frames_processed == 0:
             if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'), cap.fps(),
                                                      (image.shape[1], image.shape[0])):
@@ -131,6 +135,7 @@ def main():
         if key == 27:
             break
 
+    metrics.log_total()
     print(presenter.reportMeans())
 
 

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -146,6 +146,11 @@ Available colors files located in the `<omz_dir>/data/palettes` folder. If you w
 ## Demo Output
 
 The demo uses OpenCV to display the resulting images with blended segmentation mask.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/single_human_pose_estimation_demo/python/README.md
+++ b/demos/single_human_pose_estimation_demo/python/README.md
@@ -100,7 +100,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting frame with estimated poses and reports performance in the following format: summary inference FPS (single human pose inference FPS / detector inference FPS).
+The demo uses OpenCV to display the resulting frame with estimated poses.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/single_human_pose_estimation_demo/python/detector.py
+++ b/demos/single_human_pose_estimation_demo/python/detector.py
@@ -31,7 +31,6 @@ class Detector(object):
         _, _, self.input_h, self.input_w = self.model.input_info[self._input_layer_name].input_data.shape
         self._h = -1
         self._w = -1
-        self.infer_time = -1
 
     def _preprocess(self, img):
         self._h, self._w, _ = img.shape
@@ -42,10 +41,7 @@ class Detector(object):
         return img[None, ]
 
     def _infer(self, prep_img):
-        t0 = cv2.getTickCount()
-        output = self._exec_model.infer(inputs={self._input_layer_name: prep_img})
-        self.infer_time = (cv2.getTickCount() - t0) / cv2.getTickFrequency()
-        return output
+        return self._exec_model.infer(inputs={self._input_layer_name: prep_img})
 
 
     def _postprocess(self, bboxes):

--- a/demos/single_human_pose_estimation_demo/python/estimator.py
+++ b/demos/single_human_pose_estimation_demo/python/estimator.py
@@ -111,15 +111,12 @@ class HumanPoseEstimator(object):
         _, _, self.input_h, self.input_w = self.model.input_info[self._input_layer_name].input_data.shape
         _, _, self.output_h, self.output_w = self.model.outputs[self._output_layer_name].shape
         self._transform = TransformedCrop(self.input_h, self.input_w, self.output_h, self.output_w)
-        self.infer_time = -1
 
     def _preprocess(self, img, bbox):
         return self._transform(img, bbox)
 
     def _infer(self, prep_img):
-        t0 = cv2.getTickCount()
         output = self._exec_model.infer(inputs={self._input_layer_name: prep_img})
-        self.infer_time = ((cv2.getTickCount() - t0) / cv2.getTickFrequency())
         return output[self._output_layer_name][0]
 
     @staticmethod

--- a/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
+++ b/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
@@ -62,20 +62,22 @@ def run_demo(args):
                                                      device=args.device)
     log.info('The Human Pose Estimation model {} is loaded to {}'.format(args.model_hpe, args.device))
 
-    start_time = perf_counter()
-    frame = cap.read()
-    if frame is None:
-        raise RuntimeError("Can't read an image from the input")
     delay = int(cap.get_type() in ('VIDEO', 'CAMERA'))
-
     video_writer = cv2.VideoWriter()
-    if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
-                                             cap.fps(), (frame.shape[1], frame.shape[0])):
-        raise RuntimeError("Can't open video writer")
 
     frames_processed = 0
     presenter = monitors.Presenter(args.utilization_monitors, 25)
     metrics = PerformanceMetrics()
+
+    start_time = perf_counter()
+    frame = cap.read()
+    if frame is None:
+        raise RuntimeError("Can't read an image from the input")
+
+    if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
+                                             cap.fps(), (frame.shape[1], frame.shape[0])):
+        raise RuntimeError("Can't open video writer")
+
     while frame is not None:
         bboxes = detector_person.detect(frame)
         human_poses = [single_human_pose_estimator.estimate(frame, bbox) for bbox in bboxes]

--- a/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
+++ b/demos/single_human_pose_estimation_demo/python/single_human_pose_estimation_demo.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 import logging as log
+from time import perf_counter
 import cv2
 
 from openvino.inference_engine import IECore, get_version
@@ -14,6 +15,7 @@ from estimator import HumanPoseEstimator
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'common/python'))
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -60,6 +62,7 @@ def run_demo(args):
                                                      device=args.device)
     log.info('The Human Pose Estimation model {} is loaded to {}'.format(args.model_hpe, args.device))
 
+    start_time = perf_counter()
     frame = cap.read()
     if frame is None:
         raise RuntimeError("Can't read an image from the input")
@@ -72,6 +75,7 @@ def run_demo(args):
 
     frames_processed = 0
     presenter = monitors.Presenter(args.utilization_monitors, 25)
+    metrics = PerformanceMetrics()
     while frame is not None:
         bboxes = detector_person.detect(frame)
         human_poses = [single_human_pose_estimator.estimate(frame, bbox) for bbox in bboxes]
@@ -89,10 +93,7 @@ def run_demo(args):
             for id_kpt, kpt in enumerate(pose):
                 cv2.circle(frame, (int(kpt[0]), int(kpt[1])), 3, colors[id_kpt], -1)
 
-        cv2.putText(frame, 'summary: {:.1f} FPS (estimation: {:.1f} FPS / detection: {:.1f} FPS)'.format(
-            float(1 / (detector_person.infer_time + single_human_pose_estimator.infer_time * len(human_poses))),
-            float(1 / single_human_pose_estimator.infer_time),
-            float(1 / detector_person.infer_time)), (5, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (0, 0, 200))
+        metrics.update(start_time, frame)
 
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
@@ -104,7 +105,11 @@ def run_demo(args):
             if key == 27:
                 break
             presenter.handleKey(key)
+
+        start_time = perf_counter()
         frame = cap.read()
+
+    metrics.log_total()
     print(presenter.reportMeans())
 
 

--- a/demos/sound_classification_demo/python/README.md
+++ b/demos/sound_classification_demo/python/README.md
@@ -73,7 +73,10 @@ python3 sound_classification_demo.py -i <path_to_wav>/input_audio.wav -m <path_t
 
 ## Demo Output
 
-The demo uses console to display the predictions. It shows classification of each clip with timing of it and total prediction of whole audio.
+The demo uses console to display the predictions. It shows classification of each clip and total prediction of whole audio.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/sound_classification_demo/python/sound_classification_demo.py
+++ b/demos/sound_classification_demo/python/sound_classification_demo.py
@@ -172,11 +172,11 @@ def main():
         with open(args.labels, "r") as file:
             labels = [line.rstrip() for line in file.readlines()]
 
+    start_time = perf_counter()
     audio = AudioSource(args.input, channels=channels, samplerate=args.sample_rate)
 
     outputs = []
     clips = 0
-    start_time = perf_counter()
     for idx, chunk in enumerate(audio.chunks(length, hop, num_chunks=batch_size)):
         chunk.shape = input_shape
         output = exec_net.infer(inputs={input_blob: chunk})

--- a/demos/sound_classification_demo/python/sound_classification_demo.py
+++ b/demos/sound_classification_demo/python/sound_classification_demo.py
@@ -176,10 +176,9 @@ def main():
 
     outputs = []
     clips = 0
-    total_latency = 0
+    start_time = perf_counter()
     for idx, chunk in enumerate(audio.chunks(length, hop, num_chunks=batch_size)):
         chunk.shape = input_shape
-        processing_start_time = perf_counter()
         output = exec_net.infer(inputs={input_blob: chunk})
         clips += batch_size
         output = output[output_blob]
@@ -191,10 +190,9 @@ def main():
             if start_time < audio.duration():
                 log.info("[{:.2f}-{:.2f}] - {:6.2%} {:s}".format(start_time, end_time, data[label],
                                                                  labels[label] if labels else "Class {}".format(label)))
-        total_latency += perf_counter() - processing_start_time
-
+    total_latency = (perf_counter() - start_time) * 1e3
     log.info("Metrics report:")
-    log.info("\tLatency: {:.1f} ms".format(total_latency * 1e3))
+    log.info("\tLatency: {:.1f} ms".format(total_latency))
 
 if __name__ == '__main__':
     main()

--- a/demos/speech_recognition_deepspeech_demo/python/README.md
+++ b/demos/speech_recognition_deepspeech_demo/python/README.md
@@ -135,6 +135,9 @@ Optional (but highly recommended) language model files, `deepspeech-0.8.2-models
 ## Demo Output
 
 The application shows time taken by the initialization and processing stages, and the decoded text for the audio file. In real-time mode the current recognition result is shown while the app is running as well.
+In offline mode the demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/speech_recognition_quartznet_demo/python/README.md
+++ b/demos/speech_recognition_quartznet_demo/python/README.md
@@ -62,6 +62,9 @@ An example audio file can be taken from `<openvino_dir>/deployment_tools/demo/ho
 ## Demo Output
 
 The application prints the decoded text for the audio file.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/speech_recognition_quartznet_demo/python/speech_recognition_quartznet_demo.py
+++ b/demos/speech_recognition_quartznet_demo/python/speech_recognition_quartznet_demo.py
@@ -113,8 +113,8 @@ def build_argparser():
 def main():
     args = build_argparser().parse_args()
 
+    start_time = perf_counter()
     with wave.open(args.input, 'rb') as wave_read:
-        start_time = perf_counter()
         channel_num, sample_width, sampling_rate, pcm_length, compression_type, _ = wave_read.getparams()
         assert sample_width == 2, "Only 16-bit WAV PCM supported"
         assert compression_type == 'NONE', "Only linear PCM WAV files supported"

--- a/demos/text_spotting_demo/python/README.md
+++ b/demos/text_spotting_demo/python/README.md
@@ -168,7 +168,12 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The application uses OpenCV to display resulting text instances and current inference performance.
+The application uses OpenCV to display resulting text instances.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/text_spotting_demo/python/text_spotting_demo.py
+++ b/demos/text_spotting_demo/python/text_spotting_demo.py
@@ -18,7 +18,7 @@
 import logging as log
 import os
 import sys
-import time
+from time import perf_counter
 from argparse import ArgumentParser, SUPPRESS
 
 import cv2
@@ -33,6 +33,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.
                              'common/python'))
 import monitors
 from images_capture import open_images_capture
+from performance_metrics import PerformanceMetrics
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -208,6 +209,7 @@ def main():
     del text_enc_net
     del text_dec_net
 
+    start_time = perf_counter()
     frame = cap.read()
     if frame is None:
         raise RuntimeError("Can't read an image from the input")
@@ -224,9 +226,9 @@ def main():
 
     visualizer = Visualizer(['__background__', 'text'], show_boxes=args.show_boxes, show_scores=args.show_scores)
 
-    render_time = 0
     frames_processed = 0
 
+    metrics = PerformanceMetrics()
     presenter = monitors.Presenter(args.utilization_monitors, 45, (frame.shape[1] // 4, frame.shape[0] // 8))
     video_writer = cv2.VideoWriter()
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
@@ -254,7 +256,6 @@ def main():
         input_image = input_image.reshape((n, c, h, w)).astype(np.float32)
 
         # Run the net.
-        inf_start = time.time()
         outputs = mask_rcnn_exec_net.infer({'image': input_image})
 
         # Parse detection results of the current request
@@ -306,11 +307,6 @@ def main():
 
             texts.append(text if text_confidence >= args.tr_threshold else '')
 
-        inf_end = time.time()
-        inf_time = inf_end - inf_start
-
-        render_start = time.time()
-
         if len(boxes) and args.raw_output_message:
             log.debug('  -------------------------- Frame # {} --------------------------  '.format(frames_processed))
             log.debug('  Class ID | Confidence |     XMIN |     YMIN |     XMAX |     YMAX ')
@@ -326,12 +322,7 @@ def main():
 
         # Visualize masks.
         frame = visualizer(frame, boxes, classes, scores, masks, texts, masks_tracks_ids)
-
-        # Draw performance stats.
-        inf_time_message = 'Inference and post-processing time: {:.3f} ms'.format(inf_time * 1000)
-        render_time_message = 'OpenCV rendering time: {:.3f} ms'.format(render_time * 1000)
-        cv2.putText(frame, inf_time_message, (15, 15), cv2.FONT_HERSHEY_COMPLEX, 0.5, (200, 10, 10), 1)
-        cv2.putText(frame, render_time_message, (15, 30), cv2.FONT_HERSHEY_COMPLEX, 0.5, (10, 10, 200), 1)
+        metrics.update(start_time, frame)
 
         frames_processed += 1
         if video_writer.isOpened() and (args.output_limit <= 0 or frames_processed <= args.output_limit):
@@ -340,8 +331,6 @@ def main():
         if not args.no_show:
             # Show resulting image.
             cv2.imshow('Results', frame)
-        render_end = time.time()
-        render_time = render_end - render_start
 
         if not args.no_show:
             key = cv2.waitKey(delay)
@@ -350,8 +339,10 @@ def main():
                 break
             presenter.handleKey(key)
 
+        start_time = perf_counter()
         frame = cap.read()
 
+    metrics.log_total()
     print(presenter.reportMeans())
     cv2.destroyAllWindows()
 

--- a/demos/text_spotting_demo/python/text_spotting_demo.py
+++ b/demos/text_spotting_demo/python/text_spotting_demo.py
@@ -209,11 +209,6 @@ def main():
     del text_enc_net
     del text_dec_net
 
-    start_time = perf_counter()
-    frame = cap.read()
-    if frame is None:
-        raise RuntimeError("Can't read an image from the input")
-
     if args.no_track:
         tracker = None
     else:
@@ -229,8 +224,14 @@ def main():
     frames_processed = 0
 
     metrics = PerformanceMetrics()
-    presenter = monitors.Presenter(args.utilization_monitors, 45, (frame.shape[1] // 4, frame.shape[0] // 8))
     video_writer = cv2.VideoWriter()
+
+    start_time = perf_counter()
+    frame = cap.read()
+    if frame is None:
+        raise RuntimeError("Can't read an image from the input")
+
+    presenter = monitors.Presenter(args.utilization_monitors, 45, (frame.shape[1] // 4, frame.shape[0] // 8))
     if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                              cap.fps(), (frame.shape[1], frame.shape[0])):
         raise RuntimeError("Can't open video writer")

--- a/demos/text_to_speech_demo/python/README.md
+++ b/demos/text_to_speech_demo/python/README.md
@@ -143,6 +143,9 @@ python3 text_to_speech_demo.py \
 ## Demo Output
 
 The application outputs WAV file with generated audio.
+The demo reports
+
+* **Latency**: total processing time required to process input data (from reading the data to displaying the results).
 
 ## See Also
 

--- a/demos/whiteboard_inpainting_demo/python/README.md
+++ b/demos/whiteboard_inpainting_demo/python/README.md
@@ -125,6 +125,12 @@ The demo outputs original video with the processed one. Usage:
 * Select a part of the frame to be shown in a separate window by using your left mouse button.
 * Exit the demo by pressing `Esc`.
 
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+* **Latency**: average time required to process one frame (from reading the frame to displaying the results).
+You can use both of these metrics to measure application-level performance.
+
 ## See Also
 
 * [Open Model Zoo Demos](../../README.md)


### PR DESCRIPTION
Added performance metrics measurement to demos: 
- FPS only to demos with supporting of video processing
- latency to all demos. The latency is the total processing time, starting from reading the data to the results displaying (in cmd either in cv2 window)