### PR TITLE
Added mxnet==1.2.0 to requirements-conversion.txt for Demos Windows 10 Job

### DIFF
--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -54,7 +54,7 @@ keras-preprocessing==1.1.2
     # via tensorflow
 markdown==3.3.4
     # via tensorboard
-mxnet==1.7.0.post2 ; sys_platform != "win32"
+mxnet==1.7.0.post2
     # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
 networkx==2.5.1
     # via

--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -54,7 +54,8 @@ keras-preprocessing==1.1.2
     # via tensorflow
 markdown==3.3.4
     # via tensorboard
-mxnet==1.7.0.post2
+mxnet==1.2.0 ; sys_platform == 'win32'
+mxnet==1.7.0.post2 ; sys_platform != "win32"
     # via -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_mxnet.txt
 networkx==2.5.1
     # via


### PR DESCRIPTION
Fixing `ModuleNotFoundError: No module named 'mxnet'` (occurs during the models converting stage).