### PR TITLE
Segmentation demo: switch between overlay masks / only masks

### DIFF
--- a/demos/segmentation_demo/cpp/README.md
+++ b/demos/segmentation_demo/cpp/README.md
@@ -76,7 +76,7 @@ Options:
     -no_show                  Optional. Don't show output.
     -output_resolution        Optional. Specify the maximum output window resolution in (width x height) format. Example: 1280x720. Input frame size used by default.
     -u                        Optional. List of monitors to show initially.
-    -only_masks               Optional. Display only masks. Could be switched by TAB key.    
+    -only_masks               Optional. Display only masks. Could be switched by TAB key.
 ```
 
 Running the application with the empty list of options yields an error message.
@@ -99,7 +99,7 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `-only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks. 
+The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `-only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
 
 > **NOTE**: the output file contains the same image as displayed one.
 

--- a/demos/segmentation_demo/cpp/README.md
+++ b/demos/segmentation_demo/cpp/README.md
@@ -76,6 +76,7 @@ Options:
     -no_show                  Optional. Don't show output.
     -output_resolution        Optional. Specify the maximum output window resolution in (width x height) format. Example: 1280x720. Input frame size used by default.
     -u                        Optional. List of monitors to show initially.
+    -only_masks               Optional. Display only masks. Could be switched by TAB key.    
 ```
 
 Running the application with the empty list of options yields an error message.
@@ -98,7 +99,9 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask.
+The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `-only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks. 
+
+> **NOTE**: the output file contains the same image as displayed one.
 
 ## See Also
 

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -57,6 +57,7 @@ static const char no_show_message[] = "Optional. Don't show output.";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
 static const char output_resolution_message[] = "Optional. Specify the maximum output window resolution "
     "in (width x height) format. Example: 1280x720. Input frame size used by default.";
+static const char only_masks_message[] = "Optional. Display only masks. Could be switched by TAB key.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(m, "", model_message);
@@ -72,6 +73,7 @@ DEFINE_string(nstreams, "", num_streams_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_string(u, "", utilization_monitors_message);
 DEFINE_string(output_resolution, "", output_resolution_message);
+DEFINE_bool(only_masks, false, only_masks_message);
 
 /**
 * \brief This function shows a help message
@@ -100,6 +102,7 @@ static void showUsage() {
     std::cout << "    -no_show                  " << no_show_message << std::endl;
     std::cout << "    -output_resolution        " << output_resolution_message << std::endl;
     std::cout << "    -u                        " << utilization_monitors_message << std::endl;
+    std::cout << "    -only_masks               " << only_masks_message << std::endl;
 }
 
 
@@ -173,7 +176,7 @@ cv::Mat applyColorMap(cv::Mat input) {
     return out;
 }
 
-cv::Mat renderSegmentationData(const ImageResult& result, OutputTransform& outputTransform) {
+cv::Mat renderSegmentationData(const ImageResult& result, OutputTransform& outputTransform, bool masks_only) {
     if (!result.metaData) {
         throw std::invalid_argument("Renderer: metadata is null");
     }
@@ -186,7 +189,7 @@ cv::Mat renderSegmentationData(const ImageResult& result, OutputTransform& outpu
     }
 
     // Visualizing result data over source image
-    cv::Mat output = inputImg / 2 + applyColorMap(result.resultImage) / 2;
+    cv::Mat output = masks_only ? applyColorMap(result.resultImage) : inputImg / 2 + applyColorMap(result.resultImage) / 2;
     outputTransform.resize(output);
     return output;
 }
@@ -254,6 +257,8 @@ int main(int argc, char* argv[]) {
         OutputTransform outputTransform = OutputTransform();
         size_t found = FLAGS_output_resolution.find("x");
 
+        bool only_masks = FLAGS_only_masks;
+
         while (keepRunning) {
             if (pipeline.isReadyToProcess()) {
                 auto startTime = std::chrono::steady_clock::now();
@@ -304,7 +309,7 @@ int main(int argc, char* argv[]) {
             //    and use your own processing instead of calling renderSegmentationData().
             while (keepRunning && (result = pipeline.getResult())) {
                 auto renderingStart = std::chrono::steady_clock::now();
-                cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform);
+                cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform, only_masks);
                 //--- Showing results and device information
                 if (FLAGS_r) {
                     printRawResults(result->asRef<ImageResult>(), labels);
@@ -324,6 +329,8 @@ int main(int argc, char* argv[]) {
                     auto key = cv::waitKey(1);
                     if (27 == key || 'q' == key || 'Q' == key) { // Esc
                         keepRunning = false;
+                    } else if (9 == key) {
+                        only_masks = !only_masks;
                     } else {
                         presenter.handleKey(key);
                     }
@@ -337,7 +344,7 @@ int main(int argc, char* argv[]) {
         for (; framesProcessed <= frameNum; framesProcessed++) {
             result = pipeline.getResult();
             if (result != nullptr) {
-                cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform);
+                cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform, only_masks);
                 //--- Showing results and device information
                 if (FLAGS_r) {
                     printRawResults(result->asRef<ImageResult>(), labels);

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -113,6 +113,7 @@ Input/output options:
                         Input frame size used by default.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
+  --only_masks          Optional. Display only masks. Could be switched by TAB key.                        
 
 Debug options:
   -r, --raw_output_message
@@ -145,7 +146,10 @@ Available colors files located in the `<omz_dir>/data/palettes` folder. If you w
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask.
+The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `--only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks. 
+
+> **NOTE**: the output file contains the same image as displayed one.
+
 The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -113,7 +113,7 @@ Input/output options:
                         Input frame size used by default.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
-  --only_masks          Optional. Display only masks. Could be switched by TAB key.                        
+  --only_masks          Optional. Display only masks. Could be switched by TAB key.
 
 Debug options:
   -r, --raw_output_message
@@ -146,7 +146,7 @@ Available colors files located in the `<omz_dir>/data/palettes` folder. If you w
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `--only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks. 
+The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `--only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
 
 > **NOTE**: the output file contains the same image as displayed one.
 


### PR DESCRIPTION
Activated by `-only_masks`/`--only_masks` option or by `TAB` key during demo running