### PR TITLE
Optimize yolo model postprocessing for python detection demo

### DIFF
--- a/demos/common/python/models/yolo.py
+++ b/demos/common/python/models/yolo.py
@@ -224,6 +224,18 @@ class YOLO(Model):
         return clip_detections(detections, meta['original_shape'])
 
 
+def permute_to_N_HWA_K(tensor, K):
+    """
+    Transpose/reshape a tensor from (N, (A x K), H, W) to (N, (HxWxA), K)
+    """
+    assert tensor.ndim == 4, tensor.shape
+    N, _, H, W = tensor.shape
+    tensor = tensor.reshape(N, -1, K, H, W)
+    tensor = tensor.transpose(0, 3, 4, 1, 2)
+    tensor = tensor.reshape(N, -1, K)
+    return tensor
+
+
 class YoloV4(YOLO):
     class Params:
         def __init__(self, classes, num, sides, anchors, mask):
@@ -262,46 +274,51 @@ class YoloV4(YOLO):
         return output_info
 
     @staticmethod
-    def _parse_yolo_region(predictions, input_size, params, threshold, multiple_labels=True):
+    def _parse_yolo_region(predictions, input_size, params, threshold):
         def sigmoid(x):
             return 1. / (1. + np.exp(-x))
-        # ------------------------------------------ Extracting layer parameters ---------------------------------------
+
         objects = []
         bbox_size = params.coords + 1 + params.classes
+        predictions = permute_to_N_HWA_K(predictions, bbox_size)
         # ------------------------------------------- Parsing YOLO Region output ---------------------------------------
-        for row, col, n in np.ndindex(params.sides[0], params.sides[1], params.num):
-            # Getting raw values for each detection bounding bFox
-            bbox = predictions[0, n * bbox_size:(n + 1) * bbox_size, row, col]
-            x, y = sigmoid(bbox[:2])
-            width, height = bbox[2:4]
-            object_probability = sigmoid(bbox[4])
+        for prediction in predictions:
+            # Getting probabilities from raw outputs
+            object_probabilities = sigmoid(prediction[:, 4].flatten())
+            class_probabilities = sigmoid(prediction[:, params.coords + 1:].flatten())
+            class_probabilities *= np.repeat(object_probabilities, params.classes)
 
-            class_probabilities = sigmoid(bbox[5:])
-            if object_probability < threshold:
-                continue
-            # Process raw value
-            x = (col + x) / params.sides[1]
-            y = (row + y) / params.sides[0]
-            # Value for exp is very big number in some cases so following construction is using here
-            try:
-                width = np.exp(width)
-                height = np.exp(height)
-            except OverflowError:
-                continue
-            width = width * params.anchors[2 * n] / input_size[0]
-            height = height * params.anchors[2 * n + 1] / input_size[1]
+            # filter out the proposals with low confidence score
+            keep_idxs = np.nonzero(class_probabilities > threshold)[0]
+            class_probabilities = class_probabilities[keep_idxs]
+            obj_indx = keep_idxs // params.classes
+            class_idx = keep_idxs % params.classes
 
-            if multiple_labels:
-                for class_id, class_probability in enumerate(class_probabilities):
-                    confidence = object_probability * class_probability
-                    if confidence > threshold:
-                        objects.append(Detection(x - width / 2, y - height / 2, x + width / 2, y + height / 2,
-                                                 confidence, class_id))
-            else:
-                class_id = np.argmax(class_probabilities)
-                confidence = class_probabilities[class_id] * object_probability
-                if confidence < threshold:
+            for ind, obj_ind in enumerate(obj_indx):
+                bbox = prediction[:, :params.coords][obj_ind]
+                x, y = sigmoid(bbox[:2])
+                width, height = bbox[2:]
+
+                row = obj_ind // (params.sides[0] * params.num)
+                col = (obj_ind - row * params.sides[0] * params.num) // params.num
+                n = (obj_ind - row * params.sides[0] * params.num) % params.num
+
+                # Process raw value to get absolute coordinates of boxes
+                x = (col + x) / params.sides[1]
+                y = (row + y) / params.sides[0]
+                # Value for exp is very big number in some cases so following construction is using here
+                try:
+                    width = np.exp(width)
+                    height = np.exp(height)
+                except OverflowError:
                     continue
+                width = width * params.anchors[2 * n] / input_size[0]
+                height = height * params.anchors[2 * n + 1] / input_size[1]
+
+                # Define class_label and cofidence
+                label = class_idx[ind]
+                confidence = class_probabilities[ind]
                 objects.append(Detection(x - width / 2, y - height / 2, x + width / 2, y + height / 2,
-                                         confidence.item(), class_id.item()))
+                                         confidence.item(), label.item()))
+
         return objects


### PR DESCRIPTION
Optimize yolo postprocessing for detection demo, by using flatten operation and apply sigmoid function to all boxes at the same time.
**Speed up yoloV4**:
1. For YoloV4: `2.4 -> 3.7 fps` It's x1.55.
2. For YoloV4-tiny: `25 -> 50+ fps` It's x2.

The calculations were carried out on the CPU `Intel® Core™ i7-8700 CPU` and on video with resolution `1280 × 720`. `nstreams = 4, nrequests = 5, nthreads = auto` 

**Speed up yolo family**:
1. For `yolo-v3-tf`: `7.5 -> 8.4 fps` , **x1.12**
2. For `yolo-v3-tiny-tf`: `32 -> 62.8 fps`, **x1.96**
3. For `yolo-v2-tf`: `9 -> 9.1 fps`, x1
4. For `yolo-v2-tiny-tf`: `60 -> 70 fps`, **x1.16**
5. For `yolo-v2-tiny-ava-0001`: `51.6 -> 56.5 fps`, x1.1
6. For `yolo-v2-tiny-ava-sparse-30-0001`: `51.3 -> 57 fps`, x1.11
7. For `yolo-v2-tiny-ava-sparse-60-0001`: `52.5 -> 57 fps`, x1.085
8. For `yolo-v2-ava-0001`: `17.5 -> 17.8 fps`, x1
9. For `yolo-v2-ava-sparse-35-0001`: `17.5 -> 17.8 fps`, x1
10. For `yolo-v2-ava-sparse-70-0001`: `17.5 -> 17.8 fps`, x1
11. For `yolo-v2-tiny-vehicle-detection-0001`: `64.5 -> 68.2 fps`, x1.05
12. For `yolo-v1-tiny-tf`: `54.8 -> 57.5 fps`, x1.05
13. For `person-vehicle-bike-detection-crossroad-yolov3-1020`: `7.5 -> 8.4 fps` , **x1.12**
14. For `mobilefacedet-v1-mxnet`: `47.5 -> 99.5 fps`, **x2.1**

The calculations were carried out on the CPU `Intel® Core™ i7-8700 CPU` and on images from coco dataset. `nstreams = 4, nrequests = 5, nthreads = auto` 

Now Yolo model support only **Multiple_labels mode**, as at c++ demo