### PR TITLE
fix object_detection_demo work on hddl (#2603)

### DIFF
--- a/demos/common/cpp/pipelines/include/pipelines/requests_pool.h
+++ b/demos/common/cpp/pipelines/include/pipelines/requests_pool.h
@@ -28,6 +28,7 @@
 class RequestsPool {
 public:
     RequestsPool(InferenceEngine::ExecutableNetwork& execNetwork, unsigned int size);
+    ~RequestsPool();
 
     /// Returns idle request from the pool. Returned request is automatically marked as In Use (this status will be reset after request processing completion)
     /// This function is thread safe as long as request is used only until setRequestIdle call

--- a/demos/common/cpp/pipelines/src/async_pipeline.cpp
+++ b/demos/common/cpp/pipelines/src/async_pipeline.cpp
@@ -49,12 +49,16 @@ AsyncPipeline::~AsyncPipeline() {
 void AsyncPipeline::waitForData(bool shouldKeepOrder) {
     std::unique_lock<std::mutex> lock(mtx);
 
-    condVar.wait(lock, [&] {return callbackException != nullptr ||
-        requestsPool->isIdleRequestAvailable() ||
-        (shouldKeepOrder ?
-            completedInferenceResults.find(outputFrameId) != completedInferenceResults.end() :
-            !completedInferenceResults.empty());
-    });
+    condVar.wait(
+        lock,
+        [&]()
+        {
+            return callbackException != nullptr ||
+                   requestsPool->isIdleRequestAvailable() ||
+                   (shouldKeepOrder ?
+                       completedInferenceResults.find(outputFrameId) != completedInferenceResults.end() :
+                       !completedInferenceResults.empty());
+        });
 
     if (callbackException)
         std::rethrow_exception(callbackException);
@@ -72,12 +76,10 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
     preprocessMetrics.update(startTime);
 
     request->SetCompletionCallback(
-        [this, frameID, request, internalModelData, metaData, startTime] {
-            request->SetCompletionCallback([]{});
-
+        [this, frameID, request, internalModelData, metaData, startTime]() {
             {
-                std::lock_guard<std::mutex> lock(mtx);
-                this->inferenceMetrics.update(startTime);
+                const std::lock_guard<std::mutex> lock(mtx);
+                inferenceMetrics.update(startTime);
                 try {
                     InferenceResult result;
 
@@ -89,22 +91,21 @@ int64_t AsyncPipeline::submitData(const InputData& inputData, const std::shared_
                     {
                         auto blobPtr = request->GetBlob(outName);
 
-                        if(Precision::I32 == blobPtr->getTensorDesc().getPrecision())
+                        if (Precision::I32 == blobPtr->getTensorDesc().getPrecision())
                             result.outputsData.emplace(outName, std::make_shared<TBlob<int>>(*as<TBlob<int>>(blobPtr)));
                         else
                             result.outputsData.emplace(outName, std::make_shared<TBlob<float>>(*as<TBlob<float>>(blobPtr)));
                     }
 
                     completedInferenceResults.emplace(frameID, result);
-                    this->requestsPool->setRequestIdle(request);
+                    requestsPool->setRequestIdle(request);
                 }
                 catch (...) {
-                    if (!this->callbackException) {
-                        this->callbackException = std::current_exception();
+                    if (!callbackException) {
+                        callbackException = std::current_exception();
                     }
                 }
             }
-
             condVar.notify_one();
     });
 
@@ -133,7 +134,7 @@ std::unique_ptr<ResultBase> AsyncPipeline::getResult(bool shouldKeepOrder) {
 InferenceResult AsyncPipeline::getInferenceResult(bool shouldKeepOrder) {
     InferenceResult retVal;
     {
-        std::lock_guard<std::mutex> lock(mtx);
+        const std::lock_guard<std::mutex> lock(mtx);
 
         const auto& it = shouldKeepOrder ?
             completedInferenceResults.find(outputFrameId) :

--- a/demos/common/cpp/pipelines/src/requests_pool.cpp
+++ b/demos/common/cpp/pipelines/src/requests_pool.cpp
@@ -23,6 +23,13 @@ RequestsPool::RequestsPool(InferenceEngine::ExecutableNetwork& execNetwork, unsi
     }
 }
 
+RequestsPool::~RequestsPool() {
+    // Setting empty callback to free resources allocated for previously assigned lambdas
+    for (auto& pair : requests) {
+        pair.first->SetCompletionCallback([]{});
+    }
+}
+
 InferenceEngine::InferRequest::Ptr RequestsPool::getIdleRequest() {
     std::lock_guard<std::mutex> lock(mtx);
 

--- a/demos/object_detection_demo/cpp/main.cpp
+++ b/demos/object_detection_demo/cpp/main.cpp
@@ -341,8 +341,7 @@ int main(int argc, char *argv[]) {
                 if (curr_frame.empty()) {
                     if (frameNum == -1) {
                         throw std::logic_error("Can't read an image from the input");
-                    }
-                    else {
+                    } else {
                         // Input stream is over
                         break;
                     }
@@ -355,8 +354,7 @@ int main(int argc, char *argv[]) {
             if (frameNum == 0) {
                 if (found == std::string::npos) {
                     outputResolution = curr_frame.size();
-                }
-                else {
+                } else {
                     outputResolution = cv::Size{
                         std::stoi(FLAGS_output_resolution.substr(0, found)),
                         std::stoi(FLAGS_output_resolution.substr(found + 1, FLAGS_output_resolution.length()))
@@ -401,32 +399,35 @@ int main(int argc, char *argv[]) {
                     int key = cv::waitKey(1);
                     if (27 == key || 'q' == key || 'Q' == key) {  // Esc
                         keepRunning = false;
-                    }
-                    else {
+                    } else {
                         presenter.handleKey(key);
                     }
                 }
             }
-        }
+        } // while(keepRunning)
 
         //// ------------ Waiting for completion of data processing and rendering the rest of results ---------
         pipeline.waitForTotalCompletion();
+
         for (; framesProcessed <= frameNum; framesProcessed++) {
-            while (!(result = pipeline.getResult())) {}
-            auto renderingStart = std::chrono::steady_clock::now();
-            cv::Mat outFrame = renderDetectionData(result->asRef<DetectionResult>(), palette, outputTransform);
-            //--- Showing results and device information
-            presenter.drawGraphs(outFrame);
-            renderMetrics.update(renderingStart);
-            metrics.update(result->metaData->asRef<ImageMetaData>().timeStamp,
-                outFrame, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX, 0.65);
-            if (videoWriter.isOpened() && (FLAGS_limit == 0 || framesProcessed <= FLAGS_limit - 1)) {
-                videoWriter.write(outFrame);
-            }
-            if (!FLAGS_no_show) {
-                cv::imshow("Detection Results", outFrame);
-                //--- Updating output window
-                cv::waitKey(1);
+            result = pipeline.getResult();
+            if (result != nullptr)
+            {
+                auto renderingStart = std::chrono::steady_clock::now();
+                cv::Mat outFrame = renderDetectionData(result->asRef<DetectionResult>(), palette, outputTransform);
+                //--- Showing results and device information
+                presenter.drawGraphs(outFrame);
+                renderMetrics.update(renderingStart);
+                metrics.update(result->metaData->asRef<ImageMetaData>().timeStamp,
+                    outFrame, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX, 0.65);
+                if (videoWriter.isOpened() && (FLAGS_limit == 0 || framesProcessed <= FLAGS_limit - 1)) {
+                    videoWriter.write(outFrame);
+                }
+                if (!FLAGS_no_show) {
+                    cv::imshow("Detection Results", outFrame);
+                    //--- Updating output window
+                    cv::waitKey(1);
+                }
             }
         }
 


### PR DESCRIPTION
* Free lambda callbacks on requests pool destruction because callback cleanup does not work from callback itself for HDDL

sync processing of tail (in main.cpp) with segmentation demo

* Update demos/common/cpp/pipelines/src/async_pipeline.cpp

Co-authored-by: Fedor Zharinov <fedor.zharinov@intel.com>

* Update demos/common/cpp/pipelines/src/async_pipeline.cpp

Co-authored-by: Fedor Zharinov <fedor.zharinov@intel.com>

* Update demos/common/cpp/pipelines/src/async_pipeline.cpp

Co-authored-by: Fedor Zharinov <fedor.zharinov@intel.com>

Co-authored-by: Fedor Zharinov <fedor.zharinov@intel.com>