### PR TITLE
wav2vec2-base suppress on GPU

### DIFF
--- a/models/public/device_support.md
+++ b/models/public/device_support.md
@@ -156,7 +156,7 @@
 | vgg16 | YES | YES | YES |
 | vgg19 | YES | YES | YES |
 | vgg19-caffe2 | YES | YES | YES |
-| wav2vec2-base | YES | YES |     |
+| wav2vec2-base | YES |    |    |
 | wavernn-rnn | YES | YES | YES |
 | wavernn-upsampler | YES | YES |    |
 | yolact-resnet50-fpn-pytorch | YES | YES | YES |


### PR DESCRIPTION
wav2vec2-base does not work on GPU with OpenVINO 2021.4