### PR TITLE
Added yolo-v4-tiny-tf model to quantizable models

### DIFF
--- a/models/public/yolo-v4-tiny-tf/model.yml
+++ b/models/public/yolo-v4-tiny-tf/model.yml
@@ -76,4 +76,5 @@ model_optimizer_args:
   - --reverse_input_channels
   - --input_model=$conv_dir/yolo-v4-tiny.pb
 framework: tf
+quantizable: yes
 license: https://raw.githubusercontent.com/david8862/keras-YOLOv3-model-set/master/LICENSE


### PR DESCRIPTION
Model yolo-v4-tiny-tf quantized by POT from OpenVINO 2021.4 with default algorithm and demonstrate acceptable accuracy drop in quantized form. This PR marks model as quantizable.

Accuracy validation results on CPU w/VNNI instructions set

|model|metric|REF|FP16|FP16-INT8|
|---|---|---|---|---|
|yolo-v4-tiny-tf|map|0.403|0.40388|0.398336|
|yolo-v4-tiny-tf|AP@0.5|0.463|0.463847|0.456495|
|yolo-v4-tiny-tf|AP@0.5:0.05:95|0.226|0.226601|0.221222|
