### PR TITLE
Define armv7 instruction set for OMZ demos built natively on x32 ARM

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -60,7 +60,12 @@ else()
     set(COMPILER_IS_GCC_LIKE FALSE)
 endif()
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)" AND NOT CMAKE_CROSSCOMPILING)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64.*|aarch64.*|AARCH64.*)")
+  set(AARCH64 ON)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+  set(ARM ON)
+endif()
+if(ARM AND NOT CMAKE_CROSSCOMPILING)
     add_compile_options(-march=armv7-a)
 endif()
 


### PR DESCRIPTION
Create PR instead of corrupted https://github.com/openvinotoolkit/open_model_zoo/pull/2684

Fix to https://github.com/openvinotoolkit/open_model_zoo/pull/2641
It sets `armv7` instruction set to x32 only. The previous PR treats ARM64 architecture which is used in Apple M1 chip incorrectly.