### PR TITLE
cstddef include added

### DIFF
--- a/demos/speech_recognition_deepspeech_demo/python/ctcdecode-numpy/ctcdecode_numpy/word_prefix_set.h
+++ b/demos/speech_recognition_deepspeech_demo/python/ctcdecode-numpy/ctcdecode_numpy/word_prefix_set.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 #include <cstdint>
+// cstddef is required to get size_t definition on GCC 6
+#include <cstddef>
 
 struct WordPrefixSetState {
   // Length of the current prefix


### PR DESCRIPTION
The include was added in order to build `ctcdecode_numpy` on GCC 6.
GCC 6 raises the compilation error because `size_t` definition is not found.