### PR TITLE
cpp: remove preprocess() from SegmentationModel

### DIFF
--- a/demos/common/cpp/models/include/models/segmentation_model.h
+++ b/demos/common/cpp/models/include/models/segmentation_model.h
@@ -27,8 +27,6 @@ public:
 
     static std::vector<std::string> loadLabels(const std::string& labelFilename);
 
-    std::shared_ptr<InternalModelData> preprocess(
-        const InputData& inputData, InferenceEngine::InferRequest::Ptr& request) override;
     std::unique_ptr<ResultBase> postprocess(InferenceResult& infResult) override;
 
 protected:

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -88,31 +88,6 @@ void SegmentationModel::prepareInputsOutputs(InferenceEngine::CNNNetwork& cnnNet
     }
 }
 
-std::shared_ptr<InternalModelData> SegmentationModel::preprocess(const InputData& inputData, InferenceEngine::InferRequest::Ptr& request)
-{
-    auto imgData = inputData.asRef<ImageInputData>();
-    auto& img = imgData.inputImage;
-
-    std::shared_ptr<InternalModelData> resPtr = nullptr;
-
-    if (useAutoResize)
-    {
-        /* Just set input blob containing read image. Resize and layout conversionx will be done automatically */
-        request->SetBlob(inputsNames[0], wrapMat2Blob(img));
-        /* IE::Blob::Ptr from wrapMat2Blob() doesn't own data. Save the image to avoid deallocation before inference */
-        resPtr = std::make_shared<InternalImageMatModelData>(img);
-    }
-    else
-    {
-        /* Resize and copy data from the image to the input blob */
-        InferenceEngine::Blob::Ptr frameBlob = request->GetBlob(inputsNames[0]);
-        matU8ToBlob<uint8_t>(img, frameBlob);
-        resPtr = std::make_shared<InternalImageModelData>(img.cols, img.rows);
-    }
-
-    return resPtr;
-}
-
 std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infResult) {
     ImageResult* result = new ImageResult(infResult.frameId, infResult.metaData);
 


### PR DESCRIPTION
The same implementation as in `ImageModel` class, from which the `SegmentationModel` is inherited.