### PR TITLE
Update accuracy for intel segmentation models

### DIFF
--- a/models/intel/icnet-camvid-ava-0001/README.md
+++ b/models/intel/icnet-camvid-ava-0001/README.md
@@ -34,7 +34,7 @@ The quality metrics were calculated on the CamVid validation dataset. The `unlab
 
 | Metric                    | Value         |
 |---------------------------|---------------|
-| mIoU                      |        69.54% |
+| mIoU                      |        75.42% |
 
 - `IOU=TP/(TP+FN+FP)`, where:
   - `TP` - number of true positive pixels for given class

--- a/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
@@ -22,3 +22,5 @@ models:
         metrics:
           - type: mean_iou
             use_argmax: false
+            ignore_label: 11
+            presenter: print_vector

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/README.md
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/README.md
@@ -34,7 +34,7 @@ The quality metrics were calculated on the CamVid validation dataset. The `unlab
 
 | Metric                    | Value         |
 |---------------------------|---------------|
-| mIoU                      |        69.99% |
+| mIoU                      |        75.87% |
 
 - `IOU=TP/(TP+FN+FP)`, where:
   - `TP` - number of true positive pixels for given class

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
@@ -22,3 +22,5 @@ models:
         metrics:
           - type: mean_iou
             use_argmax: false
+            ignore_label: 11
+            presenter: print_vector

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/README.md
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/README.md
@@ -34,7 +34,7 @@ The quality metrics were calculated on the CamVid validation dataset. The `unlab
 
 | Metric                    | Value         |
 |---------------------------|---------------|
-| mIoU                      |        69.91% |
+| mIoU                      |        75.79% |
 
 - `IOU=TP/(TP+FN+FP)`, where:
   - `TP` - number of true positive pixels for given class

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
@@ -22,3 +22,5 @@ models:
         metrics:
           - type: mean_iou
             use_argmax: false
+            ignore_label: 11
+            presenter: print_vector


### PR DESCRIPTION
According to the documentation, `unlabeled` class should be ignored during metrics calculation.