### PR TITLE
Python: latency logging for every stage of pipeline

### DIFF
--- a/demos/common/cpp/utils/src/performance_metrics.cpp
+++ b/demos/common/cpp/utils/src/performance_metrics.cpp
@@ -95,15 +95,15 @@ PerformanceMetrics::Metrics PerformanceMetrics::getTotal() const {
 void PerformanceMetrics::printTotal() const {
     Metrics metrics = getTotal();
 
-    slog::info << "\tLatency: " << std::fixed << std::setprecision(1) << metrics.latency << " ms" << slog::endl;
+    slog::info << "\tLatency: " << std::fixed << std::setprecision(2) << metrics.latency << " ms" << slog::endl;
     slog::info << "\tFPS: " << metrics.fps << slog::endl;
 }
 
 void printStagesLatency(double readLat, double preprocLat, double inferLat, double postprocLat, double renderLat) {
     slog::info << "\tDecoding:\t" << std::fixed << std::setprecision(2) <<
         readLat << " ms" << slog::endl;;
-    slog::info << "\tPreprocessing:\t" << preprocLat << " ms" << slog::endl;;
-    slog::info << "\tInference:\t" << inferLat << " ms" << slog::endl;;
-    slog::info << "\tPostprocessing:\t" << postprocLat << " ms" << slog::endl;;
+    slog::info << "\tPreprocessing:\t" << preprocLat << " ms" << slog::endl;
+    slog::info << "\tInference:\t" << inferLat << " ms" << slog::endl;
+    slog::info << "\tPostprocessing:\t" << postprocLat << " ms" << slog::endl;
     slog::info << "\tRendering:\t" << renderLat << " ms" << slog::endl;
 }

--- a/demos/common/cpp/utils/src/performance_metrics.cpp
+++ b/demos/common/cpp/utils/src/performance_metrics.cpp
@@ -100,7 +100,7 @@ void PerformanceMetrics::printTotal() const {
 }
 
 void printStagesLatency(double readLat, double preprocLat, double inferLat, double postprocLat, double renderLat) {
-    slog::info << "\tDecoding:\t" << std::fixed << std::setprecision(2) <<
+    slog::info << "\tDecoding:\t" << std::fixed << std::setprecision(1) <<
         readLat << " ms" << slog::endl;
     slog::info << "\tPreprocessing:\t" << preprocLat << " ms" << slog::endl;
     slog::info << "\tInference:\t" << inferLat << " ms" << slog::endl;

--- a/demos/common/cpp/utils/src/performance_metrics.cpp
+++ b/demos/common/cpp/utils/src/performance_metrics.cpp
@@ -95,13 +95,13 @@ PerformanceMetrics::Metrics PerformanceMetrics::getTotal() const {
 void PerformanceMetrics::printTotal() const {
     Metrics metrics = getTotal();
 
-    slog::info << "\tLatency: " << std::fixed << std::setprecision(2) << metrics.latency << " ms" << slog::endl;
+    slog::info << "\tLatency: " << std::fixed << std::setprecision(1) << metrics.latency << " ms" << slog::endl;
     slog::info << "\tFPS: " << metrics.fps << slog::endl;
 }
 
 void printStagesLatency(double readLat, double preprocLat, double inferLat, double postprocLat, double renderLat) {
     slog::info << "\tDecoding:\t" << std::fixed << std::setprecision(2) <<
-        readLat << " ms" << slog::endl;;
+        readLat << " ms" << slog::endl;
     slog::info << "\tPreprocessing:\t" << preprocLat << " ms" << slog::endl;
     slog::info << "\tInference:\t" << inferLat << " ms" << slog::endl;
     slog::info << "\tPostprocessing:\t" << postprocLat << " ms" << slog::endl;

--- a/demos/common/python/helpers.py
+++ b/demos/common/python/helpers.py
@@ -52,5 +52,5 @@ def log_runtime_settings(exec_net, devices):
     log.info('\tNumber of network infer requests: {}'.format(len(exec_net.requests)))
 
 def log_latency_per_stage(pipeline_metrics):
-    for name, metric in pipeline_metrics.items():
-        log.info('\t{}:\t{:.2f} ms'.format(name, metric.get_total()[0] * 1e3))
+    for name, latency in pipeline_metrics.items():
+        log.info('\t{}:\t{:.1f} ms'.format(name, latency))

--- a/demos/common/python/helpers.py
+++ b/demos/common/python/helpers.py
@@ -51,7 +51,6 @@ def log_runtime_settings(exec_net, devices):
                 pass
     log.info('\tNumber of network infer requests: {}'.format(len(exec_net.requests)))
 
-def log_latency_per_stage(*metrics):
-    names = ('Decoding', 'Preprocessing', 'Inference', 'Postprocessing', 'Rendering')
-    for metric, name in zip(metrics, names):
+def log_latency_per_stage(pipeline_metrics):
+    for name, metric in pipeline_metrics.items():
         log.info('\t{}:\t{:.2f} ms'.format(name, metric.get_total()[0] * 1e3))

--- a/demos/common/python/helpers.py
+++ b/demos/common/python/helpers.py
@@ -51,6 +51,7 @@ def log_runtime_settings(exec_net, devices):
                 pass
     log.info('\tNumber of network infer requests: {}'.format(len(exec_net.requests)))
 
-def log_latency_per_stage(pipeline_metrics):
-    for name, latency in pipeline_metrics.items():
-        log.info('\t{}:\t{:.1f} ms'.format(name, latency))
+def log_latency_per_stage(*pipeline_metrics):
+    stages = ('Decoding', 'Preprocessing', 'Inference', 'Postprocessing', 'Rendering')
+    for stage, latency in zip(stages, pipeline_metrics):
+        log.info('\t{}:\t{:.1f} ms'.format(stage, latency))

--- a/demos/common/python/helpers.py
+++ b/demos/common/python/helpers.py
@@ -17,7 +17,6 @@
 import cv2
 import logging as log
 
-from pipelines import parse_devices
 
 def put_highlighted_text(frame, message, position, font_face, font_scale, color, thickness):
     cv2.putText(frame, message, position, font_face, font_scale, (255, 255, 255), thickness + 1) # white border
@@ -40,7 +39,7 @@ def log_blobs_info(model):
 
 def log_runtime_settings(exec_net, devices):
     if 'AUTO' not in devices:
-        for device in set(parse_devices(devices)):
+        for device in devices:
             try:
                 nstreams = exec_net.get_config(device + '_THROUGHPUT_STREAMS')
                 log.info('\tDevice: {}'.format(device))
@@ -51,3 +50,8 @@ def log_runtime_settings(exec_net, devices):
             except RuntimeError:
                 pass
     log.info('\tNumber of network infer requests: {}'.format(len(exec_net.requests)))
+
+def log_latency_per_stage(*metrics):
+    names = ('Decoding', 'Preprocessing', 'Inference', 'Postprocessing', 'Rendering')
+    for metric, name in zip(metrics, names):
+        log.info('\t{}:\t{:.2f} ms'.format(name, metric.get_total()[0] * 1e3))

--- a/demos/common/python/images_capture.py
+++ b/demos/common/python/images_capture.py
@@ -1,8 +1,11 @@
 import os
 import sys
 import copy
+from time import perf_counter
 
 import cv2
+
+from performance_metrics import PerformanceMetrics
 
 
 class InvalidInput(Exception):
@@ -33,11 +36,14 @@ class ImreadWrapper(ImagesCapture):
 
     def __init__(self, input, loop):
         self.loop = loop
+        self.reader_metrics = PerformanceMetrics()
+        start_time = perf_counter()
         if not os.path.isfile(input):
             raise InvalidInput("Can't find the image by {}".format(input))
         self.image = cv2.imread(input, cv2.IMREAD_COLOR)
         if self.image is None:
             raise OpenError("Can't open the image from {}".format(input))
+        self.reader_metrics.update(start_time)
         self.can_read = True
 
     def read(self):
@@ -59,6 +65,7 @@ class DirReader(ImagesCapture):
 
     def __init__(self, input, loop):
         self.loop = loop
+        self.reader_metrics = PerformanceMetrics()
         self.dir = input
         if not os.path.isdir(self.dir):
             raise InvalidInput("Can't find the dir by {}".format(input))
@@ -74,11 +81,13 @@ class DirReader(ImagesCapture):
         raise OpenError("Can't read the first image from {}".format(input))
 
     def read(self):
+        start_time = perf_counter()
         while self.file_id < len(self.names):
             filename = os.path.join(self.dir, self.names[self.file_id])
             image = cv2.imread(filename, cv2.IMREAD_COLOR)
             self.file_id += 1
             if image is not None:
+                self.reader_metrics.update(start_time)
                 return image
         if self.loop:
             self.file_id = 0
@@ -87,6 +96,7 @@ class DirReader(ImagesCapture):
                 image = cv2.imread(filename, cv2.IMREAD_COLOR)
                 self.file_id += 1
                 if image is not None:
+                    self.reader_metrics.update(start_time)
                     return image
         return None
 
@@ -101,12 +111,14 @@ class VideoCapWrapper(ImagesCapture):
 
     def __init__(self, input, loop):
         self.loop = loop
+        self.reader_metrics = PerformanceMetrics()
         self.cap = cv2.VideoCapture()
         status = self.cap.open(input)
         if not status:
             raise InvalidInput("Can't open the video from {}".format(input))
 
     def read(self):
+        start_time = perf_counter()
         status, image = self.cap.read()
         if not status:
             if not self.loop:
@@ -115,6 +127,7 @@ class VideoCapWrapper(ImagesCapture):
             status, image = self.cap.read()
             if not status:
                 return None
+        self.reader_metrics.update(start_time)
         return image
 
     def fps(self):
@@ -127,6 +140,7 @@ class VideoCapWrapper(ImagesCapture):
 class CameraCapWrapper(ImagesCapture):
 
     def __init__(self, input, camera_resolution):
+        self.reader_metrics = PerformanceMetrics()
         self.cap = cv2.VideoCapture()
         try:
             status = self.cap.open(int(input))
@@ -142,9 +156,11 @@ class CameraCapWrapper(ImagesCapture):
             raise InvalidInput("Can't find the camera {}".format(input))
 
     def read(self):
+        start_time = perf_counter()
         status, image = self.cap.read()
         if not status:
             return None
+        self.reader_metrics.update(start_time)
         return image
 
     def fps(self):

--- a/demos/common/python/performance_metrics.py
+++ b/demos/common/python/performance_metrics.py
@@ -41,14 +41,12 @@ class PerformanceMetrics:
         self.current_moving_statistic = Statistic()
         self.total_statistic = Statistic()
         self.last_update_time = None
-        self.first_frame_processed = False
 
     def update(self, last_request_start_time, frame=None):
         current_time = perf_counter()
 
-        if not self.first_frame_processed:
+        if self.last_update_time is None:
             self.last_update_time = last_request_start_time
-            self.first_frame_processed = True
 
         self.current_moving_statistic.latency += current_time - last_request_start_time
         self.current_moving_statistic.period = current_time - self.last_update_time
@@ -67,10 +65,10 @@ class PerformanceMetrics:
         # Draw performance stats over frame
         current_latency, current_fps = self.get_last()
         if current_latency is not None:
-            put_highlighted_text(frame, "Latency: {:.2f} ms".format(current_latency * 1e3),
+            put_highlighted_text(frame, "Latency: {:.1f} ms".format(current_latency * 1e3),
                                  position, cv2.FONT_HERSHEY_COMPLEX, font_scale, color, thickness)
         if current_fps is not None:
-            put_highlighted_text(frame, "FPS: {:.2f}".format(current_fps),
+            put_highlighted_text(frame, "FPS: {:.1f}".format(current_fps),
                                  (position[0], position[1]+30), cv2.FONT_HERSHEY_COMPLEX, font_scale, color, thickness)
 
     def get_last(self):
@@ -90,8 +88,11 @@ class PerformanceMetrics:
                 if frame_count != 0
                 else None)
 
+    def get_latency(self):
+        return self.get_total()[0] * 1e3
+
     def log_total(self):
         total_latency, total_fps = self.get_total()
         log.info('Metrics report:')
-        log.info("\tLatency: {:.2f} ms".format(total_latency * 1e3) if total_latency is not None else "\tLatency: N/A")
-        log.info("\tFPS: {:.2f}".format(total_fps) if total_fps is not None else "\tFPS: N/A")
+        log.info("\tLatency: {:.1f} ms".format(total_latency * 1e3) if total_latency is not None else "\tLatency: N/A")
+        log.info("\tFPS: {:.1f}".format(total_fps) if total_fps is not None else "\tFPS: N/A")

--- a/demos/common/python/performance_metrics.py
+++ b/demos/common/python/performance_metrics.py
@@ -63,7 +63,7 @@ class PerformanceMetrics:
         if frame is not None:
             self.paint_metrics(frame)
 
-    def paint_metrics(self, frame, position=(15,30), font_scale=0.75, color=(200,10,10), thickness=2):
+    def paint_metrics(self, frame, position=(15, 30), font_scale=0.75, color=(200, 10, 10), thickness=2):
         # Draw performance stats over frame
         current_latency, current_fps = self.get_last()
         if current_latency is not None:

--- a/demos/common/python/pipelines/async_pipeline.py
+++ b/demos/common/python/pipelines/async_pipeline.py
@@ -14,9 +14,12 @@
  limitations under the License.
 """
 
+from time import perf_counter
 import threading
 from collections import deque
 from typing import Dict, Set
+
+from performance_metrics import PerformanceMetrics
 
 
 def parse_devices(device_string):
@@ -96,11 +99,16 @@ class AsyncPipeline:
         self.callback_exceptions = {}
         self.event = threading.Event()
 
+        self.inference_metrics = PerformanceMetrics()
+        self.preprocess_metrics = PerformanceMetrics()
+        self.postprocess_metrics = PerformanceMetrics()
+
     def inference_completion_callback(self, status, callback_args):
         try:
-            request, id, meta, preprocessing_meta = callback_args
+            request, id, meta, preprocessing_meta, start_time = callback_args
             if status != 0:
                 raise RuntimeError('Infer Request has returned status code {}'.format(status))
+            self.inference_metrics.update(start_time)
             raw_outputs = {key: blob.buffer for key, blob in request.output_blobs.items()}
             self.completed_request_results[id] = (raw_outputs, meta, preprocessing_meta)
             self.empty_requests.append(request)
@@ -112,9 +120,11 @@ class AsyncPipeline:
         request = self.empty_requests.popleft()
         if len(self.empty_requests) == 0:
             self.event.clear()
+        start_time = perf_counter()
         inputs, preprocessing_meta = self.model.preprocess(inputs)
+        self.preprocess_metrics.update(start_time)
         request.set_completion_callback(py_callback=self.inference_completion_callback,
-                                        py_data=(request, id, meta, preprocessing_meta))
+                                        py_data=(request, id, meta, preprocessing_meta, perf_counter()))
         request.async_infer(inputs=inputs)
 
     def get_raw_result(self, id):
@@ -126,7 +136,10 @@ class AsyncPipeline:
         result = self.get_raw_result(id)
         if result:
             raw_result, meta, preprocess_meta = result
-            return self.model.postprocess(raw_result, preprocess_meta), meta
+            start_time = perf_counter()
+            result = self.model.postprocess(raw_result, preprocess_meta), meta
+            self.postprocess_metrics.update(start_time)
+            return result
         return None
 
     def is_ready(self):

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -186,7 +186,7 @@ def main():
                         'Preprocessing': pipeline.preprocess_metrics,
                         'Inference': pipeline.inference_metrics,
                         'Postprocessing': pipeline.postprocess_metrics,
-                        'Rendering':render_metrics}
+                        'Rendering': render_metrics}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -182,12 +182,11 @@ def main():
             break
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
-                        'Preprocessing': pipeline.preprocess_metrics.get_latency(),
-                        'Inference': pipeline.inference_metrics.get_latency(),
-                        'Postprocessing': pipeline.postprocess_metrics.get_latency(),
-                        'Rendering': render_metrics.get_latency()}
-    log_latency_per_stage(pipeline_metrics)
+    log_latency_per_stage(cap.reader_metrics.get_latency(),
+                          pipeline.preprocess_metrics.get_latency(),
+                          pipeline.inference_metrics.get_latency(),
+                          pipeline.postprocess_metrics.get_latency(),
+                          render_metrics.get_latency())
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -182,8 +182,12 @@ def main():
             break
 
     metrics.log_total()
-    log_latency_per_stage(cap.reader_metrics, pipeline.preprocess_metrics, pipeline.inference_metrics,
-                          pipeline.postprocess_metrics, render_metrics)
+    pipeline_metrics = {'Decoding': cap.reader_metrics,
+                        'Preprocessing': pipeline.preprocess_metrics,
+                        'Inference': pipeline.inference_metrics,
+                        'Postprocessing': pipeline.postprocess_metrics,
+                        'Rendering':render_metrics}
+    log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/deblurring_demo/python/deblurring_demo.py
+++ b/demos/deblurring_demo/python/deblurring_demo.py
@@ -182,11 +182,11 @@ def main():
             break
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics,
-                        'Preprocessing': pipeline.preprocess_metrics,
-                        'Inference': pipeline.inference_metrics,
-                        'Postprocessing': pipeline.postprocess_metrics,
-                        'Rendering': render_metrics}
+    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
+                        'Preprocessing': pipeline.preprocess_metrics.get_latency(),
+                        'Inference': pipeline.inference_metrics.get_latency(),
+                        'Postprocessing': pipeline.postprocess_metrics.get_latency(),
+                        'Rendering': render_metrics.get_latency()}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -285,11 +285,11 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics,
-                        'Preprocessing': hpe_pipeline.preprocess_metrics,
-                        'Inference': hpe_pipeline.inference_metrics,
-                        'Postprocessing': hpe_pipeline.postprocess_metrics,
-                        'Rendering': render_metrics}
+    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
+                        'Preprocessing': hpe_pipeline.preprocess_metrics.get_latency(),
+                        'Inference': hpe_pipeline.inference_metrics.get_latency(),
+                        'Postprocessing': hpe_pipeline.postprocess_metrics.get_latency(),
+                        'Rendering': render_metrics.get_latency()}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -285,8 +285,12 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    log_latency_per_stage(cap.reader_metrics, hpe_pipeline.preprocess_metrics, hpe_pipeline.inference_metrics,
-                          hpe_pipeline.postprocess_metrics, render_metrics)
+    pipeline_metrics = {'Decoding': cap.reader_metrics,
+                        'Preprocessing': hpe_pipeline.preprocess_metrics,
+                        'Inference': hpe_pipeline.inference_metrics,
+                        'Postprocessing': hpe_pipeline.postprocess_metrics,
+                        'Rendering':render_metrics}
+    log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -289,7 +289,7 @@ def main():
                         'Preprocessing': hpe_pipeline.preprocess_metrics,
                         'Inference': hpe_pipeline.inference_metrics,
                         'Postprocessing': hpe_pipeline.postprocess_metrics,
-                        'Rendering':render_metrics}
+                        'Rendering': render_metrics}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -285,12 +285,11 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
-                        'Preprocessing': hpe_pipeline.preprocess_metrics.get_latency(),
-                        'Inference': hpe_pipeline.inference_metrics.get_latency(),
-                        'Postprocessing': hpe_pipeline.postprocess_metrics.get_latency(),
-                        'Rendering': render_metrics.get_latency()}
-    log_latency_per_stage(pipeline_metrics)
+    log_latency_per_stage(cap.reader_metrics.get_latency(),
+                          hpe_pipeline.preprocess_metrics.get_latency(),
+                          hpe_pipeline.inference_metrics.get_latency(),
+                          hpe_pipeline.postprocess_metrics.get_latency(),
+                          render_metrics.get_latency())
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/image_retrieval_demo/python/image_retrieval_demo.py
+++ b/demos/image_retrieval_demo/python/image_retrieval_demo.py
@@ -168,7 +168,7 @@ def main():
                         img_retrieval.input_size, np.mean(compute_embeddings_times),
                         np.mean(search_in_gallery_times), imshow_delay=3, presenter=presenter, no_show=args.no_show)
 
-        metrics.update(start_time, image, draw_metrics=False)
+        metrics.update(start_time)
         if frames_processed == 0:
             if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'),
                                                      cap.fps(), (image.shape[1], image.shape[0])):

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -354,8 +354,12 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    log_latency_per_stage(cap.reader_metrics, detector_pipeline.preprocess_metrics, detector_pipeline.inference_metrics,
-                          detector_pipeline.postprocess_metrics, render_metrics)
+    pipeline_metrics = {'Decoding': cap.reader_metrics,
+                        'Preprocessing': detector_pipeline.preprocess_metrics,
+                        'Inference': detector_pipeline.inference_metrics,
+                        'Postprocessing': detector_pipeline.postprocess_metrics,
+                        'Rendering':render_metrics}
+    log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -354,12 +354,11 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
-                        'Preprocessing': detector_pipeline.preprocess_metrics.get_latency(),
-                        'Inference': detector_pipeline.inference_metrics.get_latency(),
-                        'Postprocessing': detector_pipeline.postprocess_metrics.get_latency(),
-                        'Rendering': render_metrics.get_latency()}
-    log_latency_per_stage(pipeline_metrics)
+    log_latency_per_stage(cap.reader_metrics.get_latency(),
+                          detector_pipeline.preprocess_metrics.get_latency(),
+                          detector_pipeline.inference_metrics.get_latency(),
+                          detector_pipeline.postprocess_metrics.get_latency(),
+                          render_metrics.get_latency())
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -32,10 +32,10 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 
 import models
 import monitors
-from pipelines import get_user_config, AsyncPipeline
+from pipelines import get_user_config, parse_devices, AsyncPipeline
 from images_capture import open_images_capture
 from performance_metrics import PerformanceMetrics
-from helpers import resolution, log_blobs_info, log_runtime_settings
+from helpers import resolution, log_blobs_info, log_runtime_settings, log_latency_per_stage
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -248,13 +248,14 @@ def main():
                                       device=args.device, max_num_requests=args.num_infer_requests)
 
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
-    log_runtime_settings(detector_pipeline.exec_net, args.device)
+    log_runtime_settings(detector_pipeline.exec_net, set(parse_devices(args.device)))
 
     next_frame_id = 0
     next_frame_id_to_show = 0
 
     palette = ColorPalette(len(model.labels) if model.labels else 100)
     metrics = PerformanceMetrics()
+    render_metrics = PerformanceMetrics()
     presenter = None
     output_transform = None
     video_writer = cv2.VideoWriter()
@@ -273,7 +274,9 @@ def main():
                 print_raw_results(objects, model.labels, next_frame_id_to_show)
 
             presenter.drawGraphs(frame)
+            rendering_start_time = perf_counter()
             frame = draw_detections(frame, objects, palette, model.labels, output_transform)
+            render_metrics.update(rendering_start_time)
             metrics.update(start_time, frame)
 
             if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
@@ -332,7 +335,9 @@ def main():
             print_raw_results(objects, model.labels, next_frame_id_to_show)
 
         presenter.drawGraphs(frame)
+        rendering_start_time = perf_counter()
         frame = draw_detections(frame, objects, palette, model.labels, output_transform)
+        render_metrics.update(rendering_start_time)
         metrics.update(start_time, frame)
 
         if video_writer.isOpened() and (args.output_limit <= 0 or next_frame_id_to_show <= args.output_limit-1):
@@ -349,6 +354,8 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
+    log_latency_per_stage(cap.reader_metrics, detector_pipeline.preprocess_metrics, detector_pipeline.inference_metrics,
+                          detector_pipeline.postprocess_metrics, render_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -354,11 +354,11 @@ def main():
             presenter.handleKey(key)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics,
-                        'Preprocessing': detector_pipeline.preprocess_metrics,
-                        'Inference': detector_pipeline.inference_metrics,
-                        'Postprocessing': detector_pipeline.postprocess_metrics,
-                        'Rendering': render_metrics}
+    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
+                        'Preprocessing': detector_pipeline.preprocess_metrics.get_latency(),
+                        'Inference': detector_pipeline.inference_metrics.get_latency(),
+                        'Postprocessing': detector_pipeline.postprocess_metrics.get_latency(),
+                        'Rendering': render_metrics.get_latency()}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -358,7 +358,7 @@ def main():
                         'Preprocessing': detector_pipeline.preprocess_metrics,
                         'Inference': detector_pipeline.inference_metrics,
                         'Postprocessing': detector_pipeline.postprocess_metrics,
-                        'Rendering':render_metrics}
+                        'Rendering': render_metrics}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/place_recognition_demo/python/place_recognition_demo.py
+++ b/demos/place_recognition_demo/python/place_recognition_demo.py
@@ -122,7 +122,7 @@ def main():
                                np.mean(compute_embeddings_times), np.mean(search_in_gallery_times),
                                imshow_delay=3, presenter=presenter, no_show=args.no_show)
 
-        metrics.update(start_time, image, draw_metrics=False)
+        metrics.update(start_time)
         if frames_processed == 0:
             if args.output and not video_writer.open(args.output, cv2.VideoWriter_fourcc(*'MJPG'), cap.fps(),
                                                      (image.shape[1], image.shape[0])):

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -285,8 +285,12 @@ def main():
             key = cv2.waitKey(1)
 
     metrics.log_total()
-    log_latency_per_stage(cap.reader_metrics, pipeline.preprocess_metrics, pipeline.inference_metrics,
-                          pipeline.postprocess_metrics, render_metrics)
+    pipeline_metrics = {'Decoding': cap.reader_metrics,
+                        'Preprocessing': pipeline.preprocess_metrics,
+                        'Inference': pipeline.inference_metrics,
+                        'Postprocessing': pipeline.postprocess_metrics,
+                        'Rendering':render_metrics}
+    log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -285,11 +285,11 @@ def main():
             key = cv2.waitKey(1)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics,
-                        'Preprocessing': pipeline.preprocess_metrics,
-                        'Inference': pipeline.inference_metrics,
-                        'Postprocessing': pipeline.postprocess_metrics,
-                        'Rendering': render_metrics}
+    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
+                        'Preprocessing': pipeline.preprocess_metrics.get_latency(),
+                        'Inference': pipeline.inference_metrics.get_latency(),
+                        'Postprocessing': pipeline.postprocess_metrics.get_latency(),
+                        'Rendering': render_metrics.get_latency()}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -289,7 +289,7 @@ def main():
                         'Preprocessing': pipeline.preprocess_metrics,
                         'Inference': pipeline.inference_metrics,
                         'Postprocessing': pipeline.postprocess_metrics,
-                        'Rendering':render_metrics}
+                        'Rendering': render_metrics}
     log_latency_per_stage(pipeline_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -285,12 +285,11 @@ def main():
             key = cv2.waitKey(1)
 
     metrics.log_total()
-    pipeline_metrics = {'Decoding': cap.reader_metrics.get_latency(),
-                        'Preprocessing': pipeline.preprocess_metrics.get_latency(),
-                        'Inference': pipeline.inference_metrics.get_latency(),
-                        'Postprocessing': pipeline.postprocess_metrics.get_latency(),
-                        'Rendering': render_metrics.get_latency()}
-    log_latency_per_stage(pipeline_metrics)
+    log_latency_per_stage(cap.reader_metrics.get_latency(),
+                          pipeline.preprocess_metrics.get_latency(),
+                          pipeline.inference_metrics.get_latency(),
+                          pipeline.postprocess_metrics.get_latency(),
+                          render_metrics.get_latency())
     for rep in presenter.reportMeans():
         log.info(rep)
 

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -29,10 +29,10 @@ sys.path.append(str(Path(__file__).resolve().parents[2] / 'common/python'))
 
 from models import OutputTransform, SegmentationModel, SalientObjectDetectionModel
 import monitors
-from pipelines import get_user_config, AsyncPipeline
+from pipelines import get_user_config, parse_devices, AsyncPipeline
 from images_capture import open_images_capture
 from performance_metrics import PerformanceMetrics
-from helpers import resolution, log_blobs_info, log_runtime_settings
+from helpers import resolution, log_blobs_info, log_runtime_settings, log_latency_per_stage
 
 log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=sys.stdout)
 
@@ -194,12 +194,13 @@ def main():
     pipeline = AsyncPipeline(ie, model, plugin_config, device=args.device, max_num_requests=args.num_infer_requests)
 
     log.info('The model {} is loaded to {}'.format(args.model, args.device))
-    log_runtime_settings(pipeline.exec_net, args.device)
+    log_runtime_settings(pipeline.exec_net, set(parse_devices(args.device)))
 
     next_frame_id = 0
     next_frame_id_to_show = 0
 
     metrics = PerformanceMetrics()
+    render_metrics = PerformanceMetrics()
     presenter = None
     output_transform = None
     video_writer = cv2.VideoWriter()
@@ -241,7 +242,9 @@ def main():
                 print_raw_results(objects, next_frame_id_to_show, model.labels)
             frame = frame_meta['frame']
             start_time = frame_meta['start_time']
+            rendering_start_time = perf_counter()
             frame = visualizer.overlay_masks(frame, objects, output_transform)
+            render_metrics.update(rendering_start_time)
             presenter.drawGraphs(frame)
             metrics.update(start_time, frame)
 
@@ -268,7 +271,9 @@ def main():
         frame = frame_meta['frame']
         start_time = frame_meta['start_time']
 
+        rendering_start_time = perf_counter()
         frame = visualizer.overlay_masks(frame, objects, output_transform)
+        render_metrics.update(rendering_start_time)
         presenter.drawGraphs(frame)
         metrics.update(start_time, frame)
 
@@ -280,6 +285,8 @@ def main():
             key = cv2.waitKey(1)
 
     metrics.log_total()
+    log_latency_per_stage(cap.reader_metrics, pipeline.preprocess_metrics, pipeline.inference_metrics,
+                          pipeline.postprocess_metrics, render_metrics)
     for rep in presenter.reportMeans():
         log.info(rep)
 


### PR DESCRIPTION
Add logging of latency per stage for API demos, update `PerformanceMetrics` to be consistent with C++ implementation (fix latency for one image case, move drawing metrics on the frame in a separate function)