### PR TITLE
Model API refactoring

### DIFF
--- a/demos/common/python/models/__init__.py
+++ b/demos/common/python/models/__init__.py
@@ -26,7 +26,7 @@ from .retinaface import RetinaFace, RetinaFacePyTorch
 from .segmentation import SegmentationModel, SalientObjectDetectionModel
 from .ssd import SSD
 from .ultra_lightweight_face_detection import UltraLightweightFaceDetection
-from .utils import DetectionWithLandmarks, InputTransform, OutputTransform
+from .utils import DetectionWithLandmarks, InputTransform, OutputTransform, RESIZE_TYPES
 from .yolo import YOLO, YoloV4, YOLOX
 
 __all__ = [
@@ -40,6 +40,7 @@ __all__ = [
     'InputTransform',
     'OpenPose',
     'OutputTransform',
+    'RESIZE_TYPES',
     'RetinaFace',
     'RetinaFacePyTorch',
     'SalientObjectDetectionModel',

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,14 +23,12 @@ from .utils import Detection, clip_detections
 
 
 class CenterNet(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type=None, 
                  labels=None, threshold=0.5, iou_threshold=0.5):
+        if not resize_type:
+            resize_type = 'standard'
         super().__init__(ie, model_path, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The CenterNet model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 3)
         self._output_layer_names = sorted(self.net.outputs)
 

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -18,45 +18,17 @@ import cv2
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
-from .model import Model
-from .utils import Detection, load_labels, clip_detections
+from .detection_model import DetectionModel
+from .utils import Detection, clip_detections
 
 
-class CenterNet(Model):
-    def __init__(self, ie, model_path, labels=None, threshold=0.3):
-        super().__init__(ie, model_path)
-
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        assert len(self.net.outputs) == 3, "Expected 3 output blobs"
-
-        if isinstance(labels, (list, tuple)):
-            self.labels = labels
-        else:
-            self.labels = load_labels(labels) if labels else None
-
-        self.image_blob_name = next(iter(self.net.input_info))
+class CenterNet(DetectionModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+                 labels=None, threshold=0.5, iou_threshold=0.5):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+                         labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        
         self._output_layer_names = sorted(self.net.outputs)
-
-        self._threshold = threshold
-
-        self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-        assert self.c == 3, "Expected 3-channel input"
-
-    def preprocess(self, inputs):
-        image = inputs
-        meta = {'original_shape': image.shape}
-
-        height, width = image.shape[0:2]
-        center = np.array([width / 2., height / 2.], dtype=np.float32)
-        scale = max(height, width)
-        trans_input = self.get_affine_transform(center, scale, 0, [self.w, self.h])
-        resized_image = cv2.warpAffine(image, trans_input, (self.w, self.h), flags=cv2.INTER_LINEAR)
-        resized_image = self.input_transform(resized_image)
-        resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        dict_inputs = {self.image_blob_name: resized_image}
-        return dict_inputs, meta
 
     def postprocess(self, outputs, meta):
         heat = outputs[self._output_layer_names[0]][0]
@@ -83,7 +55,7 @@ class CenterNet(Model):
                                  xs + wh[..., 0:1] / 2,
                                  ys + wh[..., 1:2] / 2), axis=1)
         detections = np.concatenate((bboxes, scores, clses), axis=1)
-        mask = detections[..., 4] >= self._threshold
+        mask = detections[..., 4] >= self.threshold
         filtered_detections = detections[mask]
         scale = max(meta['original_shape'])
         center = np.array(meta['original_shape'][:2])/2.0

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,9 +23,9 @@ from .utils import Detection, clip_detections
 
 
 class CenterNet(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+        super().__init__(ie, model_path, resize_type=resize_type,
                          keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,7 +23,7 @@ from .utils import Detection, clip_detections
 
 
 class CenterNet(DetectionModel):
-    def __init__(self, ie, model_path, resize_type=None, 
+    def __init__(self, ie, model_path, resize_type=None,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         if not resize_type:
             resize_type = 'standard'

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -27,6 +27,7 @@ class CenterNet(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        self._check_io_number(1, 3)
         self._output_layer_names = sorted(self.net.outputs)
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,11 +23,10 @@ from .utils import Detection, clip_detections
 
 
 class CenterNet(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        
         self._output_layer_names = sorted(self.net.outputs)
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/models/centernet.py
+++ b/demos/common/python/models/centernet.py
@@ -23,10 +23,14 @@ from .utils import Detection, clip_detections
 
 
 class CenterNet(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The CenterNet model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 3)
         self._output_layer_names = sorted(self.net.outputs)
 

--- a/demos/common/python/models/ctpn.py
+++ b/demos/common/python/models/ctpn.py
@@ -24,6 +24,7 @@ from .utils import Detection, nms, clip_detections
 class CTPN(Model):
     def __init__(self, ie, model_path, input_size, threshold=0.9):
         super().__init__(ie, model_path)
+        self._check_io_number(1, 2)
 
         self.image_blob_name = self.prepare_inputs()
         self.bboxes_blob_name, self.scores_blob_name = self.prepare_outputs()
@@ -60,9 +61,6 @@ class CTPN(Model):
         self.net.reshape(input_shape)
 
     def prepare_inputs(self):
-        if len(self.net.input_info) != 1:
-            raise RuntimeError("The CTPN topology supposes only 1 input layer")
-
         image_blob_name = next(iter(self.net.input_info))
         input_size = self.net.input_info[image_blob_name].input_data.shape
 
@@ -72,9 +70,6 @@ class CTPN(Model):
         return image_blob_name
 
     def prepare_outputs(self):
-        if len(self.net.outputs) != 2:
-            raise RuntimeError("The CTPN topology supposes exactly 2 output layers")
-
         (boxes_name, boxes_data_repr), (scores_name, scores_data_repr) = self.net.outputs.items()
 
         if len(boxes_data_repr.shape) != 4 or len(scores_data_repr.shape) != 4:

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -29,7 +29,7 @@ class DetectionModel(ImageModel):
         iou_threshold(float): threshold for NMS detection filtering
     '''
 
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=None, iou_threshold=None):
         '''The Detection Model constructor
         

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -1,3 +1,18 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
 from .image_model import ImageModel
 from .utils import load_labels, clip_detections
 

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -1,0 +1,76 @@
+from .image_model import ImageModel
+from .utils import Detection, load_labels, clip_detections
+
+
+class DetectionModel(ImageModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+                 labels=None, threshold=None, iou_threshold=None):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
+        if isinstance(labels, (list, tuple)):
+            self.labels = labels
+        else:
+            self.labels = load_labels(labels) if labels else None
+
+        self.threshold = threshold
+        self.iou_threshold = iou_threshold
+
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs, meta)
+        resized_shape = meta['resized_shape']
+        original_shape = meta['original_shape']
+
+        if self.resize_type=='letterbox':
+            detections = self._resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
+        elif self.resize_type == 'keep_aspect_ratio':
+            detections = self._resize_detections_with_aspect(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
+        elif self.resize_type == 'default':
+            detections = self._resize_detections(detections, original_shape[1::-1])
+        else:
+            raise RuntimeError('Unknown resize type {}'.format(self.resize_type))
+        return clip_detections(detections, original_shape)
+
+    def _parse_outputs(self, outputs, meta):
+        raise NotImplementedError
+
+
+    @staticmethod
+    def _resize_detections(detections, original_image_size):
+        '''
+        original_shape - (w, h, ...)
+        '''
+        for detection in detections:
+            detection.xmin *= original_image_size[0]
+            detection.xmax *= original_image_size[0]
+            detection.ymin *= original_image_size[1]
+            detection.ymax *= original_image_size[1]
+        return detections
+
+    @staticmethod
+    def _resize_detections_with_aspect(detections, original_image_size, resized_image_size, model_input_size):
+        '''
+        original_shape - (w, h)
+        resized_shape - (w, h)
+        model_shape - (w, h)
+        '''
+        print(model_input_size, resized_image_size)
+        scale_x = model_input_size[0] / resized_image_size[0] * original_image_size[0]
+        scale_y = model_input_size[1] / resized_image_size[1] * original_image_size[1]
+        for detection in detections:
+            detection.xmin *= scale_x
+            detection.xmax *= scale_x
+            detection.ymin *= scale_y
+            detection.ymax *= scale_y
+        return detections
+
+    @staticmethod
+    def _resize_detections_letterbox(detections, original_shape, resized_shape):
+        scales = [x / y for x, y in zip(resized_shape, original_shape)]
+        scale = min(scales)
+        scales = (scale / scales[0], scale / scales[1])
+        offset = [0.5 * (1 - x) for x in scales]
+        for detection in detections:
+            detection.xmin = ((detection.xmin - offset[0]) / scales[0]) * original_shape[0]
+            detection.xmax = ((detection.xmax - offset[0]) / scales[0]) * original_shape[0]
+            detection.ymin = ((detection.ymin - offset[1]) / scales[1]) * original_shape[1]
+            detection.ymax = ((detection.ymax - offset[1]) / scales[1]) * original_shape[1]
+        return detections

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -58,17 +58,17 @@ class DetectionModel(ImageModel):
         self.iou_threshold = iou_threshold
 
     def _resize_detections(self, detections, meta):
-        '''Resizes detection bounding box according to initial image size
+        '''Resizes detection bounding boxes according to initial image size
 
         Implements resize operations for different image resize types (see ``ImageModel`` class for details).
-        Applies clipping bounding box to image size.
+        Applies clipping bounding box to original image size.
 
         Args:
             detections(List[Detection]): list of detections with coordinates in normalized form
             meta: meta information with fields `resized_shape` and `original_shape`
 
         Returns:
-            List of detections for initial image
+            List of detections fit to initial image (resized and clipped)
 
         Raises:
             RuntimeError: If model uses custom resize or `resize_type` not set

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -1,5 +1,5 @@
 from .image_model import ImageModel
-from .utils import Detection, load_labels, clip_detections
+from .utils import load_labels, clip_detections
 
 
 class DetectionModel(ImageModel):
@@ -14,63 +14,56 @@ class DetectionModel(ImageModel):
         self.threshold = threshold
         self.iou_threshold = iou_threshold
 
-    def postprocess(self, outputs, meta):
-        detections = self._parse_outputs(outputs, meta)
+    def _resize_detections(self, detections, meta):
         resized_shape = meta['resized_shape']
         original_shape = meta['original_shape']
 
         if self.resize_type=='letterbox':
-            detections = self._resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
+            detections = resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
         elif self.resize_type == 'keep_aspect_ratio':
-            detections = self._resize_detections_with_aspect(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
+            detections = resize_detections_with_aspect(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
         elif self.resize_type == 'default':
-            detections = self._resize_detections(detections, original_shape[1::-1])
+            detections = resize_detections(detections, original_shape[1::-1])
         else:
             raise RuntimeError('Unknown resize type {}'.format(self.resize_type))
         return clip_detections(detections, original_shape)
 
-    def _parse_outputs(self, outputs, meta):
-        raise NotImplementedError
 
+def resize_detections(detections, original_image_size):
+    '''
+    original_shape - (w, h, ...)
+    '''
+    for detection in detections:
+        detection.xmin *= original_image_size[0]
+        detection.xmax *= original_image_size[0]
+        detection.ymin *= original_image_size[1]
+        detection.ymax *= original_image_size[1]
+    return detections
 
-    @staticmethod
-    def _resize_detections(detections, original_image_size):
-        '''
-        original_shape - (w, h, ...)
-        '''
-        for detection in detections:
-            detection.xmin *= original_image_size[0]
-            detection.xmax *= original_image_size[0]
-            detection.ymin *= original_image_size[1]
-            detection.ymax *= original_image_size[1]
-        return detections
+def resize_detections_with_aspect(detections, original_image_size, resized_image_size, model_input_size):
+    '''
+    original_shape - (w, h)
+    resized_shape - (w, h)
+    model_shape - (w, h)
+    '''
+    print(model_input_size, resized_image_size)
+    scale_x = model_input_size[0] / resized_image_size[0] * original_image_size[0]
+    scale_y = model_input_size[1] / resized_image_size[1] * original_image_size[1]
+    for detection in detections:
+        detection.xmin *= scale_x
+        detection.xmax *= scale_x
+        detection.ymin *= scale_y
+        detection.ymax *= scale_y
+    return detections
 
-    @staticmethod
-    def _resize_detections_with_aspect(detections, original_image_size, resized_image_size, model_input_size):
-        '''
-        original_shape - (w, h)
-        resized_shape - (w, h)
-        model_shape - (w, h)
-        '''
-        print(model_input_size, resized_image_size)
-        scale_x = model_input_size[0] / resized_image_size[0] * original_image_size[0]
-        scale_y = model_input_size[1] / resized_image_size[1] * original_image_size[1]
-        for detection in detections:
-            detection.xmin *= scale_x
-            detection.xmax *= scale_x
-            detection.ymin *= scale_y
-            detection.ymax *= scale_y
-        return detections
-
-    @staticmethod
-    def _resize_detections_letterbox(detections, original_shape, resized_shape):
-        scales = [x / y for x, y in zip(resized_shape, original_shape)]
-        scale = min(scales)
-        scales = (scale / scales[0], scale / scales[1])
-        offset = [0.5 * (1 - x) for x in scales]
-        for detection in detections:
-            detection.xmin = ((detection.xmin - offset[0]) / scales[0]) * original_shape[0]
-            detection.xmax = ((detection.xmax - offset[0]) / scales[0]) * original_shape[0]
-            detection.ymin = ((detection.ymin - offset[1]) / scales[1]) * original_shape[1]
-            detection.ymax = ((detection.ymax - offset[1]) / scales[1]) * original_shape[1]
-        return detections
+def resize_detections_letterbox(detections, original_shape, resized_shape):
+    scales = [x / y for x, y in zip(resized_shape, original_shape)]
+    scale = min(scales)
+    scales = (scale / scales[0], scale / scales[1])
+    offset = [0.5 * (1 - x) for x in scales]
+    for detection in detections:
+        detection.xmin = ((detection.xmin - offset[0]) / scales[0]) * original_shape[0]
+        detection.xmax = ((detection.xmax - offset[0]) / scales[0]) * original_shape[0]
+        detection.ymin = ((detection.ymin - offset[1]) / scales[1]) * original_shape[1]
+        detection.ymax = ((detection.ymax - offset[1]) / scales[1]) * original_shape[1]
+    return detections

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -21,6 +21,11 @@ class DetectionModel(ImageModel):
     def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=None, iou_threshold=None):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
+
+        if not self.image_blob_name:
+            raise RuntimeError("The DetectionModel wrappers supports only one image input, but {} found"
+                               .format(len(self.image_blob_names)))
+
         if isinstance(labels, (list, tuple)):
             self.labels = labels
         else:

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -29,10 +29,10 @@ class DetectionModel(ImageModel):
         iou_threshold(float): threshold for NMS detection filtering
     '''
 
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=None, iou_threshold=None):
         '''The Detection Model constructor
-        
+
         Calls the ``ImageModel`` construtor first.
 
         Args:
@@ -43,7 +43,7 @@ class DetectionModel(ImageModel):
         Raises:
             RuntimeError: If loaded model has more than one image inputs
         '''
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio)
 
         if not self.image_blob_name:
             raise RuntimeError("The DetectionModel wrappers supports only one image input, but {} found"
@@ -64,7 +64,7 @@ class DetectionModel(ImageModel):
         Applies clipping bounding box to image size.
 
         Args:
-            detections(List[Detection]): list of detections with coordinates in normalized form 
+            detections(List[Detection]): list of detections with coordinates in normalized form
             meta: meta information with fields `resized_shape` and `original_shape`
 
         Returns:

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -18,8 +18,31 @@ from .utils import load_labels, clip_detections
 
 
 class DetectionModel(ImageModel):
+    '''A abstract detection model class
+
+    This class supports the detection models. The Detection Model should have single image input.
+
+    Attributes:
+        labels(List[str]): list of labels for classes (could be None)
+        threshold(float): threshold for detection filtering, any detection with confidence less than this value
+            should be omitted in ``posptrocess`` method (0<=thresold<=1.0 for most models)
+        iou_threshold(float): threshold for NMS detection filtering
+    '''
+
     def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=None, iou_threshold=None):
+        '''The Detection Model constructor
+        
+        Calls the ``ImageModel`` construtor first.
+
+        Args:
+            labels(Iterable[str], str, Path): list of labels for detection classes or path to file with them
+            threshold(float): threshold for detections filtering by confidence
+            iou_threshold(float): threshold for NMS filtering
+
+        Raises:
+            RuntimeError: If loaded model has more than one image inputs
+        '''
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
 
         if not self.image_blob_name:
@@ -35,6 +58,21 @@ class DetectionModel(ImageModel):
         self.iou_threshold = iou_threshold
 
     def _resize_detections(self, detections, meta):
+        '''Resizes detection bounding box according to initial image size
+
+        Implements resize operations for different image resize types (see ``ImageModel`` class for details).
+        Applies clipping bounding box to image size.
+
+        Args:
+            detections(List[Detection]): list of detections with coordinates in normalized form 
+            meta: meta information with fields `resized_shape` and `original_shape`
+
+        Returns:
+            List of detections for initial image
+
+        Raises:
+            RuntimeError: If model uses custom resize or `resize_type` not set
+        '''
         resized_shape = meta['resized_shape']
         original_shape = meta['original_shape']
 

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -36,7 +36,7 @@ class DetectionModel(ImageModel):
         if self.resize_type=='letterbox':
             detections = resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
         elif self.resize_type == 'keep_aspect_ratio':
-            detections = resize_detections_with_aspect(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
+            detections = resize_detections_with_aspect_ratio(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
         elif self.resize_type == 'default':
             detections = resize_detections(detections, original_shape[1::-1])
         else:
@@ -45,9 +45,6 @@ class DetectionModel(ImageModel):
 
 
 def resize_detections(detections, original_image_size):
-    '''
-    original_shape - (w, h, ...)
-    '''
     for detection in detections:
         detection.xmin *= original_image_size[0]
         detection.xmax *= original_image_size[0]
@@ -55,13 +52,7 @@ def resize_detections(detections, original_image_size):
         detection.ymax *= original_image_size[1]
     return detections
 
-def resize_detections_with_aspect(detections, original_image_size, resized_image_size, model_input_size):
-    '''
-    original_shape - (w, h)
-    resized_shape - (w, h)
-    model_shape - (w, h)
-    '''
-    print(model_input_size, resized_image_size)
+def resize_detections_with_aspect_ratio(detections, original_image_size, resized_image_size, model_input_size):
     scale_x = model_input_size[0] / resized_image_size[0] * original_image_size[0]
     scale_y = model_input_size[1] / resized_image_size[1] * original_image_size[1]
     for detection in detections:
@@ -71,14 +62,14 @@ def resize_detections_with_aspect(detections, original_image_size, resized_image
         detection.ymax *= scale_y
     return detections
 
-def resize_detections_letterbox(detections, original_shape, resized_shape):
-    scales = [x / y for x, y in zip(resized_shape, original_shape)]
+def resize_detections_letterbox(detections, original_image_size, resized_image_size):
+    scales = [x / y for x, y in zip(resized_image_size, original_image_size)]
     scale = min(scales)
     scales = (scale / scales[0], scale / scales[1])
     offset = [0.5 * (1 - x) for x in scales]
     for detection in detections:
-        detection.xmin = ((detection.xmin - offset[0]) / scales[0]) * original_shape[0]
-        detection.xmax = ((detection.xmax - offset[0]) / scales[0]) * original_shape[0]
-        detection.ymin = ((detection.ymin - offset[1]) / scales[1]) * original_shape[1]
-        detection.ymax = ((detection.ymax - offset[1]) / scales[1]) * original_shape[1]
+        detection.xmin = ((detection.xmin - offset[0]) / scales[0]) * original_image_size[0]
+        detection.xmax = ((detection.xmax - offset[0]) / scales[0]) * original_image_size[0]
+        detection.ymin = ((detection.ymin - offset[1]) / scales[1]) * original_image_size[1]
+        detection.ymax = ((detection.ymax - offset[1]) / scales[1]) * original_image_size[1]
     return detections

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -29,7 +29,7 @@ class DetectionModel(ImageModel):
         iou_threshold(float): threshold for NMS detection filtering
     '''
 
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type=None,
                  labels=None, threshold=None, iou_threshold=None):
         '''The Detection Model constructor
 
@@ -43,7 +43,7 @@ class DetectionModel(ImageModel):
         Raises:
             RuntimeError: If loaded model has more than one image inputs
         '''
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio)
+        super().__init__(ie, model_path, resize_type=resize_type)
 
         if not self.image_blob_name:
             raise RuntimeError("The DetectionModel wrappers supports only one image input, but {} found"
@@ -76,11 +76,11 @@ class DetectionModel(ImageModel):
         resized_shape = meta['resized_shape']
         original_shape = meta['original_shape']
 
-        if self.resize_type=='letterbox':
+        if self.resize_type=='fit_to_window_letterbox':
             detections = resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
-        elif self.resize_type == 'keep_aspect_ratio':
+        elif self.resize_type == 'fit_to_window':
             detections = resize_detections_with_aspect_ratio(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))
-        elif self.resize_type == 'default':
+        elif self.resize_type == 'standard':
             detections = resize_detections(detections, original_shape[1::-1])
         else:
             raise RuntimeError('Unknown resize type {}'.format(self.resize_type))

--- a/demos/common/python/models/detection_model.py
+++ b/demos/common/python/models/detection_model.py
@@ -3,7 +3,7 @@ from .utils import Detection, load_labels, clip_detections
 
 
 class DetectionModel(ImageModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=None, iou_threshold=None):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
         if isinstance(labels, (list, tuple)):

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -20,10 +20,14 @@ from .utils import Detection
 
 
 class DETR(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The DETR model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 2)
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
 

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -15,9 +15,8 @@
 """
 import numpy as np
 
-from .model import Model
 from .detection_model import DetectionModel
-from .utils import Detection, resize_image, load_labels, clip_detections
+from .utils import Detection
 
 
 class DETR(DetectionModel):
@@ -25,13 +24,10 @@ class DETR(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-
-        
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
-
         assert len(self.net.outputs) == 2, "Expected 2 output blobs"
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
-        
+
     def _get_outputs(self):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.net.outputs.items()
 

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -46,7 +46,7 @@ class DETR(DetectionModel):
         detections = self._resize_detections(detections, meta)
         return detections
 
-    def _parse_outputs(self, outputs, meta):
+    def _parse_outputs(self, outputs):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]
 

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -20,20 +20,19 @@ from .utils import Detection
 
 
 class DETR(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+        if not resize_type:
+            resize_type = 'standard'
+        super().__init__(ie, model_path, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The DETR model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 2)
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
 
     def _get_outputs(self):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.net.outputs.items()
 
-        if bboxes_layer.shape[1] == scores_layer.shape[1]:
+        if bboxes_layer.shape[1] != scores_layer.shape[1]:
             raise RuntimeError("Expected the same second dimension for boxes and scores, but got {} and {}"
                                .format(bboxes_layer.shape, scores_layer.shape))
 

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -20,10 +20,9 @@ from .utils import Detection
 
 
 class DETR(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:
             self.logger.warn('The DETR model wrapper has no default resizer with keeping aspect ratio.'

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -41,6 +41,11 @@ class DETR(DetectionModel):
             raise RuntimeError("Expected shape [:,:,4] for bboxes output, but got {} and {}"
                                .format(*[output.shape for output in self.net.outputs]))
 
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs)
+        detections = self._resize_detections(detections, meta)
+        return detections
+
     def _parse_outputs(self, outputs, meta):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -24,14 +24,15 @@ class DETR(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        assert len(self.net.outputs) == 2, "Expected 2 output blobs"
+        self._check_io_number(1, 2)
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
 
     def _get_outputs(self):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.net.outputs.items()
 
-        assert bboxes_layer.shape[1] == scores_layer.shape[1], "Expected the same dimension for boxes and scores"
+        if bboxes_layer.shape[1] == scores_layer.shape[1]:
+            raise RuntimeError("Expected the same second dimension for boxes and scores, but got {} and {}"
+                               .format(bboxes_layer.shape, scores_layer.shape))
 
         if bboxes_layer.shape[2] == 4:
             return bboxes_blob_name, scores_blob_name

--- a/demos/common/python/models/detr.py
+++ b/demos/common/python/models/detr.py
@@ -16,30 +16,23 @@
 import numpy as np
 
 from .model import Model
+from .detection_model import DetectionModel
 from .utils import Detection, resize_image, load_labels, clip_detections
 
 
-class DETR(Model):
-    def __init__(self, ie, model_path, labels=None, threshold=0.5):
-        super().__init__(ie, model_path)
+class DETR(DetectionModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+                 labels=None, threshold=0.5, iou_threshold=0.5):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
+        
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        self.image_blob_name = next(iter(self.net.input_info))
 
         assert len(self.net.outputs) == 2, "Expected 2 output blobs"
-        self.bboxes_blob_name, self.scores_blob_name = self._parse_outputs()
-
-        if isinstance(labels, (list, tuple)):
-            self.labels = labels
-        else:
-            self.labels = load_labels(labels) if labels else None
-
-        self.threshold = threshold
-
-        self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-        assert self.c == 3, "Expected 3-channel input"
-
-    def _parse_outputs(self):
+        self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
+        
+    def _get_outputs(self):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.net.outputs.items()
 
         assert bboxes_layer.shape[1] == scores_layer.shape[1], "Expected the same dimension for boxes and scores"
@@ -52,29 +45,11 @@ class DETR(Model):
             raise RuntimeError("Expected shape [:,:,4] for bboxes output, but got {} and {}"
                                .format(*[output.shape for output in self.net.outputs]))
 
-    def preprocess(self, inputs):
-        image = inputs
-
-        resized_image = resize_image(image, (self.w, self.h))
-        meta = {'original_shape': image.shape,
-                'resized_shape': resized_image.shape}
-        resized_image = self.input_transform(resized_image)
-        resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        dict_inputs = {self.image_blob_name: resized_image}
-        return dict_inputs, meta
-
-    def postprocess(self, outputs, meta):
+    def _parse_outputs(self, outputs, meta):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]
 
         x_mins, y_mins, x_maxs, y_maxs = self.box_cxcywh_to_xyxy(boxes)
-
-        x_mins = x_mins * meta['original_shape'][1]
-        y_mins = y_mins * meta['original_shape'][0]
-        x_maxs = x_maxs * meta['original_shape'][1]
-        y_maxs = y_maxs * meta['original_shape'][0]
 
         scores = self.softmax(scores)
         labels = np.argmax(scores[:, :-1], axis=-1)
@@ -84,7 +59,7 @@ class DETR(Model):
 
         detections = [Detection(*det) for det in zip(x_mins[keep], y_mins[keep], x_maxs[keep], y_maxs[keep],
                                                      det_scores[keep], labels[keep])]
-        return clip_detections(detections, meta['original_shape'])
+        return detections
 
     @staticmethod
     def box_cxcywh_to_xyxy(box):

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -26,7 +26,6 @@ class FaceBoxes(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.3):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-
         if not self.labels:
             self.labels = ['Face']
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
@@ -46,8 +45,10 @@ class FaceBoxes(DetectionModel):
             else:
                 raise RuntimeError("Expected shapes [:,:,4] and [:,:2] for outputs, but got {} and {}"
                                    .format(*[output.shape for output in self.net.outputs]))
-        assert self.net.outputs[bboxes_blob_name].shape[1] == self.net.outputs[scores_blob_name].shape[1], \
-            "Expected the same dimension for boxes and scores"
+        if self.net.outputs[bboxes_blob_name].shape[1] != self.net.outputs[scores_blob_name].shape[1]:
+            raise RuntimeError("Expected the same second dimension for boxes and scores, but got {} and {}"
+                               .format(self.net.outputs[bboxes_blob_name].shape,
+                                       self.net.outputs[scores_blob_name].shape))
         return bboxes_blob_name, scores_blob_name
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -50,6 +50,11 @@ class FaceBoxes(DetectionModel):
             "Expected the same dimension for boxes and scores"
         return bboxes_blob_name, scores_blob_name
 
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs, meta)
+        detections = self._resize_detections(detections, meta)
+        return detections
+
     def _parse_outputs(self, outputs, meta):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -22,9 +22,9 @@ from .utils import Detection, nms
 
 
 class FaceBoxes(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.3):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
         if not self.labels:

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -17,34 +17,25 @@ import itertools
 import math
 import numpy as np
 
-from .model import Model
-from .utils import Detection, resize_image, nms, clip_detections
+from .detection_model import DetectionModel
+from .utils import Detection, nms
 
 
-class FaceBoxes(Model):
-    def __init__(self, ie, model_path, threshold=0.5):
-        super().__init__(ie, model_path)
+class FaceBoxes(DetectionModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+                 labels=None, threshold=0.5, iou_threshold=0.3):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+                         labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        self.image_blob_name = next(iter(self.net.input_info))
-
-        self._output_layer_names = sorted(self.net.outputs)
-        assert len(self.net.outputs) == 2, "Expected 2 output blobs"
-        self.bboxes_blob_name, self.scores_blob_name = self._parse_outputs()
-
-        self.labels = ['Face']
-
-        self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-        assert self.c == 3, "Expected 3-channel input"
-
+        if not self.labels:
+            self.labels = ['Face']
+        self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
         self.min_sizes = [[32, 64, 128], [256], [512]]
         self.steps = [32, 64, 128]
         self.variance = [0.1, 0.2]
-        self.confidence_threshold = threshold
-        self.nms_threshold = 0.3
         self.keep_top_k = 750
 
-    def _parse_outputs(self):
+    def _get_outputs(self):
         bboxes_blob_name = None
         scores_blob_name = None
         for name, layer in self.net.outputs.items():
@@ -59,20 +50,7 @@ class FaceBoxes(Model):
             "Expected the same dimension for boxes and scores"
         return bboxes_blob_name, scores_blob_name
 
-    def preprocess(self, inputs):
-        image = inputs
-
-        resized_image = resize_image(image, (self.w, self.h))
-        meta = {'original_shape': image.shape,
-                'resized_shape': resized_image.shape}
-        resized_image = self.input_transform(resized_image)
-        resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        dict_inputs = {self.image_blob_name: resized_image}
-        return dict_inputs, meta
-
-    def postprocess(self, outputs, meta):
+    def _parse_outputs(self, outputs, meta):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]
 
@@ -89,7 +67,7 @@ class FaceBoxes(Model):
 
         score = np.transpose(scores)[1]
 
-        mask = score > self.confidence_threshold
+        mask = score > self.threshold
         filtered_boxes, filtered_score = boxes[mask, :], score[mask]
         if filtered_score.size != 0:
             x_mins = (filtered_boxes[:, 0] - 0.5 * filtered_boxes[:, 2])
@@ -97,7 +75,7 @@ class FaceBoxes(Model):
             x_maxs = (filtered_boxes[:, 0] + 0.5 * filtered_boxes[:, 2])
             y_maxs = (filtered_boxes[:, 1] + 0.5 * filtered_boxes[:, 3])
 
-            keep = nms(x_mins, y_mins, x_maxs, y_maxs, filtered_score, self.nms_threshold,
+            keep = nms(x_mins, y_mins, x_maxs, y_maxs, filtered_score, self.iou_threshold,
                        keep_top_k=self.keep_top_k)
 
             filtered_score = filtered_score[keep]
@@ -114,9 +92,7 @@ class FaceBoxes(Model):
                 y_maxs = y_maxs[:self.keep_top_k]
 
             detections = [Detection(*det, 0) for det in zip(x_mins, y_mins, x_maxs, y_maxs, filtered_score)]
-
-        detections = self.resize_boxes(detections, meta['original_shape'][:2])
-        return clip_detections(detections, meta['original_shape'])
+        return detections
 
     @staticmethod
     def calculate_anchors(list_x, list_y, min_size, image_size, step):
@@ -157,13 +133,3 @@ class FaceBoxes(Model):
         anchors = np.clip(anchors, 0, 1)
 
         return anchors
-
-    @staticmethod
-    def resize_boxes(detections, image_size):
-        h, w = image_size
-        for detection in detections:
-            detection.xmin *= w
-            detection.xmax *= w
-            detection.ymin *= h
-            detection.ymax *= h
-        return detections

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -22,10 +22,14 @@ from .utils import Detection, nms
 
 
 class FaceBoxes(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.3):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The FaceBoxes model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         if not self.labels:
             self.labels = ['Face']
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -22,10 +22,9 @@ from .utils import Detection, nms
 
 
 class FaceBoxes(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.3):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:
             self.logger.warn('The FaceBoxes model wrapper has no default resizer with keeping aspect ratio.'

--- a/demos/common/python/models/faceboxes.py
+++ b/demos/common/python/models/faceboxes.py
@@ -22,13 +22,12 @@ from .utils import Detection, nms
 
 
 class FaceBoxes(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.3):
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+        if not resize_type:
+            resize_type = 'standard'
+        super().__init__(ie, model_path, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The FaceBoxes model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         if not self.labels:
             self.labels = ['Face']
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -39,7 +39,7 @@ class ImageModel(Model):
         for blob_name, blob in self.net.input_info.items():
             if len(blob.input_data.shape) == 4:
                 image_blob_names.append(blob_name)
-            if len(blob.input_data.shape) == 2:
+            elif len(blob.input_data.shape) == 2:
                 image_info_blob_names.append(blob_name)
             else:
                 raise RuntimeError('Failed to identify the input for ImageModel: only 2D and 4D input layer supported')

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -29,7 +29,7 @@ class ImageModel(Model):
         self.image_blob_name = self._get_image_input()
         if self.image_blob_name:
             self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-        self.image_layout = 'CHW'
+        self.image_layout = 'NCHW'
         self.resize_type = resize_type
         self.resize = self.RESIZE_TYPES[self.resize_type]
 
@@ -59,9 +59,9 @@ class ImageModel(Model):
         return dict_inputs, meta
 
     def _change_layout(self, image):
-        if self.image_layout == 'CHW':
+        if self.image_layout == 'NCHW':
             image = image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-            image = image.reshape((self.n, self.c, self.h, self.w))
+            image = image.reshape((1, self.c, self.h, self.w))
         else:
-            image = image.reshape((self.n, self.h, self.w, self.c))
+            image = image.reshape((1, self.h, self.w, self.c))
         return image

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -14,14 +14,8 @@
  limitations under the License.
 """
 from .model import Model
-from .utils import resize_image, resize_image_with_aspect, resize_image_letterbox, pad_image
+from .utils import RESIZE_TYPES, pad_image
 
-
-RESIZE_TYPES = {
-    'standart': resize_image,
-    'fit_to_window': resize_image_with_aspect,
-    'fit_to_window_letterbox': resize_image_letterbox,
-}
 
 class ImageModel(Model):
     '''An abstract wrapper for image-bases model
@@ -37,15 +31,13 @@ class ImageModel(Model):
         image_blob_name(str): name of image input (None, if they are many)
     '''
 
-    def __init__(self, ie, model_path, resize_type=None, keep_aspect_ratio=False):
+    def __init__(self, ie, model_path, resize_type=None):
         '''Image model constructor
 
         Calls the `Model` constructor first
 
         Args:
             resize_type(str): sets the type for image resizing (see ``RESIZE_TYPE`` for info)
-            keep_aspect_ratio(bool): sets the default resizer type with keeping aspect ratio.
-                Should be defined in concrete model.
         '''
         super().__init__(ie, model_path)
         self.image_blob_names, self.image_info_blob_names = self._get_inputs()
@@ -53,13 +45,11 @@ class ImageModel(Model):
         if self.image_blob_name:
             self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
         self.image_layout = 'NCHW'
-        if not resize_type and keep_aspect_ratio:
-            self.logger.warn('The model wrapper has no default resizer with keeping aspect ratio.')
         if not resize_type:
-            self.logger.warn('The resizer isn\'t set. The "standart" will be used')
-            resize_type = 'standart'
+            self.logger.warn('The resizer isn\'t set. The "standard" will be used')
+            resize_type = 'standard'
         self.resize_type = resize_type
-        self.resize = self.RESIZE_TYPES[self.resize_type]
+        self.resize = RESIZE_TYPES[self.resize_type]
 
     def _get_inputs(self):
         image_blob_names, image_info_blob_names = [], []

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -1,3 +1,18 @@
+"""
+ Copyright (c) 2021 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
 from .model import Model
 from .utils import resize_image, resize_image_with_aspect, resize_image_letterbox, pad_image
 

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -48,12 +48,6 @@ class ImageModel(Model):
     def preprocess(self, inputs):
         image = inputs
         meta = {'original_shape': image.shape}
-
-
-        # for image in inputs:
-        #     resized_image, meta = self._preprocess_single_image(image)
-
-
         resized_image = self.resize(image, (self.w, self.h))
         meta.update({'resized_shape': resized_image.shape})
         if self.resize_type == 'keep_aspect_ratio':
@@ -63,15 +57,6 @@ class ImageModel(Model):
         resized_image = self._change_layout(resized_image)
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta
-
-    def _preprocess_single_image(self, image):
-        meta = {'original_shape': image.shape}
-        resized_image = self.resize(image, (self.w, self.h))
-        resized_image = self.input_transform(resized_image)
-        resized_image = self._change_layout(resized_image)
-        meta.update({'resized_shape': resized_image.shape})
-        dict_inputs = {self.image_blob_name: image}
-        return resized_image, meta
 
     def _change_layout(self, image):
         if self.image_layout == 'CHW':

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -1,5 +1,5 @@
 from .model import Model
-from .utils import resize_image,resize_image_with_aspect, resize_image_letterbox, pad_image
+from .utils import resize_image, resize_image_with_aspect, resize_image_letterbox, pad_image
 
 
 class ImageModel(Model):
@@ -7,7 +7,7 @@ class ImageModel(Model):
         'default': resize_image,
         'keep_aspect_ratio': resize_image_with_aspect,
         'letterbox': resize_image_letterbox,
-        }
+    }
 
     def __init__(self, ie, model_path, input_transform=None, resize_type='default'):
         super().__init__(ie, model_path, input_transform=input_transform)
@@ -44,7 +44,7 @@ class ImageModel(Model):
         if self.resize_type == 'keep_aspect_ratio':
             resized_image = pad_image(resized_image, (self.w, self.h))
         if self.input_transform:
-            resized_image = self.input_transform(resized_image)       
+            resized_image = self.input_transform(resized_image)
         resized_image = self._change_layout(resized_image)
         dict_inputs = {self.image_blob_name: resized_image}
         return dict_inputs, meta
@@ -52,7 +52,7 @@ class ImageModel(Model):
     def _preprocess_single_image(self, image):
         meta = {'original_shape': image.shape}
         resized_image = self.resize(image, (self.w, self.h))
-        resized_image = self.input_transform(resized_image)       
+        resized_image = self.input_transform(resized_image)
         resized_image = self._change_layout(resized_image)
         meta.update({'resized_shape': resized_image.shape})
         dict_inputs = {self.image_blob_name: image}

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -17,6 +17,12 @@ from .model import Model
 from .utils import resize_image, resize_image_with_aspect, resize_image_letterbox, pad_image
 
 
+RESIZE_TYPES = {
+    'standart': resize_image,
+    'fit_to_window': resize_image_with_aspect,
+    'fit_to_window_letterbox': resize_image_letterbox,
+}
+
 class ImageModel(Model):
     '''An abstract wrapper for image-bases model
 
@@ -31,13 +37,7 @@ class ImageModel(Model):
         image_blob_name(str): name of image input (None, if they are many)
     '''
 
-    RESIZE_TYPES = {
-        'default': resize_image,
-        'keep_aspect_ratio': resize_image_with_aspect,
-        'letterbox': resize_image_letterbox,
-    }
-
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default'):
+    def __init__(self, ie, model_path, input_transform=None, resize_type=None, keep_aspect_ratio=False):
         '''Image model constructor
 
         Calls the `Model` constructor first
@@ -93,7 +93,7 @@ class ImageModel(Model):
         meta = {'original_shape': image.shape}
         resized_image = self.resize(image, (self.w, self.h))
         meta.update({'resized_shape': resized_image.shape})
-        if self.resize_type == 'keep_aspect_ratio':
+        if self.resize_type == 'fit_to_window':
             resized_image = pad_image(resized_image, (self.w, self.h))
         if self.input_transform:
             resized_image = self.input_transform(resized_image)

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -18,10 +18,10 @@ from .utils import RESIZE_TYPES, pad_image
 
 
 class ImageModel(Model):
-    '''An abstract wrapper for image-bases model
+    '''An abstract wrapper for image-based model
 
     An image-based model is model which has one or more inputs with image - 4D tensors with NWHC or NCHW layout.
-    Also it may have support inputs - 2D tensor.
+    Also it may have support additional inputs - 2D tensor.
     Implements basic preprocessing for image: resizing and aligning to model input.
 
     Attributes:

--- a/demos/common/python/models/image_model.py
+++ b/demos/common/python/models/image_model.py
@@ -1,0 +1,67 @@
+from .model import Model
+from .utils import resize_image,resize_image_with_aspect, resize_image_letterbox, pad_image
+
+
+class ImageModel(Model):
+    RESIZE_TYPES = {
+        'default': resize_image,
+        'keep_aspect_ratio': resize_image_with_aspect,
+        'letterbox': resize_image_letterbox,
+        }
+
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default'):
+        super().__init__(ie, model_path, input_transform=input_transform)
+        self.image_blob_name = self._get_image_input()
+        if self.image_blob_name:
+            self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
+        self.image_layout = 'CHW'
+        self.resize_type = resize_type
+        self.resize = self.RESIZE_TYPES[self.resize_type]
+
+    def _get_image_input(self):
+        image_blob_name = None
+        for blob_name, blob in self.net.input_info.items():
+            if len(blob.input_data.shape) == 4:
+                if not image_blob_name:
+                    image_blob_name = blob_name
+                else:
+                    raise RuntimeError('Failed to identify the input for image: more than one 4D input layer found')
+        if image_blob_name is None:
+            raise RuntimeError('Failed to identify the input for the image: no 4D input layer found')
+        return image_blob_name
+
+    def preprocess(self, inputs):
+        image = inputs
+        meta = {'original_shape': image.shape}
+
+
+        # for image in inputs:
+        #     resized_image, meta = self._preprocess_single_image(image)
+
+
+        resized_image = self.resize(image, (self.w, self.h))
+        meta.update({'resized_shape': resized_image.shape})
+        if self.resize_type == 'keep_aspect_ratio':
+            resized_image = pad_image(resized_image, (self.w, self.h))
+        if self.input_transform:
+            resized_image = self.input_transform(resized_image)       
+        resized_image = self._change_layout(resized_image)
+        dict_inputs = {self.image_blob_name: resized_image}
+        return dict_inputs, meta
+
+    def _preprocess_single_image(self, image):
+        meta = {'original_shape': image.shape}
+        resized_image = self.resize(image, (self.w, self.h))
+        resized_image = self.input_transform(resized_image)       
+        resized_image = self._change_layout(resized_image)
+        meta.update({'resized_shape': resized_image.shape})
+        dict_inputs = {self.image_blob_name: image}
+        return resized_image, meta
+
+    def _change_layout(self, image):
+        if self.image_layout == 'CHW':
+            image = image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
+            image = image.reshape((self.n, self.c, self.h, self.w))
+        else:
+            image = image.reshape((self.n, self.h, self.w, self.c))
+        return image

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -65,3 +65,38 @@ class Model:
             Postrocessed data in format accoding to conrete model
         '''
         raise NotImplementedError
+
+    def _check_io_number(self, number_of_inputs, number_of_outputs):
+        '''Checking actual number of input/output blobs with supported by model wrapper
+        
+
+        Args:
+            number_of_inputs(int, Tuple(int)): number of input blobs, supported by wrapper. Use -1 to omit check
+            number_of_outputs(int, Tuple(int)): number of output blobs, supported by wrapper. Use -1 to omit check
+        
+        Raises:
+            RuntimeError: if loaded model has unsupported number of input or output blob
+        '''
+        if not isinstance(number_of_inputs, tuple):
+            if len(self.inputs) != number_of_inputs and number_of_inputs != -1:
+                raise RuntimeError("Expected {} input blob{}, but {} found: {}".format(
+                    number_of_inputs, 's' if number_of_inputs !=1 else '', len(self.inputs), ', '.join(self.inputs)
+                ))
+        else:
+            if not len(self.inputs) in number_of_inputs:
+                raise RuntimeError("Expected {} or {} input blobs, but {} found: {}".format(
+                    ', '.join(str(n) for n in number_of_inputs[:-1]), int(number_of_inputs[-1]), len(self.inputs), 
+                    ', '.join(self.inputs)
+                ))
+
+        if not isinstance(number_of_outputs, tuple):
+            if len(self.outputs) != number_of_outputs and number_of_outputs != -1:
+                raise RuntimeError("Expected {} output blob{}, but {} found: {}".format(
+                    number_of_outputs, 's' if number_of_outputs !=1 else '', len(self.outputs), ', '.join(self.outputs)
+                ))
+        else:
+            if not len(self.outputs) in number_of_outputs:
+                raise RuntimeError("Expected {} or {} output blobs, but {} found: {}".format(
+                    ', '.join(str(n) for n in number_of_outputs[:-1]), int(number_of_outputs[-1]), len(self.outputs),
+                    ', '.join(self.outputs)
+                ))

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -19,7 +19,23 @@ from .utils import InputTransform
 
 
 class Model:
+    '''An abstract model wrapper
+    
+    An abstract model wrapper can only load model from the disk.
+    The ``preprocess`` and ``postprocess`` method should be implemented in concrete class
+
+    Attributes    
+        net(CNNNetwork): loaded network
+        logger(Logger): instance of the logger
+    '''
+
     def __init__(self, ie, model_path):
+        '''Abstract model constructor
+
+        Args:
+            ie(openvino.core): instance of Inference Engine core, needs for model loading
+            model_path(str, Path): path to model's *.xml file
+        '''
         self.logger = log.getLogger()
         self.net = ie.read_network(model_path)
         self.inputs = self.net.input_info
@@ -31,8 +47,21 @@ class Model:
         self.input_transform = InputTransform(reverse_input_channels, mean_values, scale_values)
 
     def preprocess(self, inputs):
-        meta = {}
-        return inputs, meta
+        '''Interface for preprocess method
+        Args:
+            inputs: raw input data, data types are defined by concrete model
+        Returns:
+            - The preprocessed data ready for inference
+            - The metadata, which could be used in postprocessing
+        '''
+        raise NotImplementedError
 
     def postprocess(self, outputs, meta):
-        return outputs
+        '''Interface for postrpocess metod
+        Args:
+            outputs: the model outputs  as dict with `name: tensor` data
+            meta: the metadata from the `preprocess` method results
+        Returns:
+            Postrocessed data in format accoding to conrete model
+        '''
+        raise NotImplementedError

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -20,7 +20,7 @@ from .utils import InputTransform
 
 class Model:
     '''An abstract model wrapper
-    
+
     An abstract model wrapper can only load model from the disk.
     The ``preprocess`` and ``postprocess`` method should be implemented in concrete class
 
@@ -40,7 +40,6 @@ class Model:
         self.net = ie.read_network(model_path)
         self.inputs = self.net.input_info
         self.outputs = self.net.outputs
-        self.set_batch_size(1)
         self.input_transform = InputTransform()
 
     def set_inputs_preprocessing(self, reverse_input_channels, mean_values, scale_values):
@@ -68,12 +67,11 @@ class Model:
 
     def _check_io_number(self, number_of_inputs, number_of_outputs):
         '''Checking actual number of input/output blobs with supported by model wrapper
-        
 
         Args:
             number_of_inputs(int, Tuple(int)): number of input blobs, supported by wrapper. Use -1 to omit check
             number_of_outputs(int, Tuple(int)): number of output blobs, supported by wrapper. Use -1 to omit check
-        
+
         Raises:
             RuntimeError: if loaded model has unsupported number of input or output blob
         '''
@@ -85,7 +83,7 @@ class Model:
         else:
             if not len(self.inputs) in number_of_inputs:
                 raise RuntimeError("Expected {} or {} input blobs, but {} found: {}".format(
-                    ', '.join(str(n) for n in number_of_inputs[:-1]), int(number_of_inputs[-1]), len(self.inputs), 
+                    ', '.join(str(n) for n in number_of_inputs[:-1]), int(number_of_inputs[-1]), len(self.inputs),
                     ', '.join(self.inputs)
                 ))
 

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -24,7 +24,7 @@ class Model:
     An abstract model wrapper can only load model from the disk.
     The ``preprocess`` and ``postprocess`` method should be implemented in concrete class
 
-    Attributes    
+    Attributes:
         net(CNNNetwork): loaded network
         logger(Logger): instance of the logger
     '''

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -34,7 +34,7 @@ class Model:
 
         Args:
             ie(openvino.core): instance of Inference Engine core, needs for model loading
-            model_path(str, Path): path to model's *.xml file
+            model_path(str, Path): path to model's *.xml or *.onnx file 
         '''
         self.logger = log.getLogger()
         self.net = ie.read_network(model_path)

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -36,10 +36,3 @@ class Model:
 
     def postprocess(self, outputs, meta):
         return outputs
-
-    def set_batch_size(self, batch):
-        shapes = {}
-        for input_layer in self.net.input_info:
-            new_shape = [batch] + self.net.input_info[input_layer].input_data.shape[1:]
-            shapes.update({input_layer: new_shape})
-        self.net.reshape(shapes)

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -22,6 +22,8 @@ class Model:
     def __init__(self, ie, model_path):
         self.logger = log.getLogger()
         self.net = ie.read_network(model_path)
+        self.inputs = self.net.input_info
+        self.outputs = self.net.outputs
         self.set_batch_size(1)
         self.input_transform = InputTransform()
 

--- a/demos/common/python/models/model.py
+++ b/demos/common/python/models/model.py
@@ -34,7 +34,7 @@ class Model:
 
         Args:
             ie(openvino.core): instance of Inference Engine core, needs for model loading
-            model_path(str, Path): path to model's *.xml or *.onnx file 
+            model_path(str, Path): path to model's *.xml or *.onnx file
         '''
         self.logger = log.getLogger()
         self.net = ie.read_network(model_path)

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -28,10 +28,7 @@ class RetinaFace(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        expected_outputs_count = (6, 9, 12)
-        assert len(self.net.outputs) in expected_outputs_count, "Expected {} or {} output blobs".format(
-            ', '.join(str(count) for count in expected_outputs_count[:-1]), int(expected_outputs_count[-1]))
+        self._check_io_number(1, (6, 9, 12))
 
         self.detect_masks = len(self.net.outputs) == 12
         self.process_landmarks = len(self.net.outputs) > 6
@@ -57,10 +54,7 @@ class RetinaFacePyTorch(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        expected_outputs_count = (2, 3)
-        assert len(self.net.outputs) in expected_outputs_count, "Expected {} or {} output blobs".format(
-            expected_outputs_count[0], expected_outputs_count[1])
+        self._check_io_number(1, (2, 3))
 
         self.process_landmarks = len(self.net.outputs) == 3
         self.postprocessor = RetinaFacePyTorchPostprocessor(process_landmarks=self.process_landmarks)

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -24,13 +24,12 @@ from .utils import DetectionWithLandmarks, Detection, nms, clip_detections
 
 
 class RetinaFace(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+        if not resize_type:
+            resize_type = 'standard'
+        super().__init__(ie, model_path, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The RetinaFace model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, (6, 9, 12))
 
         self.detect_masks = len(self.net.outputs) == 12
@@ -53,13 +52,12 @@ class RetinaFace(DetectionModel):
 
 
 class RetinaFacePyTorch(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path,  resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+        if not resize_type:
+            resize_type = 'standard'
+        super().__init__(ie, model_path,  resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The RetinaFacePyTorch model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, (2, 3))
 
         self.process_landmarks = len(self.net.outputs) == 3

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -24,10 +24,14 @@ from .utils import DetectionWithLandmarks, Detection, nms, clip_detections
 
 
 class RetinaFace(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The RetinaFace model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, (6, 9, 12))
 
         self.detect_masks = len(self.net.outputs) == 12
@@ -50,10 +54,14 @@ class RetinaFace(DetectionModel):
 
 
 class RetinaFacePyTorch(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The RetinaFacePyTorch model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, (2, 3))
 
         self.process_landmarks = len(self.net.outputs) == 3

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -24,7 +24,7 @@ from .utils import DetectionWithLandmarks, Detection, nms, clip_detections
 
 
 class RetinaFace(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
@@ -44,7 +44,6 @@ class RetinaFace(DetectionModel):
         self._output_layer_names = self.net.outputs
         self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
 
-    
     def postprocess(self, outputs, meta):
         scale_x = meta['resized_shape'][1] / meta['original_shape'][1]
         scale_y = meta['resized_shape'][0] / meta['original_shape'][0]
@@ -54,7 +53,7 @@ class RetinaFace(DetectionModel):
 
 
 class RetinaFacePyTorch(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -19,49 +19,64 @@ import re
 import numpy as np
 from itertools import product as product
 
-from .model import Model
-from .utils import DetectionWithLandmarks, Detection, resize_image, nms, clip_detections
+from .detection_model import DetectionModel
+from .utils import DetectionWithLandmarks, Detection, nms, clip_detections
 
 
-class RetinaFace(Model):
-    def __init__(self, ie, model_path, threshold=0.5, mask_threshold=0.5):
-        super().__init__(ie, model_path)
-
+class RetinaFace(DetectionModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+                 labels=None, threshold=0.5, iou_threshold=0.5):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         assert len(self.net.input_info) == 1, "Expected 1 input blob"
         expected_outputs_count = (6, 9, 12)
         assert len(self.net.outputs) in expected_outputs_count, "Expected {} or {} output blobs".format(
             ', '.join(str(count) for count in expected_outputs_count[:-1]), int(expected_outputs_count[-1]))
 
-        self.threshold = threshold
         self.detect_masks = len(self.net.outputs) == 12
         self.process_landmarks = len(self.net.outputs) > 6
-        self.mask_threshold = mask_threshold
+        self.mask_threshold = 0.5
         self.postprocessor = RetinaFacePostprocessor(detect_attributes=self.detect_masks,
                                                      process_landmarks=self.process_landmarks)
 
         self.labels = ['Face'] if not self.detect_masks else ['Mask', 'No mask']
 
-        self.image_blob_name = next(iter(self.net.input_info))
         self._output_layer_names = self.net.outputs
         self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
 
-    def preprocess(self, inputs):
-        image = inputs
-
-        resized_image = resize_image(image, (self.w, self.h))
-        meta = {'original_shape': image.shape,
-                'resized_shape': resized_image.shape}
-        resized_image = resized_image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        resized_image = resized_image.reshape((self.n, self.c, self.h, self.w))
-
-        dict_inputs = {self.image_blob_name: resized_image}
-        return dict_inputs, meta
-
+    
     def postprocess(self, outputs, meta):
         scale_x = meta['resized_shape'][1] / meta['original_shape'][1]
         scale_y = meta['resized_shape'][0] / meta['original_shape'][0]
 
         outputs = self.postprocessor.process_output(outputs, scale_x, scale_y, self.threshold, self.mask_threshold)
+        return clip_detections(outputs, meta['original_shape'])
+
+
+class RetinaFacePyTorch(DetectionModel):
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+                 labels=None, threshold=0.5, iou_threshold=0.5):
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        assert len(self.net.input_info) == 1, "Expected 1 input blob"
+        expected_outputs_count = (2, 3)
+        assert len(self.net.outputs) in expected_outputs_count, "Expected {} or {} output blobs".format(
+            expected_outputs_count[0], expected_outputs_count[1])
+
+        self.process_landmarks = len(self.net.outputs) == 3
+        self.postprocessor = RetinaFacePyTorchPostprocessor(process_landmarks=self.process_landmarks)
+
+        self.labels = ['Face']
+
+        self._output_layer_names = self.net.outputs
+        self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
+
+    def postprocess(self, outputs, meta):
+        scale_x = meta['resized_shape'][1] / meta['original_shape'][1]
+        scale_y = meta['resized_shape'][0] / meta['original_shape'][0]
+
+        outputs = self.postprocessor.process_output(outputs, scale_x, scale_y, self.threshold,
+                                                    meta['resized_shape'][:2])
         return clip_detections(outputs, meta['original_shape'])
 
 
@@ -303,46 +318,6 @@ class RetinaFacePostprocessor:
             pred[:, i, 1] = landmark_deltas[:, i, 1] * heights + ctr_y
 
         return pred
-
-
-class RetinaFacePyTorch(Model):
-    def __init__(self, ie, model_path, threshold=0.5):
-        super().__init__(ie, model_path)
-
-        assert len(self.net.input_info) == 1, "Expected 1 input blob"
-        expected_outputs_count = (2, 3)
-        assert len(self.net.outputs) in expected_outputs_count, "Expected {} or {} output blobs".format(
-            expected_outputs_count[0], expected_outputs_count[1])
-
-        self.threshold = threshold
-        self.process_landmarks = len(self.net.outputs) == 3
-        self.postprocessor = RetinaFacePyTorchPostprocessor(process_landmarks=self.process_landmarks)
-
-        self.labels = ['Face']
-
-        self.image_blob_name = next(iter(self.net.input_info))
-        self._output_layer_names = self.net.outputs
-        self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-
-    def preprocess(self, inputs):
-        image = inputs
-
-        resized_image = resize_image(image, (self.w, self.h))
-        meta = {'original_shape': image.shape,
-                'resized_shape': resized_image.shape}
-        resized_image = self.input_transform(resized_image)
-        resized_image = np.expand_dims(resized_image.transpose((2, 0, 1)), axis=0) # Change data layout from HWC to CHW
-
-        dict_inputs = {self.image_blob_name: resized_image}
-        return dict_inputs, meta
-
-    def postprocess(self, outputs, meta):
-        scale_x = meta['resized_shape'][1] / meta['original_shape'][1]
-        scale_y = meta['resized_shape'][0] / meta['original_shape'][0]
-
-        outputs = self.postprocessor.process_output(outputs, scale_x, scale_y, self.threshold,
-                                                    meta['resized_shape'][:2])
-        return clip_detections(outputs, meta['original_shape'])
 
 
 class RetinaFacePyTorchPostprocessor:

--- a/demos/common/python/models/retinaface.py
+++ b/demos/common/python/models/retinaface.py
@@ -24,10 +24,9 @@ from .utils import DetectionWithLandmarks, Detection, nms, clip_detections
 
 
 class RetinaFace(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:
             self.logger.warn('The RetinaFace model wrapper has no default resizer with keeping aspect ratio.'
@@ -54,10 +53,9 @@ class RetinaFace(DetectionModel):
 
 
 class RetinaFacePyTorch(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path,  resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:
             self.logger.warn('The RetinaFacePyTorch model wrapper has no default resizer with keeping aspect ratio.'

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -22,10 +22,9 @@ from .utils import load_labels
 
 
 class SegmentationModel(ImageModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart',
                  labels=None):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
-
         if isinstance(labels, (list, tuple)):
             self.labels = labels
         else:

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -51,7 +51,7 @@ class SegmentationModel(ImageModel):
         return blob_name
 
     def postprocess(self, outputs, meta):
-        predictions = outputs[self.out_blob_name].squeeze()
+        predictions = outputs[self.output_blob_name].squeeze()
         input_image_height = meta['original_shape'][0]
         input_image_width = meta['original_shape'][1]
 
@@ -69,7 +69,7 @@ class SalientObjectDetectionModel(SegmentationModel):
     def postprocess(self, outputs, meta):
         input_image_height = meta['original_shape'][0]
         input_image_width = meta['original_shape'][1]
-        result = outputs[self.out_blob_name].squeeze()
+        result = outputs[self.output_blob_name].squeeze()
         result = 1/(1 + np.exp(-result))
         result = cv2.resize(result, (input_image_width, input_image_height), 0, 0, interpolation=cv2.INTER_NEAREST)
         return result

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -22,7 +22,7 @@ from .utils import load_labels
 
 
 class SegmentationModel(ImageModel):
-    def __init__(self, ie, model_path, resize_type='standart',
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None):
         super().__init__(ie, model_path, resize_type=resize_type)
         self._check_io_number(1, 1)

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -22,9 +22,9 @@ from .utils import load_labels
 
 
 class SegmentationModel(ImageModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart',
+    def __init__(self, ie, model_path, resize_type='standart',
                  labels=None):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
+        super().__init__(ie, model_path, resize_type=resize_type)
         self._check_io_number(1, 1)
         if isinstance(labels, (list, tuple)):
             self.labels = labels

--- a/demos/common/python/models/segmentation.py
+++ b/demos/common/python/models/segmentation.py
@@ -25,6 +25,7 @@ class SegmentationModel(ImageModel):
     def __init__(self, ie, model_path, input_transform=None, resize_type='standart',
                  labels=None):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type)
+        self._check_io_number(1, 1)
         if isinstance(labels, (list, tuple)):
             self.labels = labels
         else:
@@ -33,9 +34,6 @@ class SegmentationModel(ImageModel):
         self.output_blob_name = self._get_outputs()
 
     def _get_outputs(self):
-        if len(self.net.outputs) != 1:
-            raise RuntimeError("The Segmentation model wrapper supports topologies only with 1 output")
-
         blob_name = next(iter(self.net.outputs))
         blob = self.net.outputs[blob_name]
 

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -20,9 +20,12 @@ from .utils import Detection
 
 
 class SSD(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type=None, keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
+        if not resize_type:
+            resize_type = 'fit_to_window' if keep_aspect_ratio else 'stantard'
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.image_info_blob_name = self.image_info_blob_names[0] if len(self.image_info_blob_names) == 1 else None
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -20,17 +20,19 @@ from .utils import Detection
 
 
 class SSD(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        print(resize_type)
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        print(self.resize_type)
-        
         if len(self.inputs) != 1:
             self.image_info_blob_name = self._get_image_info_input()
-
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)
+
+    def preprocess(self, inputs):
+        dict_inputs, meta =  super().preprocess(inputs)
+        if self.image_info_blob_name:
+            dict_inputs[self.image_info_blob_name] = [self.h, self.w, 1]
+        return dict_inputs, meta
 
     def _get_image_info_input(self):
         image_info_blob_name = None

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -20,11 +20,11 @@ from .utils import Detection
 
 
 class SSD(DetectionModel):
-    def __init__(self, ie, model_path, resize_type=None, keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.5):
         if not resize_type:
-            resize_type = 'fit_to_window' if keep_aspect_ratio else 'stantard'
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+            resize_type = 'standard'
+        super().__init__(ie, model_path, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.image_info_blob_name = self.image_info_blob_names[0] if len(self.image_info_blob_names) == 1 else None
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -52,21 +52,6 @@ class SSD(DetectionModel):
             raise RuntimeError('Failed to identify the input for the image info: no 2D input layer found')
         return  image_info_blob_name
 
-    def _get_inputs(self):
-        image_blob_name = None
-        image_info_blob_name = None
-        for blob_name, blob in self.net.input_info.items():
-            if len(blob.input_data.shape) == 4:
-                image_blob_name = blob_name
-            elif len(blob.input_data.shape) == 2:
-                image_info_blob_name = blob_name
-            else:
-                raise RuntimeError('Unsupported {}D input layer "{}". Only 2D and 4D input layers are supported'
-                                   .format(len(blob.shape), blob_name))
-        if image_blob_name is None:
-            raise RuntimeError('Failed to identify the input for the image.')
-        return image_blob_name, image_info_blob_name
-
     def _get_output_parser(self, net, image_blob_name, bboxes='bboxes', labels='labels', scores='scores'):
         try:
             parser = SingleOutputParser(net.outputs)

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -24,9 +24,7 @@ class SSD(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        self.image_info_blob_name = None
-        if len(self.inputs) != 1:
-            self.image_info_blob_name = self._get_image_info_input()
+        self.image_info_blob_name = self.image_info_blob_names[0] if len(self.image_info_blob_names) == 1 else None
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)
 
     def preprocess(self, inputs):
@@ -39,18 +37,6 @@ class SSD(DetectionModel):
         detections = self._parse_outputs(outputs, meta)
         detections = self._resize_detections(detections, meta)
         return detections
-
-    def _get_image_info_input(self):
-        image_info_blob_name = None
-        for blob_name, blob in self.net.input_info.items():
-            if len(blob.input_data.shape) == 2:
-                if not image_info_blob_name:
-                    image_info_blob_name = blob_name
-                else:
-                    raise RuntimeError('Failed to identify the input for image info: more than one 2D input layer found')
-        if image_info_blob_name is None:
-            raise RuntimeError('Failed to identify the input for the image info: no 2D input layer found')
-        return  image_info_blob_name
 
     def _get_output_parser(self, net, image_blob_name, bboxes='bboxes', labels='labels', scores='scores'):
         try:

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -20,12 +20,11 @@ from .utils import Detection
 
 
 class SSD(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type=None, keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type=None, keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         if not resize_type:
             resize_type = 'fit_to_window' if keep_aspect_ratio else 'stantard'
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.image_info_blob_name = self.image_info_blob_names[0] if len(self.image_info_blob_names) == 1 else None
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -24,6 +24,7 @@ class SSD(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        self.image_info_blob_name = None
         if len(self.inputs) != 1:
             self.image_info_blob_name = self._get_image_info_input()
         self.output_parser = self._get_output_parser(self.net, self.image_blob_name)
@@ -36,7 +37,7 @@ class SSD(DetectionModel):
 
     def postprocess(self, outputs, meta):
         detections = self._parse_outputs(outputs, meta)
-        detections = self._resize_detections(detections)
+        detections = self._resize_detections(detections, meta)
         return detections
 
     def _get_image_info_input(self):
@@ -88,7 +89,7 @@ class SSD(DetectionModel):
         except ValueError:
             pass
         raise RuntimeError('Unsupported model outputs')
-    
+
     def _parse_outputs(self, outputs, meta):
         detections = self.output_parser(outputs)
 

--- a/demos/common/python/models/ssd.py
+++ b/demos/common/python/models/ssd.py
@@ -34,6 +34,11 @@ class SSD(DetectionModel):
             dict_inputs[self.image_info_blob_name] = [self.h, self.w, 1]
         return dict_inputs, meta
 
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs, meta)
+        detections = self._resize_detections(detections)
+        return detections
+
     def _get_image_info_input(self):
         image_info_blob_name = None
         for blob_name, blob in self.net.input_info.items():

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -45,6 +45,11 @@ class UltraLightweightFaceDetection(DetectionModel):
             "Expected the same dimension for boxes and scores"
         return bboxes_blob_name, scores_blob_name
 
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs, meta)
+        detections = self._resize_detections(detections, meta)
+        return detections
+
     def _parse_outputs(self, outputs, meta):
         boxes = outputs[self.bboxes_blob_name][0]
         scores = outputs[self.scores_blob_name][0]

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -20,10 +20,9 @@ from .utils import Detection, nms
 
 
 class UltraLightweightFaceDetection(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
-                         keep_aspect_ratio=keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         if keep_aspect_ratio:
             self.logger.warn('The UltraLightweightFaceDetection model wrapper has no default resizer with keeping aspect ratio.'

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -20,10 +20,14 @@ from .utils import Detection, nms
 
 
 class UltraLightweightFaceDetection(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
+    def __init__(self, ie, model_path, input_transform=None, resize_type='standart', keep_aspect_ratio=False,
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+                         keep_aspect_ratio=keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
+        if keep_aspect_ratio:
+            self.logger.warn('The UltraLightweightFaceDetection model wrapper has no default resizer with keeping aspect ratio.'
+                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 2)
         self.labels = ['Face']
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -24,10 +24,8 @@ class UltraLightweightFaceDetection(DetectionModel):
                  labels=None, threshold=0.5, iou_threshold=0.5):
         super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-
+        self._check_io_number(1, 2)
         self.labels = ['Face']
-
-        assert len(self.net.outputs) == 2, "Expected 2 output blobs"
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()
 
     def _get_outputs(self):
@@ -41,8 +39,10 @@ class UltraLightweightFaceDetection(DetectionModel):
             else:
                 raise RuntimeError("Expected shapes [:,:,4] and [:,:2] for outputs, but got {} and {}"
                                    .format(*[output.shape for output in self.net.outputs]))
-        assert self.net.outputs[bboxes_blob_name].shape[1] == self.net.outputs[scores_blob_name].shape[1], \
-            "Expected the same dimension for boxes and scores"
+        if self.net.outputs[bboxes_blob_name].shape[1] != self.net.outputs[scores_blob_name].shape[1]:
+            raise RuntimeError("Expected the same second dimension for boxes and scores, but got {} and {}"
+                               .format(self.net.outputs[bboxes_blob_name].shape,
+                                       self.net.outputs[scores_blob_name].shape))
         return bboxes_blob_name, scores_blob_name
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -20,9 +20,9 @@ from .utils import Detection, nms
 
 
 class UltraLightweightFaceDetection(DetectionModel):
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='default',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
         self.labels = ['Face']

--- a/demos/common/python/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/models/ultra_lightweight_face_detection.py
@@ -20,13 +20,12 @@ from .utils import Detection, nms
 
 
 class UltraLightweightFaceDetection(DetectionModel):
-    def __init__(self, ie, model_path, resize_type='standart', keep_aspect_ratio=False,
+    def __init__(self, ie, model_path, resize_type='standard',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, resize_type=resize_type, keep_aspect_ratio=keep_aspect_ratio,
+        if not resize_type:
+            resize_type = 'standard'
+        super().__init__(ie, model_path, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
-        if keep_aspect_ratio:
-            self.logger.warn('The UltraLightweightFaceDetection model wrapper has no default resizer with keeping aspect ratio.'
-                             'The "{}" will be used.'.format(resize_type))
         self._check_io_number(1, 2)
         self.labels = ['Face']
         self.bboxes_blob_name, self.scores_blob_name = self._get_outputs()

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -113,6 +113,18 @@ def resize_image(image, size, keep_aspect_ratio=False):
     return resized_frame
 
 
+def resize_image_with_aspect(image, size):
+    return resize_image(image, size, keep_aspect_ratio=True)
+
+
+def pad_image(image, size):
+    h, w = image.shape[:2]
+    if h != size[1] or w != size[0]:
+        image = np.pad(image, ((0, size[1] - h), (0, size[0] - w), (0, 0)),
+                               mode='constant', constant_values=0)
+    return image
+
+
 def resize_image_letterbox(image, size):
     ih, iw = image.shape[0:2]
     w, h = size

--- a/demos/common/python/models/utils.py
+++ b/demos/common/python/models/utils.py
@@ -139,6 +139,13 @@ def resize_image_letterbox(image, size):
     return resized_image
 
 
+RESIZE_TYPES = {
+    'standard': resize_image,
+    'fit_to_window': resize_image_with_aspect,
+    'fit_to_window_letterbox': resize_image_letterbox,
+}
+
+
 def nms(x1, y1, x2, y2, scores, thresh, include_boundaries=False, keep_top_k=None):
     b = 1 if include_boundaries else 0
     areas = (x2 - x1 + b) * (y2 - y1 + b)

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -66,11 +66,11 @@ class YOLO(DetectionModel):
 
                 self.isYoloV3 = True  # Weak way to determine but the only one.
 
-    def __init__(self, ie, model_path, resize_type=None, keep_aspect_ratio=True,
+    def __init__(self, ie, model_path, resize_type='fit_to_window_letterbox',
                  labels=None, threshold=0.5, iou_threshold=0.5):
         if not resize_type:
-            resize_type = 'letterbox' if keep_aspect_ratio else 'standart'
-        super().__init__(ie, model_path, resize_type, keep_aspect_ratio,
+            resize_type = 'fit_to_window_letterbox'
+        super().__init__(ie, model_path, resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.is_tiny = self.net.name.lower().find('tiny') != -1  # Weak way to distinguish between YOLOv4 and YOLOv4-tiny
 
@@ -206,12 +206,12 @@ class YoloV4(YOLO):
                 masked_anchors += [anchors[idx * 2], anchors[idx * 2 + 1]]
             self.anchors = masked_anchors
 
-    def __init__(self, ie, model_path, resize_type=None, keep_aspect_ratio=True,
+    def __init__(self, ie, model_path, resize_type='fit_to_window_letterbox',
                  labels=None, threshold=0.5, iou_threshold=0.5,
                  anchors=None, masks=None):
         self.anchors = anchors
         self.masks = masks
-        super().__init__(ie, model_path, resize_type, keep_aspect_ratio,
+        super().__init__(ie, model_path, resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
     def _get_output_info(self):

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -65,9 +65,11 @@ class YOLO(DetectionModel):
 
                 self.isYoloV3 = True  # Weak way to determine but the only one.
 
-    def __init__(self, ie, model_path, input_transform=None, resize_type='letterbox',
+    def __init__(self, ie, model_path, input_transform=None, resize_type=None, keep_aspect_ratio=True,
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
+        if not resize_type:
+            resize_type = 'letterbox' if keep_aspect_ratio else 'standart'
+        super().__init__(ie, model_path, input_transform, resize_type, keep_aspect_ratio,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.is_tiny = self.net.name.lower().find('tiny') != -1  # Weak way to distinguish between YOLOv4 and YOLOv4-tiny
 

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -98,6 +98,11 @@ class YOLO(DetectionModel):
             output_info[layer_name] = (shape, yolo_params)
         return output_info
 
+    def postprocess(self, outputs, meta):
+        detections = self._parse_outputs(outputs, meta)
+        detections = self._resize_detections(detections, meta)
+        return detections
+
     @staticmethod
     def _parse_yolo_region(predictions, input_size, params, threshold):
         # ------------------------------------------ Extracting layer parameters ---------------------------------------

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -71,9 +71,7 @@ class YOLO(DetectionModel):
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.is_tiny = self.net.name.lower().find('tiny') != -1  # Weak way to distinguish between YOLOv4 and YOLOv4-tiny
 
-        if len(self.inputs) != 1:
-            raise RuntimeError(f"The YOLO model family expects only one input blob but {len(self.inputs)} found:\n"
-                               f"{','.join(*self.inputs)}")
+        self._check_io_number(1, -1)
 
         if self.net.input_info[self.image_blob_name].input_data.shape[1] == 3:
             self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -65,9 +65,9 @@ class YOLO(DetectionModel):
 
                 self.isYoloV3 = True  # Weak way to determine but the only one.
 
-    def __init__(self, ie, model_path, input_transform=None, resize_type='default', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='letterbox',
                  labels=None, threshold=0.5, iou_threshold=0.5):
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
         self.is_tiny = self.net.name.lower().find('tiny') != -1  # Weak way to distinguish between YOLOv4 and YOLOv4-tiny
 
@@ -200,12 +200,12 @@ class YoloV4(YOLO):
                 masked_anchors += [anchors[idx * 2], anchors[idx * 2 + 1]]
             self.anchors = masked_anchors
 
-    def __init__(self, ie, model_path, input_transform=None, resize_type='letterbox', 
+    def __init__(self, ie, model_path, input_transform=None, resize_type='letterbox',
                  labels=None, threshold=0.5, iou_threshold=0.5,
                  anchors=None, masks=None):
         self.anchors = anchors
         self.masks = masks
-        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type, 
+        super().__init__(ie, model_path, input_transform=input_transform, resize_type=resize_type,
                          labels=labels, threshold=threshold, iou_threshold=iou_threshold)
 
     def _get_output_info(self):

--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -77,10 +77,10 @@ class YOLO(DetectionModel):
 
         if self.net.input_info[self.image_blob_name].input_data.shape[1] == 3:
             self.n, self.c, self.h, self.w = self.net.input_info[self.image_blob_name].input_data.shape
-            self.image_layout = 'CHW'
+            self.image_layout = 'NCHW'
         else:
             self.n, self.h, self.w, self.c = self.net.input_info[self.image_blob_name].input_data.shape
-            self.image_layout = 'HWС'
+            self.image_layout = 'NHWС'
 
         self.yolo_layer_params = self._get_output_info()
 

--- a/demos/object_detection_demo/python/README.md
+++ b/demos/object_detection_demo/python/README.md
@@ -148,19 +148,14 @@ Running the application with the `-h` option yields the following usage message:
 ```
 usage: object_detection_demo.py [-h] -m MODEL -at
                                 {ssd,yolo,yolov4,yolox,faceboxes,centernet,ctpn,retinaface,ultra_lightweight_face_detection,retinaface-pytorch,detr}
-                                -i INPUT [-d DEVICE] [--labels LABELS]
-                                [-t PROB_THRESHOLD] [--keep_aspect_ratio]
-                                [--input_size INPUT_SIZE INPUT_SIZE]
-                                [-nireq NUM_INFER_REQUESTS]
-                                [-nstreams NUM_STREAMS]
-                                [-nthreads NUM_THREADS] [--loop] [-o OUTPUT]
-                                [-limit OUTPUT_LIMIT] [--no_show]
-                                [--output_resolution OUTPUT_RESOLUTION]
-                                [-u UTILIZATION_MONITORS]
-                                [--reverse_input_channels REVERSE_CHANNELS]
-                                [--mean_values MEAN_VALUES]
-                                [--scale_values SCALE_VALUES]
-                                [-r]
+                                -i INPUT [-d DEVICE] [--labels LABELS] [-t PROB_THRESHOLD]
+                                [--resize_type {standard,fit_to_window,fit_to_window_letterbox}]
+                                [--input_size INPUT_SIZE INPUT_SIZE] [--anchors ANCHORS [ANCHORS ...]]
+                                [--masks MASKS [MASKS ...]] [-nireq NUM_INFER_REQUESTS] [-nstreams NUM_STREAMS]
+                                [-nthreads NUM_THREADS] [--loop] [-o OUTPUT] [-limit OUTPUT_LIMIT] [--no_show]
+                                [--output_resolution OUTPUT_RESOLUTION] [-u UTILIZATION_MONITORS]
+                                [--reverse_input_channels] [--mean_values MEAN_VALUES MEAN_VALUES MEAN_VALUES]
+                                [--scale_values SCALE_VALUES SCALE_VALUES SCALE_VALUES] [-r]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -182,7 +177,8 @@ Common model options:
   -t PROB_THRESHOLD, --prob_threshold PROB_THRESHOLD
                         Optional. Probability threshold for detections
                         filtering.
-  --keep_aspect_ratio   Optional. Keeps aspect ratio on resize.
+  --resize_type {standard,fit_to_window,fit_to_window_letterbox}
+                        Optional. A resize type for model preprocess. By defauld used model predefined type.
   --input_size INPUT_SIZE INPUT_SIZE
                         Optional. The first image size used for CTPN model
                         reshaping. Default: 600 600. Note that submitted

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -62,8 +62,8 @@ def build_argparser():
     common_model_args.add_argument('--labels', help='Optional. Labels mapping file.', default=None, type=str)
     common_model_args.add_argument('-t', '--prob_threshold', default=0.5, type=float,
                                    help='Optional. Probability threshold for detections filtering.')
-    common_model_args.add_argument('--keep_aspect_ratio', action='store_true', default=False,
-                                   help='Optional. Keeps aspect ratio on resize.')
+    common_model_args.add_argument('--resize_type', default=None, choices=models.RESIZE_TYPES.keys(),
+                                   help='Optional. A resize type for model preprocess. By defauld used model predefined type.')
     common_model_args.add_argument('--input_size', default=(600, 600), type=int, nargs=2,
                                    help='Optional. The first image size used for CTPN model reshaping. '
                                         'Default: 600 600. Note that submitted images should have the same resolution, '
@@ -163,15 +163,16 @@ class ColorPalette:
 
 def get_model(ie, args):
     if args.architecture_type == 'ssd':
-        return models.SSD(ie, args.model, labels=args.labels, keep_aspect_ratio=args.keep_aspect_ratio)
+        return models.SSD(ie, args.model, labels=args.labels, resize_type=args.resize_type,
+                          threshold=args.prob_threshold)
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':
-        return models.YOLO(ie, args.model, labels=args.labels, keep_aspect_ratio=args.keep_aspect_ratio,
+        return models.YOLO(ie, args.model, labels=args.labels, resize_type=args.resize_type,
                            threshold=args.prob_threshold)
     elif args.architecture_type == 'yolov4':
         return models.YoloV4(ie, args.model, labels=args.labels,
-                             threshold=args.prob_threshold, keep_aspect_ratio=args.keep_aspect_ratio,
+                             threshold=args.prob_threshold, resize_type=args.resize_type,
                              anchors=args.anchors, masks=args.masks)
     elif args.architecture_type == 'yolox':
         return models.YOLOX(ie, args.model, labels=args.labels, threshold=args.prob_threshold)

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -168,11 +168,11 @@ def get_model(ie, args):
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':
-        return models.YOLO(ie, args.model, labels=args.labels,
-                           threshold=args.prob_threshold, keep_aspect_ratio=args.keep_aspect_ratio)
+        return models.YOLO(ie, args.model, labels=args.labels, resize_type = 'letterbox' if args.keep_aspect_ratio else 'default',
+                           threshold=args.prob_threshold)
     elif args.architecture_type == 'yolov4':
         return models.YoloV4(ie, args.model, labels=args.labels,
-                             threshold=args.prob_threshold, keep_aspect_ratio=args.keep_aspect_ratio,
+                             threshold=args.prob_threshold, resize_type = 'letterbox' if args.keep_aspect_ratio else 'default',
                              anchors=args.anchors, masks=args.masks)
     elif args.architecture_type == 'yolox':
         return models.YOLOX(ie, args.model, labels=args.labels, threshold=args.prob_threshold)

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -163,15 +163,15 @@ class ColorPalette:
 
 def get_model(ie, args):
     if args.architecture_type == 'ssd':
-        return models.SSD(ie, args.model, labels=args.labels, keep_aspect_ratio_resize=args.keep_aspect_ratio,
+        return models.SSD(*common_args, labels=args.labels, resize_type = 'keep_aspect_ratio' if args.keep_aspect_ratio else 'default',
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':
-        return models.YOLO(ie, args.model, labels=args.labels, resize_type = 'letterbox' if args.keep_aspect_ratio else 'default',
+        return models.YOLO(ie, args.model, labels=args.labels, keep_aspect_ratio=args.keep_aspect_ratio,
                            threshold=args.prob_threshold)
     elif args.architecture_type == 'yolov4':
         return models.YoloV4(ie, args.model, labels=args.labels,
-                             threshold=args.prob_threshold, resize_type = 'letterbox' if args.keep_aspect_ratio else 'default',
+                             threshold=args.prob_threshold, keep_aspect_ratio=args.keep_aspect_ratio,
                              anchors=args.anchors, masks=args.masks)
     elif args.architecture_type == 'yolox':
         return models.YOLOX(ie, args.model, labels=args.labels, threshold=args.prob_threshold)

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -163,7 +163,7 @@ class ColorPalette:
 
 def get_model(ie, args):
     if args.architecture_type == 'ssd':
-        return models.SSD(*common_args, labels=args.labels, resize_type = 'keep_aspect_ratio' if args.keep_aspect_ratio else 'default',
+        return models.SSD(ie, args.model, labels=args.labels, keep_aspect_ratio=args.keep_aspect_ratio)
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -164,7 +164,6 @@ class ColorPalette:
 def get_model(ie, args):
     if args.architecture_type == 'ssd':
         return models.SSD(ie, args.model, labels=args.labels, keep_aspect_ratio_resize=args.keep_aspect_ratio,
-                          threshold=args.prob_threshold)
     elif args.architecture_type == 'ctpn':
         return models.CTPN(ie, args.model, input_size=args.input_size, threshold=args.prob_threshold)
     elif args.architecture_type == 'yolo':


### PR DESCRIPTION
This PR demonstrates the possible refactoring of ModelAPI. The main goals of it is to make model wrappers more flexible and reusable.

TODO:
- [x] Add documentation
- [x] Remove the assertions

The class structure is represented below
- *Model*
   Constructor parameters: `(ie, model_path)`
   Abstract class, which just loads model from the disk and presents to methods to overload: `preprocess(inputs) -> preprocessed_inputs, meta` and `postprocess(outputs, meta) -> postprocessed_outputs`
 - *ImageModel*
    Constructor parameters: `(..., input_transform, resize_type)`
    Incapsulates most common operations for image inputs, like resizing etc.  Finds image input blob with `_get_image_input()` method and puts it to `image_blob_name` field (image input is 4D tensor, if no or more than one found raise an error). Configures the resize operation (see `RESIZE_TYPES`). Implements the `preprocess` method: resizes, transposes and apply mean-scale values.
- *DetectionModel(ImageModel)*
   Constructor parameters: `(..., labels, threshold, iou_threshold)`
  Incapsulates most common operations with detection output processing, like resizing to original image, clipping, etc. Partially implements the `postprocess` method, which can resize and clip the normalized detections. Introduces the abstract method `_parse_outputs(outputs, meta) -> List[Detections]` which should return list of detections normalised coordinates (should be implemented in concrete model class).
- Concrete model classes: *SSD(DetectionModel)*, *YOLO(DetectionModel)*, etc.
  Implements necessary specific postprocessing (sometimes preprocessing) routines. 
