### PR TITLE
Added reference values to AC configs

### DIFF
--- a/models/intel/action-recognition-0001/accuracy-check.yml
+++ b/models/intel/action-recognition-0001/accuracy-check.yml
@@ -25,3 +25,7 @@ evaluations:
           metrics:
             - type: clip_accuracy
               presenter: print_vector
+              reference:
+                clip_accuracy: 0.565
+                video_accuracy: 0.565283
+                mean: 0.565141

--- a/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
+++ b/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
@@ -29,6 +29,12 @@ models:
             label_map: age_label_map
             annotation_source: age_class_annotation
             prediction_source: age_classification
+            reference:
+              child: 0.007263
+              young: 0.853628
+              middle: 0.751714
+              old: 0.229058
+              mean: 0.460416
 
           - type: mae
             reference: 6.99

--- a/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
+++ b/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
@@ -21,6 +21,7 @@ models:
             type: accuracy
             annotation_source: gender_annotation
             prediction_source: gender
+            reference: 0.958
 
           - name: accuracy@age
             type: accuracy_per_class
@@ -30,3 +31,4 @@ models:
             prediction_source: age_classification
 
           - type: mae
+            reference: 6.99

--- a/models/intel/asl-recognition-0004/accuracy-check.yml
+++ b/models/intel/asl-recognition-0004/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
           - type: accuracy
             name: rank@1
             top_k: 1
+            reference: 0.847

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-0001/accuracy-check.yml
@@ -31,5 +31,7 @@ models:
         metrics:
           - name: 'F1'
             type: 'f1'
+            reference: 0.9321
           - name: 'EM'
             type: 'exact_match'
+            reference: 0.872

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/accuracy-check.yml
@@ -33,3 +33,4 @@ models:
           - name: 'top_5_acc'
             type: 'qa_embedding_accuracy'
             top_k: 5
+            reference: 0.905

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/accuracy-check.yml
@@ -31,5 +31,7 @@ models:
         metrics:
           - name: 'F1'
             type: 'f1'
+            reference: 0.926
           - name: 'EM'
             type: 'exact_match'
+            reference: 0.8636

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0001/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0001/accuracy-check.yml
@@ -32,5 +32,7 @@ models:
         metrics:
           - name: 'F1'
             type: 'f1'
+            reference: 0.9157
           - name: 'EM'
             type: 'exact_match'
+            reference: 0.8504

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0002/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0002/accuracy-check.yml
@@ -36,5 +36,7 @@ models:
         metrics:
           - name: 'F1'
             type: 'f1'
+            reference: 0.919
           - name: 'EM'
             type: 'exact_match'
+            reference: 0.854

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/accuracy-check.yml
@@ -33,3 +33,4 @@ models:
           - name: 'top_5_acc'
             type: 'qa_embedding_accuracy'
             top_k: 5
+            reference: 0.876

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/accuracy-check.yml
@@ -36,5 +36,7 @@ models:
         metrics:
           - name: 'F1'
             type: 'f1'
+            reference: 0.914
           - name: 'EM'
             type: 'exact_match'
+            reference: 0.844

--- a/models/intel/common-sign-language-0002/accuracy-check.yml
+++ b/models/intel/common-sign-language-0002/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
           - type: accuracy
             name: rank@1
             top_k: 1
+            reference: 0.98

--- a/models/intel/driver-action-recognition-adas-0002/accuracy-check.yml
+++ b/models/intel/driver-action-recognition-adas-0002/accuracy-check.yml
@@ -24,3 +24,7 @@ evaluations:
 
           metrics:
             - type: clip_accuracy
+              reference:
+                clip_accuracy: 0.920221
+                video_accuracy: 0.938253
+                mean: 0.929237

--- a/models/intel/emotions-recognition-retail-0003/accuracy-check.yml
+++ b/models/intel/emotions-recognition-retail-0003/accuracy-check.yml
@@ -10,3 +10,4 @@ models:
 
         metrics:
           - type: accuracy
+            reference: 0.702

--- a/models/intel/face-detection-0200/accuracy-check.yml
+++ b/models/intel/face-detection-0200/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.8674

--- a/models/intel/face-detection-0202/accuracy-check.yml
+++ b/models/intel/face-detection-0202/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.9194

--- a/models/intel/face-detection-0204/accuracy-check.yml
+++ b/models/intel/face-detection-0204/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.9289

--- a/models/intel/face-detection-0205/accuracy-check.yml
+++ b/models/intel/face-detection-0205/accuracy-check.yml
@@ -31,3 +31,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.9357

--- a/models/intel/face-detection-0206/accuracy-check.yml
+++ b/models/intel/face-detection-0206/accuracy-check.yml
@@ -31,3 +31,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.9427

--- a/models/intel/face-detection-adas-0001/accuracy-check.yml
+++ b/models/intel/face-detection-adas-0001/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: True
+            reference: 0.941

--- a/models/intel/face-detection-retail-0004/accuracy-check.yml
+++ b/models/intel/face-detection-retail-0004/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.83

--- a/models/intel/face-detection-retail-0005/accuracy-check.yml
+++ b/models/intel/face-detection-retail-0005/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
+            reference: 0.8452

--- a/models/intel/face-reidentification-retail-0095/accuracy-check.yml
+++ b/models/intel/face-reidentification-retail-0095/accuracy-check.yml
@@ -1,0 +1,17 @@
+models:
+  - name: face-reidentification-retail-0095
+    launchers:
+      - framework: dlsdk
+        adapter: reid
+
+    datasets:
+      - name: lfw
+
+        preprocessing:
+          - type: point_alignment
+            size: 400
+          - type: resize
+            size: 128
+        metrics:
+          - type: pairwise_accuracy_subsets
+            reference: 0.9947

--- a/models/intel/facial-landmarks-35-adas-0002/accuracy-check.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/accuracy-check.yml
@@ -13,3 +13,7 @@ models:
             calculate_std: True
             percentile: 90
             presenter: print_vector
+            reference:
+              90th percentile: 0.143
+              mean: 0.106
+              std: 0.038

--- a/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/accuracy-check.yml
@@ -31,3 +31,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.3874

--- a/models/intel/formula-recognition-medium-scan-0001/accuracy-check.yml
+++ b/models/intel/formula-recognition-medium-scan-0001/accuracy-check.yml
@@ -28,6 +28,7 @@ evaluations:
           metrics:
             - type: im2latex_match_images_metric
               max_pixel_column_diff: 0
+              reference: 0.815
 
         - name: im2latex_medium_rendered
 
@@ -44,3 +45,4 @@ evaluations:
           metrics:
             - type: im2latex_match_images_metric
               max_pixel_column_diff: 0
+              reference: 0.957

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/accuracy-check.yml
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/accuracy-check.yml
@@ -19,3 +19,4 @@ evaluations:
           metrics:
             - type: im2latex_match_images_metric
               max_pixel_column_diff: 0
+              reference: 0.705

--- a/models/intel/gaze-estimation-adas-0002/accuracy-check.yml
+++ b/models/intel/gaze-estimation-adas-0002/accuracy-check.yml
@@ -21,3 +21,6 @@ models:
         metrics:
           - type: angle_error
             presenter: print_vector
+            reference:
+              mean: 6.95
+              std: 3.58

--- a/models/intel/handwritten-japanese-recognition-0001/accuracy-check.yml
+++ b/models/intel/handwritten-japanese-recognition-0001/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
 
         metrics:
           - type: label_level_recognition_accuracy
+            reference: 0.9816

--- a/models/intel/handwritten-score-recognition-0003/accuracy-check.yml
+++ b/models/intel/handwritten-score-recognition-0003/accuracy-check.yml
@@ -16,3 +16,4 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9883

--- a/models/intel/handwritten-simplified-chinese-recognition-0001/accuracy-check.yml
+++ b/models/intel/handwritten-simplified-chinese-recognition-0001/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
 
         metrics:
           - type: label_level_recognition_accuracy
+            reference: 0.7531

--- a/models/intel/head-pose-estimation-adas-0001/accuracy-check.yml
+++ b/models/intel/head-pose-estimation-adas-0001/accuracy-check.yml
@@ -18,15 +18,24 @@ models:
             presenter: print_vector
             annotation_source: yaw
             prediction_source: angle_yaw
+            reference:
+              mean: 5.4
+              std: 4.4
 
           - name: pitch_mae
             type: mae
             presenter: print_vector
             annotation_source: pitch
             prediction_source: angle_pitch
+            reference:
+              mean: 5.5
+              std: 5.3
 
           - name: roll_mae
             type: mae
             presenter: print_vector
             annotation_source: roll
             prediction_source: angle_roll
+            reference:
+              mean: 4.6
+              std: 5.6

--- a/models/intel/horizontal-text-detection-0001/accuracy-check.yml
+++ b/models/intel/horizontal-text-detection-0001/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
             ignore_difficult: True
             area_recall_constrain: 0.5
             area_precision_constrain: 0.5
+            reference: 0.8845

--- a/models/intel/human-pose-estimation-0001/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
           - name: AP
             type: coco_precision
             max_detections: 20
+            reference: 0.428

--- a/models/intel/human-pose-estimation-0005/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0005/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
         metrics:
           - name: AP
             type: coco_orig_keypoints_precision
+            reference: 0.456

--- a/models/intel/human-pose-estimation-0006/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0006/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
         metrics:
           - name: AP
             type: coco_orig_keypoints_precision
+            reference: 0.511

--- a/models/intel/human-pose-estimation-0007/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0007/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
         metrics:
           - name: AP
             type: coco_orig_keypoints_precision
+            reference: 0.543

--- a/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
             use_argmax: false
             ignore_label: 11
             presenter: print_vector
+            reference: 0.7542

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
             use_argmax: false
             ignore_label: 11
             presenter: print_vector
+            reference: 0.7587

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
             use_argmax: false
             ignore_label: 11
             presenter: print_vector
+            reference: 0.7579

--- a/models/intel/image-retrieval-0001/accuracy-check.yml
+++ b/models/intel/image-retrieval-0001/accuracy-check.yml
@@ -12,5 +12,6 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.834
 
           - type: reid_map

--- a/models/intel/image-retrieval-0001/accuracy-check.yml
+++ b/models/intel/image-retrieval-0001/accuracy-check.yml
@@ -15,3 +15,4 @@ models:
             reference: 0.834
 
           - type: reid_map
+            reference: 0.855644

--- a/models/intel/instance-segmentation-security-0002/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0002/accuracy-check.yml
@@ -27,6 +27,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.3644
 
           - name: AP@boxes
             type: coco_orig_precision
+            reference: 0.3986

--- a/models/intel/instance-segmentation-security-0091/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0091/accuracy-check.yml
@@ -27,6 +27,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.3814
 
           - name: AP@boxes
             type: coco_orig_precision
+            reference: 0.4355

--- a/models/intel/instance-segmentation-security-0228/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0228/accuracy-check.yml
@@ -19,6 +19,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.339
 
           - name: AP@boxes
             type: coco_orig_precision
+            reference: 0.3885

--- a/models/intel/instance-segmentation-security-1039/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-1039/accuracy-check.yml
@@ -20,6 +20,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.286
 
           - name: AP@boxes
             type: coco_orig_precision
+            reference: 0.329

--- a/models/intel/instance-segmentation-security-1040/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-1040/accuracy-check.yml
@@ -20,6 +20,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.312
 
           - name: AP@boxes
             type: coco_orig_precision
+            reference: 0.35

--- a/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
+++ b/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
@@ -20,5 +20,12 @@ models:
         metrics:
           - type: per_point_normed_error
             presenter: print_vector
+            reference:
+              point_0_normed_error: 0.06802
+              point_1_normed_error: 0.061613
+              point_2_normed_error: 0.093053
+              point_3_normed_error: 0.067112
+              point_4_normed_error: 0.062814
+              mean: 0.070523
           - type: normed_error
             reference: 0.0705

--- a/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
+++ b/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
           - type: per_point_normed_error
             presenter: print_vector
           - type: normed_error
+            reference: 0.0705

--- a/models/intel/license-plate-recognition-barrier-0001/accuracy-check.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/accuracy-check.yml
@@ -14,3 +14,4 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8858

--- a/models/intel/machine-translation-nar-de-en-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-de-en-0002/accuracy-check.yml
@@ -35,3 +35,4 @@ models:
         metrics:
           - type: bleu
             smooth: True
+            reference: 0.214

--- a/models/intel/machine-translation-nar-en-de-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-en-de-0002/accuracy-check.yml
@@ -35,3 +35,4 @@ models:
         metrics:
           - type: bleu
             smooth: True
+            reference: 0.177

--- a/models/intel/machine-translation-nar-en-ru-0001/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-en-ru-0001/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
         metrics:
           - type: bleu
             smooth: True
+            reference: 0.216

--- a/models/intel/machine-translation-nar-ru-en-0001/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-ru-en-0001/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
         metrics:
           - type: bleu
             smooth: True
+            reference: 0.228

--- a/models/intel/noise-suppression-poconetlike-0001/accuracy-check.yml
+++ b/models/intel/noise-suppression-poconetlike-0001/accuracy-check.yml
@@ -167,3 +167,6 @@ models:
           - type: sisdr
             delay: 640
             presenter: print_vector
+            reference:
+              mean: 20.544
+              std: 5.13

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/accuracy-check.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: True
+            reference: 0.9

--- a/models/intel/pedestrian-detection-adas-0002/accuracy-check.yml
+++ b/models/intel/pedestrian-detection-adas-0002/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: True
+            reference: 0.88

--- a/models/intel/person-attributes-recognition-crossroad-0230/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/accuracy-check.yml
@@ -20,3 +20,11 @@ models:
           - type: f1-score
             calculate_average: False
             presenter: print_vector
+            reference:
+              has_backpack: 0.77
+              has_bag: 0.66
+              has_hat: 0.64
+              has_longhair: 0.83
+              has_longpants: 0.83
+              has_longsleeves: 0.21
+              is male: 0.91

--- a/models/intel/person-attributes-recognition-crossroad-0234/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0234/accuracy-check.yml
@@ -20,3 +20,10 @@ models:
           - type: f1-score
             calculate_average: False
             presenter: print_vector
+            reference:
+              has_bag: 0.44
+              has_hat: 0.74
+              has_longhair: 0.84
+              has_longpants: 0.89
+              has_longsleeves: 0.45
+              is male: 0.92

--- a/models/intel/person-attributes-recognition-crossroad-0238/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0238/accuracy-check.yml
@@ -20,3 +20,10 @@ models:
           - type: f1-score
             calculate_average: False
             presenter: print_vector
+            reference:
+              has_bag: 0.48
+              has_hat: 0.42
+              has_longhair: 0.77
+              has_longpants: 0.75
+              has_longsleeves: 0.17
+              is male: 0.8

--- a/models/intel/person-detection-0106/accuracy-check.yml
+++ b/models/intel/person-detection-0106/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
             use_numpy: True
         metrics:
           - type: coco_orig_precision
+            reference: 0.442

--- a/models/intel/person-detection-0200/accuracy-check.yml
+++ b/models/intel/person-detection-0200/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.244

--- a/models/intel/person-detection-0201/accuracy-check.yml
+++ b/models/intel/person-detection-0201/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.299

--- a/models/intel/person-detection-0202/accuracy-check.yml
+++ b/models/intel/person-detection-0202/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.328

--- a/models/intel/person-detection-0203/accuracy-check.yml
+++ b/models/intel/person-detection-0203/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
 
         metrics:
           - type: coco_orig_precision
+            reference: 0.408

--- a/models/intel/person-detection-action-recognition-0005/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-0005/accuracy-check.yml
@@ -50,6 +50,7 @@ models:
             annotation_source: person_annotation
             prediction_source: class_agnostic_prediction
             label_map: person_label_map
+            reference: 0.8
 
           - type: detection_accuracy
             use_normalization: True
@@ -57,3 +58,4 @@ models:
             prediction_source: action_prediction
             label_map: action_label_map
             ignore_label: 3
+            reference: 0.838

--- a/models/intel/person-detection-action-recognition-0006/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-0006/accuracy-check.yml
@@ -53,6 +53,7 @@ models:
             annotation_source: person_annotation
             prediction_source: class_agnostic_prediction
             label_map: person_label_map
+            reference: 0.907
 
           - type: detection_accuracy
             use_normalization: True
@@ -60,3 +61,4 @@ models:
             prediction_source: action_prediction
             label_map: action_label_map
             ignore_label: 6
+            reference: 0.8074

--- a/models/intel/person-detection-action-recognition-teacher-0002/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/accuracy-check.yml
@@ -50,6 +50,7 @@ models:
             annotation_source: person_annotation
             prediction_source: class_agnostic_prediction
             label_map: person_label_map
+            reference: 0.8
 
           - type: detection_accuracy
             use_normalization: True
@@ -58,3 +59,4 @@ models:
             label_map: action_label_map
             fast_match: True
             ignore_label: 3
+            reference: 0.724

--- a/models/intel/person-detection-asl-0001/accuracy-check.yml
+++ b/models/intel/person-detection-asl-0001/accuracy-check.yml
@@ -34,3 +34,4 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.8

--- a/models/intel/person-detection-raisinghand-recognition-0001/accuracy-check.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/accuracy-check.yml
@@ -50,6 +50,7 @@ models:
             annotation_source: person_annotation
             prediction_source: class_agnostic_prediction
             label_map: person_label_map
+            reference: 0.8
 
           - type: detection_accuracy
             use_normalization: True
@@ -57,3 +58,4 @@ models:
             prediction_source: action_prediction
             label_map: action_label_map
             ignore_label: 2
+            reference: 0.905

--- a/models/intel/person-detection-retail-0002/accuracy-check.yml
+++ b/models/intel/person-detection-retail-0002/accuracy-check.yml
@@ -51,3 +51,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.8014

--- a/models/intel/person-detection-retail-0013/accuracy-check.yml
+++ b/models/intel/person-detection-retail-0013/accuracy-check.yml
@@ -33,3 +33,4 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.8862

--- a/models/intel/person-reidentification-retail-0277/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0277/accuracy-check.yml
@@ -19,5 +19,7 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.962
 
           - type: reid_map
+            reference: 0.877

--- a/models/intel/person-reidentification-retail-0286/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0286/accuracy-check.yml
@@ -19,5 +19,7 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.948
 
           - type: reid_map
+            reference: 0.837

--- a/models/intel/person-reidentification-retail-0287/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0287/accuracy-check.yml
@@ -19,5 +19,7 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.929
 
           - type: reid_map
+            reference: 0.766

--- a/models/intel/person-reidentification-retail-0288/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0288/accuracy-check.yml
@@ -19,5 +19,7 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.861
 
           - type: reid_map
+            reference: 0.597

--- a/models/intel/person-vehicle-bike-detection-2000/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2000/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.165

--- a/models/intel/person-vehicle-bike-detection-2001/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2001/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.226

--- a/models/intel/person-vehicle-bike-detection-2002/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2002/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.248

--- a/models/intel/person-vehicle-bike-detection-2003/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2003/accuracy-check.yml
@@ -23,3 +23,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.336

--- a/models/intel/person-vehicle-bike-detection-2004/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2004/accuracy-check.yml
@@ -23,3 +23,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.274

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/accuracy-check.yml
@@ -32,3 +32,8 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: False
+            reference:
+              mean: 0.6512
+              non-vehicle: 0.4414
+              person: 0.7747
+              vehicle: 0.7494

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/accuracy-check.yml
@@ -31,3 +31,8 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: False
+            reference:
+              mean: 0.6255
+              non-vehicle: 0.3618
+              person: 0.7363
+              vehicle: 0.7784

--- a/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/accuracy-check.yml
@@ -47,3 +47,8 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: False
+            reference:
+              mean: 0.4889
+              non-vehicle: 0.2566
+              person: 0.5894
+              vehicle: 0.6205

--- a/models/intel/product-detection-0001/accuracy-check.yml
+++ b/models/intel/product-detection-0001/accuracy-check.yml
@@ -18,3 +18,6 @@ models:
           - type: filter
             min_confidence: 0.02
             apply_to: prediction
+        metrics:
+          - type: coco_precision
+            reference: 0.715

--- a/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
@@ -25,6 +25,7 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.6171
           - name: accuracy@top5
             type: accuracy
             top_k: 5

--- a/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.8353

--- a/models/intel/resnet50-binary-0001/accuracy-check.yml
+++ b/models/intel/resnet50-binary-0001/accuracy-check.yml
@@ -24,6 +24,7 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7069
           - name: accuracy@top5
             type: accuracy
             top_k: 5

--- a/models/intel/resnet50-binary-0001/accuracy-check.yml
+++ b/models/intel/resnet50-binary-0001/accuracy-check.yml
@@ -28,3 +28,4 @@ models:
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.8923

--- a/models/intel/road-segmentation-adas-0001/accuracy-check.yml
+++ b/models/intel/road-segmentation-adas-0001/accuracy-check.yml
@@ -10,5 +10,17 @@ models:
         metrics:
           - type: mean_iou
             presenter: print_vector
+            reference:
+              BG: 0.986
+              curbs: 0.727
+              marks: 0.708
+              mean: 0.844
+              road: 0.954
           - type: mean_accuracy
             presenter: print_vector
+            reference:
+              BG: 0.994
+              curbs: 0.831
+              marks: 0.806
+              mean: 0.901
+              road: 0.974

--- a/models/intel/semantic-segmentation-adas-0001/accuracy-check.yml
+++ b/models/intel/semantic-segmentation-adas-0001/accuracy-check.yml
@@ -16,3 +16,25 @@ models:
           - type: mean_iou
             use_argmax: False
             presenter: print_vector
+            reference:
+              Bicycle: 0.622246
+              Building: 0.860139
+              Bus: 0.743752
+              Car: 0.877892
+              Ego-Vehicle: 0.852932
+              Fence: 0.592632
+              Motorcycle: 0.600701
+              Person: 0.711653
+              Pole: 0.559078
+              Rider: 0.612787
+              Road: 0.910379
+              Sidewalk: 0.630676
+              Sky: 0.976889
+              Terrain: 0.620521
+              Traffic Light: 0.654779
+              Traffic Sign: 0.648217
+              Train: 0.358641
+              Truck: 0.674829
+              Vegetation: 0.882593
+              Wall: 0.424166
+              mean: 0.6907

--- a/models/intel/single-image-super-resolution-1032/accuracy-check.yml
+++ b/models/intel/single-image-super-resolution-1032/accuracy-check.yml
@@ -16,3 +16,9 @@ models:
 
     datasets:
       - name: super_resolution_x4
+        metrics:
+          - type: psnr
+            scale_border: 4
+            presenter: print_vector
+            reference:
+              mean: 29.29

--- a/models/intel/single-image-super-resolution-1033/accuracy-check.yml
+++ b/models/intel/single-image-super-resolution-1033/accuracy-check.yml
@@ -21,3 +21,5 @@ models:
           - type: psnr
             scale_border: 4
             presenter: print_vector
+            reference:
+              mean: 30.97

--- a/models/intel/text-detection-0003/accuracy-check.yml
+++ b/models/intel/text-detection-0003/accuracy-check.yml
@@ -35,3 +35,4 @@ models:
           - type: incidental_text_hmean
             name: f-measure
             ignore_difficult: True
+            reference: 0.8212

--- a/models/intel/text-detection-0004/accuracy-check.yml
+++ b/models/intel/text-detection-0004/accuracy-check.yml
@@ -35,3 +35,4 @@ models:
           - type: incidental_text_hmean
             name: f-measure
             ignore_difficult: True
+            reference: 0.7943

--- a/models/intel/text-image-super-resolution-0001/accuracy-check.yml
+++ b/models/intel/text-image-super-resolution-0001/accuracy-check.yml
@@ -8,3 +8,9 @@ models:
 
     datasets:
       - name: text_super_resolution_x3
+        metrics:
+          - type: psnr
+            scale_border: 4
+            presenter: print_vector
+            reference:
+              mean: 21.64

--- a/models/intel/text-recognition-0012/accuracy-check.yml
+++ b/models/intel/text-recognition-0012/accuracy-check.yml
@@ -16,3 +16,4 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8818

--- a/models/intel/text-recognition-0014/accuracy-check.yml
+++ b/models/intel/text-recognition-0014/accuracy-check.yml
@@ -67,7 +67,7 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
-            - reference: 0.8157
+            reference: 0.8157
 
       - name: ICDAR2015_recognition
         preprocessing:

--- a/models/intel/text-recognition-0014/accuracy-check.yml
+++ b/models/intel/text-recognition-0014/accuracy-check.yml
@@ -56,6 +56,7 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.83
 
       - name: IIIT5K
         preprocessing:
@@ -66,6 +67,7 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            - reference: 0.8157
 
       - name: ICDAR2015_recognition
         preprocessing:
@@ -76,6 +78,7 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.6908
 
       - name: ICDAR03_recognition
         preprocessing:
@@ -86,6 +89,7 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9077
 
       - name: ICDAR2013
         preprocessing:
@@ -96,3 +100,4 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8887

--- a/models/intel/text-recognition-0015/accuracy-check.yml
+++ b/models/intel/text-recognition-0015/accuracy-check.yml
@@ -87,6 +87,7 @@ evaluations:
               dst_height: 64
           metrics:
             - type: character_recognition_accuracy
+              reference: 0.8764
 
         - name: IIIT5K
           preprocessing:
@@ -97,6 +98,7 @@ evaluations:
               dst_height: 64
           metrics:
             - type: character_recognition_accuracy
+              reference: 0.8413
 
         - name: ICDAR2015_recognition
           preprocessing:
@@ -107,6 +109,7 @@ evaluations:
               dst_height: 64
           metrics:
             - type: character_recognition_accuracy
+              reference: 0.7355
 
         - name: ICDAR03_recognition
           preprocessing:
@@ -117,6 +120,7 @@ evaluations:
               dst_height: 64
           metrics:
             - type: character_recognition_accuracy
+              reference: 0.9389
 
         - name: ICDAR2013
           preprocessing:
@@ -127,3 +131,4 @@ evaluations:
               dst_height: 64
           metrics:
             - type: character_recognition_accuracy
+              reference: 0.8995

--- a/models/intel/text-spotting-0005/accuracy-check.yml
+++ b/models/intel/text-spotting-0005/accuracy-check.yml
@@ -51,3 +51,4 @@ evaluations:
               name: f-measure
               ignore_difficult: True
               word_spotting: True
+              reference: 0.7129

--- a/models/intel/text-to-speech-en-0001/accuracy-check.yml
+++ b/models/intel/text-to-speech-en-0001/accuracy-check.yml
@@ -28,3 +28,6 @@ evaluations:
           metrics:
             - type: relative_l2_error
               presenter: print_vector
+              reference:
+                mean: 0.0002
+                std: 0.00011

--- a/models/intel/text-to-speech-en-multi-0001/accuracy-check.yml
+++ b/models/intel/text-to-speech-en-multi-0001/accuracy-check.yml
@@ -29,3 +29,6 @@ evaluations:
           metrics:
             - type: relative_l2_error
               presenter: print_vector
+              reference:
+                mean: 0.0002
+                std: 0.00011

--- a/models/intel/time-series-forecasting-electricity-0001/accuracy-check.yml
+++ b/models/intel/time-series-forecasting-electricity-0001/accuracy-check.yml
@@ -22,5 +22,8 @@ models:
         metrics:
           - type: normalised_quantile_loss
             presenter: print_vector
+            reference:
+              0.5: 0.056
+              0.9: 0.028
         postprocessing:
           - type: time_series_denormalize

--- a/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
+++ b/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
@@ -28,3 +28,5 @@ models:
             use_argmax: True
             ignore_label: 11
             presenter: print_vector
+            reference:
+              mean: 0.7195

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/accuracy-check.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/accuracy-check.yml
@@ -27,9 +27,24 @@ models:
             annotation_source: color
             prediction_source: color
             label_map: color_label_map
+            reference:
+              black: 0.961
+              blue: 0.7953
+              gray: 0.7801
+              green: 0.8333
+              mean: 0.8115
+              red: 0.9227
+              white: 0.8483
+              yellow: 0.5401
           - name: type_accuracy
             type: accuracy_per_class
             presenter: print_vector
             annotation_source: type
             prediction_source: type
             label_map: type_label_map
+            reference:
+              bus: 0.6857
+              car: 0.9826
+              mean: 0.8756
+              truck: 0.9427
+              van: 0.8916

--- a/models/intel/vehicle-attributes-recognition-barrier-0042/accuracy-check.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0042/accuracy-check.yml
@@ -27,9 +27,24 @@ models:
             annotation_source: color
             prediction_source: color
             label_map: color_label_map
+            reference:
+              black: 0.9684
+              blue: 0.8249
+              gray: 0.7747
+              green: 0.8182
+              mean: 0.8271
+              red: 0.9465
+              white: 0.842
+              yellow: 0.615
           - name: type_accuracy
             type: accuracy_per_class
             presenter: print_vector
             annotation_source: type
             prediction_source: type
             label_map: type_label_map
+            reference:
+              bus: 0.6857
+              car: 0.9744
+              mean: 0.8734
+              truck: 0.9695
+              van: 0.8641

--- a/models/intel/vehicle-detection-0200/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0200/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.254

--- a/models/intel/vehicle-detection-0201/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0201/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.323

--- a/models/intel/vehicle-detection-0202/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0202/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
         metrics:
           - type: coco_orig_precision
             include_boundaries: false
+            reference: 0.36

--- a/models/intel/vehicle-detection-adas-0002/accuracy-check.yml
+++ b/models/intel/vehicle-detection-adas-0002/accuracy-check.yml
@@ -28,3 +28,4 @@ models:
             include_boundaries: True
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: True
+            reference: 0.906

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/accuracy-check.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/accuracy-check.yml
@@ -34,3 +34,7 @@ models:
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
             presenter: print_vector
+            reference:
+              mean: 0.9965
+              plate: 0.9942
+              vehicle: 0.9988

--- a/models/intel/weld-porosity-detection-0001/accuracy-check.yml
+++ b/models/intel/weld-porosity-detection-0001/accuracy-check.yml
@@ -19,3 +19,4 @@ models:
 
         metrics:
           - type: accuracy
+            reference: 0.9714

--- a/models/intel/yolo-v2-ava-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.639

--- a/models/intel/yolo-v2-ava-sparse-35-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-sparse-35-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.6371

--- a/models/intel/yolo-v2-ava-sparse-70-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-sparse-70-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.629

--- a/models/intel/yolo-v2-tiny-ava-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.3537

--- a/models/intel/yolo-v2-tiny-ava-sparse-30-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-30-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.3633

--- a/models/intel/yolo-v2-tiny-ava-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-60-0001/accuracy-check.yml
@@ -32,3 +32,4 @@ models:
             include_boundaries: True
             presenter: print_scalar
             allow_multiple_matches_per_ignored: True
+            reference: 0.3532

--- a/models/intel/yolo-v2-tiny-vehicle-detection-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-vehicle-detection-0001/accuracy-check.yml
@@ -30,6 +30,8 @@ models:
             integral: 11point
             ignore_difficult: false
             presenter: print_scalar
+            reference: 0.8864
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.9497

--- a/models/public/Sphereface/accuracy-check.yml
+++ b/models/public/Sphereface/accuracy-check.yml
@@ -14,3 +14,7 @@ models:
           - type: resize
             dst_height: 112
             dst_width: 96
+        metrics:
+          - type: pairwise_accuracy_subsets
+            subset_number: 2
+            reference: 0.988321

--- a/models/public/aclnet-int8/accuracy-check.yml
+++ b/models/public/aclnet-int8/accuracy-check.yml
@@ -18,6 +18,8 @@ models:
           - type: accuracy
             name: top@1
             top_k: 1
+            reference: 0.871
           - type: accuracy
             name: top@5
             top_k: 5
+            reference: 0.93

--- a/models/public/aclnet/accuracy-check.yml
+++ b/models/public/aclnet/accuracy-check.yml
@@ -18,6 +18,8 @@ models:
           - type: accuracy
             name: top@1
             top_k: 1
+            reference: 0.863
           - type: accuracy
             name: top@5
             top_k: 5
+            reference: 0.92

--- a/models/public/alexnet/accuracy-check.yml
+++ b/models/public/alexnet/accuracy-check.yml
@@ -14,6 +14,15 @@ models:
             size: 227
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.56598
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.79812
 
   - name: alexnet
     launchers:
@@ -32,6 +41,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.56598
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.79812

--- a/models/public/anti-spoof-mn3/accuracy-check.yml
+++ b/models/public/anti-spoof-mn3/accuracy-check.yml
@@ -16,3 +16,4 @@ models:
         metrics:
           - name: acer
             type: acer_score
+            reference: 0.0381

--- a/models/public/bert-base-ner/accuracy-check.yml
+++ b/models/public/bert-base-ner/accuracy-check.yml
@@ -23,7 +23,8 @@ models:
             - segment_ids
         metrics:
           - type: ner_accuracy
+            reference: 0.9915
           - type: ner_f_score
             presenter: print_vector
             reference:
-              mean: 0.8445
+              mean: 0.9445

--- a/models/public/bert-base-ner/accuracy-check.yml
+++ b/models/public/bert-base-ner/accuracy-check.yml
@@ -25,3 +25,5 @@ models:
           - type: ner_accuracy
           - type: ner_f_score
             presenter: print_vector
+            reference:
+              mean: 0.8445

--- a/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
@@ -19,13 +19,11 @@ models:
             median: True
             presenter: print_vector
             reference:
-              mean:
-                overall tumor: 0.924003
-                necrotic and non-enhancing tumor: 0.71467
-                edema: 0.820533
-                enhancing tumor: 0.727001
-              median:
-                overall tumor: 0.931653
-                necrotic and non-enhancing tumor: 0.771611
-                edema: 0.853434
-                enhancing tumor: 0.845571
+              mean@overall tumor: 0.924003
+              mean@necrotic and non-enhancing tumor: 0.71467
+              mean@edema: 0.820533
+              mean@enhancing tumor: 0.727001
+              median@overall tumor: 0.931653
+              median@necrotic and non-enhancing tumor: 0.771611
+              median@edema: 0.853434
+              median@enhancing tumor: 0.845571

--- a/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
@@ -18,3 +18,14 @@ models:
           - type: dice_index
             median: True
             presenter: print_vector
+            reference:
+              mean:
+                overall tumor: 0.924003
+                necrotic and non-enhancing tumor: 0.71467
+                edema: 0.820533
+                enhancing tumor: 0.727001
+              median:
+                overall tumor: 0.931653
+                necrotic and non-enhancing tumor: 0.771611
+                edema: 0.853434
+                enhancing tumor: 0.845571

--- a/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
@@ -27,13 +27,11 @@ models:
             median: True
             presenter: print_vector
             reference:
-              mean:
-                overall tumor: 0.915
-                necrotic and non-enhancing tumor: 0.611
-                edema: 0.806
-                enhancing tumor: 0.794
-              median:
-                overall tumor: 0.927
-                necrotic and non-enhancing tumor: 0.645
-                edema: 0.835
-                enhancing tumor: 0.86
+              mean@overall tumor: 0.915
+              mean@necrotic and non-enhancing tumor: 0.611
+              mean@edema: 0.806
+              mean@enhancing tumor: 0.794
+              median@overall tumor: 0.927
+              median@necrotic and non-enhancing tumor: 0.645
+              median@edema: 0.835
+              median@enhancing tumor: 0.86

--- a/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
@@ -26,3 +26,14 @@ models:
           - type: dice_index
             median: True
             presenter: print_vector
+            reference:
+              mean:
+                overall tumor: 0.915
+                necrotic and non-enhancing tumor: 0.611
+                edema: 0.806
+                enhancing tumor: 0.794
+              median:
+                overall tumor: 0.927
+                necrotic and non-enhancing tumor: 0.645
+                edema: 0.835
+                enhancing tumor: 0.86

--- a/models/public/caffenet/accuracy-check.yml
+++ b/models/public/caffenet/accuracy-check.yml
@@ -14,6 +14,15 @@ models:
             size: 227
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.56714
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.79916
 
   - name: caffenet
     launchers:
@@ -27,3 +36,12 @@ models:
             size: 256
           - type: crop
             size: 227
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.56714
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.79916

--- a/models/public/cocosnet/accuracy-check.yml
+++ b/models/public/cocosnet/accuracy-check.yml
@@ -51,5 +51,9 @@ evaluations:
             - type: psnr
               scale_border: 0
               presenter: print_vector
+              reference:
+                mean: 12.99
             - type: ssim
               presenter: print_vector
+              reference:
+                mean: 0.34

--- a/models/public/colorization-siggraph/accuracy-check.yml
+++ b/models/public/colorization-siggraph/accuracy-check.yml
@@ -32,5 +32,9 @@ models:
         metrics:
           - type: psnr
             presenter: print_vector
+            reference:
+              mean: 27.73
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.92

--- a/models/public/colorization-v2/accuracy-check.yml
+++ b/models/public/colorization-v2/accuracy-check.yml
@@ -23,5 +23,9 @@ models:
         metrics:
           - type: psnr
             presenter: print_vector
+            reference:
+              mean: 26.99
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.9

--- a/models/public/common-sign-language-0001/accuracy-check.yml
+++ b/models/public/common-sign-language-0001/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
           - type: accuracy
             name: rank@1
             top_k: 1
+            reference: 0.9358

--- a/models/public/ctdet_coco_dlav0_384/accuracy-check.yml
+++ b/models/public/ctdet_coco_dlav0_384/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
           - type: map
             integral: 11point
             presenter: print_scalar
+            reference: 0.4181

--- a/models/public/ctdet_coco_dlav0_512/accuracy-check.yml
+++ b/models/public/ctdet_coco_dlav0_512/accuracy-check.yml
@@ -26,3 +26,4 @@ models:
           - type: map
             integral: 11point
             presenter: print_scalar
+            reference: 0.442

--- a/models/public/ctpn/accuracy-check.yml
+++ b/models/public/ctpn/accuracy-check.yml
@@ -31,12 +31,14 @@ models:
             ignore_difficult: True
             area_recall_constrain: 0.8
             area_precision_constrain: 0.4
+            reference: 0.73
 
           - type: focused_text_recall
             name: recall
             ignore_difficult: True
             area_recall_constrain: 0.8
             area_precision_constrain: 0.4
+            reference: 0.743379
 
           - type: focused_text_hmean
             name: hmean

--- a/models/public/ctpn/accuracy-check.yml
+++ b/models/public/ctpn/accuracy-check.yml
@@ -43,3 +43,4 @@ models:
             ignore_difficult: True
             area_recall_constrain: 0.8
             area_precision_constrain: 0.4
+            reference: 0.7367

--- a/models/public/deblurgan-v2/accuracy-check.yml
+++ b/models/public/deblurgan-v2/accuracy-check.yml
@@ -27,8 +27,12 @@ models:
           - type: psnr
             scale_border: 0
             presenter: print_vector
+            reference:
+              mean: 28.25
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.97
 
   - name: deblurgan-v2
 
@@ -53,5 +57,9 @@ models:
           - type: psnr
             scale_border: 0
             presenter: print_vector
+            reference:
+              mean: 28.25
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.97

--- a/models/public/deeplabv3/accuracy-check.yml
+++ b/models/public/deeplabv3/accuracy-check.yml
@@ -27,3 +27,4 @@ models:
           - type: mean_iou
             use_argmax: false
             presenter: print_scalar
+            reference: 0.6841

--- a/models/public/densenet-121-caffe2/accuracy-check.yml
+++ b/models/public/densenet-121-caffe2/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 103.94,116.78,123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.74904
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92192
 
   - name: densenet-121-caffe2
     launchers:
@@ -31,3 +40,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.74904
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92192

--- a/models/public/densenet-121-tf/accuracy-check.yml
+++ b/models/public/densenet-121-tf/accuracy-check.yml
@@ -15,6 +15,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7446
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9213

--- a/models/public/densenet-121/accuracy-check.yml
+++ b/models/public/densenet-121/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7442
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92136
 
   - name: densenet-121
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7442
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92136

--- a/models/public/densenet-161-tf/accuracy-check.yml
+++ b/models/public/densenet-161-tf/accuracy-check.yml
@@ -11,3 +11,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76446
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93228

--- a/models/public/densenet-161/accuracy-check.yml
+++ b/models/public/densenet-161/accuracy-check.yml
@@ -16,6 +16,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7755
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9392
 
   - name: densenet-161
     launchers:
@@ -29,3 +38,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7755
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9392

--- a/models/public/densenet-169-tf/accuracy-check.yml
+++ b/models/public/densenet-169-tf/accuracy-check.yml
@@ -15,6 +15,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7614
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9312

--- a/models/public/densenet-169/accuracy-check.yml
+++ b/models/public/densenet-169/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76106
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93106
 
   - name: densenet-169
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76106
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93106

--- a/models/public/densenet-201-tf/accuracy-check.yml
+++ b/models/public/densenet-201-tf/accuracy-check.yml
@@ -15,6 +15,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7693
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9356

--- a/models/public/densenet-201/accuracy-check.yml
+++ b/models/public/densenet-201/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76886
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93556
 
   - name: densenet-201
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76886
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93556

--- a/models/public/detr-resnet50/accuracy-check.yml
+++ b/models/public/detr-resnet50/accuracy-check.yml
@@ -22,7 +22,9 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.4236
           - type: coco_orig_precision
+            reference: 0.3927
 
   - name: detr-resnet50
     launchers:
@@ -44,4 +46,6 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.4236
           - type: coco_orig_precision
+            reference: 0.3927

--- a/models/public/dla-34/accuracy-check.yml
+++ b/models/public/dla-34/accuracy-check.yml
@@ -26,6 +26,15 @@ models:
           - type: normalization
             mean: (123.675,116.28,103.53)
             std: (58.395,57.12,57.375)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7464
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9206
 
   - name: dla-34
 
@@ -47,3 +56,12 @@ models:
           - type: crop
             size: 224
             use_pillow: True
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7464
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9206

--- a/models/public/drn-d-38/accuracy-check.yml
+++ b/models/public/drn-d-38/accuracy-check.yml
@@ -12,3 +12,4 @@ models:
             use_argmax: false
             presenter: print_vector
             ignore_label: 19
+            reference: 0.7131

--- a/models/public/efficientdet-d0-tf/accuracy-check.yml
+++ b/models/public/efficientdet-d0-tf/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
 
         metrics:
           - type: coco_precision
+            reference: 0.3195

--- a/models/public/efficientdet-d1-tf/accuracy-check.yml
+++ b/models/public/efficientdet-d1-tf/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
 
         metrics:
           - type: coco_precision
+            reference: 0.3754

--- a/models/public/efficientnet-b0-pytorch/accuracy-check.yml
+++ b/models/public/efficientnet-b0-pytorch/accuracy-check.yml
@@ -29,6 +29,15 @@ models:
           - type: normalization
             mean: (123.675,116.28,103.53)
             std: (58.395,57.12,57.375)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7691
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9321
 
   - name: efficientnet-b0-pytorch
 
@@ -52,3 +61,12 @@ models:
           - type: crop
             use_pillow: True
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7691
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9321

--- a/models/public/efficientnet-b0/accuracy-check.yml
+++ b/models/public/efficientnet-b0/accuracy-check.yml
@@ -22,6 +22,15 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.757
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9276
 
   - name: efficientnet-b0
 
@@ -39,3 +48,12 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.757
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9276

--- a/models/public/efficientnet-b0_auto_aug/accuracy-check.yml
+++ b/models/public/efficientnet-b0_auto_aug/accuracy-check.yml
@@ -22,7 +22,15 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
-
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7643
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9304
 
   - name: efficientnet-b0_auto_aug
 
@@ -40,3 +48,12 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7643
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9304

--- a/models/public/efficientnet-b5-pytorch/accuracy-check.yml
+++ b/models/public/efficientnet-b5-pytorch/accuracy-check.yml
@@ -29,6 +29,16 @@ models:
             mean: (123.675,116.28,103.53)
             std: (58.395,57.12,57.375)
 
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8369
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9671
+
   - name: efficientnet-b5-pytorch
 
     launchers:
@@ -51,3 +61,13 @@ models:
           - type: crop
             use_pillow: True
             size: 456
+
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8369
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9671

--- a/models/public/efficientnet-b5/accuracy-check.yml
+++ b/models/public/efficientnet-b5/accuracy-check.yml
@@ -22,6 +22,15 @@ models:
             size: 456
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8333
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9667
 
   - name: efficientnet-b5
 
@@ -39,3 +48,12 @@ models:
             size: 456
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8333
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9667

--- a/models/public/efficientnet-b7-pytorch/accuracy-check.yml
+++ b/models/public/efficientnet-b7-pytorch/accuracy-check.yml
@@ -28,6 +28,15 @@ models:
           - type: normalization
             mean: (123.675,116.28,103.53)
             std: (58.395,57.12,57.375)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8442
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9691
 
   - name: efficientnet-b7-pytorch
 
@@ -51,3 +60,12 @@ models:
           - type: crop
             use_pillow: True
             size: 600
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8442
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9691

--- a/models/public/efficientnet-b7_auto_aug/accuracy-check.yml
+++ b/models/public/efficientnet-b7_auto_aug/accuracy-check.yml
@@ -22,6 +22,15 @@ models:
             size: 600
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8468
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9709
 
   - name: efficientnet-b7_auto_aug
 
@@ -39,3 +48,12 @@ models:
             size: 600
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8468
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9709

--- a/models/public/f3net/accuracy-check.yml
+++ b/models/public/f3net/accuracy-check.yml
@@ -20,6 +20,8 @@ models:
         metrics:
           - type: salience_f-measure
             presenter: print_vector
+            reference:
+              f-measure: 0.8421
 
   - name: f3net
     launchers:
@@ -37,3 +39,5 @@ models:
         metrics:
           - type: salience_f-measure
             presenter: print_vector
+            reference:
+              f-measure: 0.8421

--- a/models/public/face-detection-retail-0044/accuracy-check.yml
+++ b/models/public/face-detection-retail-0044/accuracy-check.yml
@@ -34,3 +34,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.83

--- a/models/public/face-recognition-resnet100-arcface-onnx/accuracy-check.yml
+++ b/models/public/face-recognition-resnet100-arcface-onnx/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
 
         metrics:
           - type: pairwise_accuracy_subsets
+            reference: 0.9968

--- a/models/public/faceboxes-pytorch/accuracy-check.yml
+++ b/models/public/faceboxes-pytorch/accuracy-check.yml
@@ -27,3 +27,4 @@ models:
           - type: map
             ignore_difficult: True
             include_boundaries: False
+            reference: 0.83565

--- a/models/public/facenet-20180408-102900/accuracy-check.yml
+++ b/models/public/facenet-20180408-102900/accuracy-check.yml
@@ -20,3 +20,4 @@ models:
             min_score: best_train_threshold
             distance_method: 'cosine_distance'
             subtract_mean: True
+            reference: 0.9914

--- a/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
+++ b/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
@@ -27,3 +27,6 @@ models:
               mean: 12.03
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.496712
+              std: 0.137477

--- a/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
+++ b/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
@@ -19,3 +19,11 @@ models:
           - type: resize_style_transfer
             dst_width: 224
             dst_height: 224
+        metrics:
+          - type: psnr
+            scale_border: 0
+            presenter: print_vector
+            reference:
+              mean: 12.03
+          - type: ssim
+            presenter: print_vector

--- a/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.4069

--- a/models/public/faster_rcnn_inception_v2_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_inception_v2_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.2624

--- a/models/public/faster_rcnn_resnet101_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_resnet101_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.3572

--- a/models/public/faster_rcnn_resnet50_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_resnet50_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.3109

--- a/models/public/fastseg-large/accuracy-check.yml
+++ b/models/public/fastseg-large/accuracy-check.yml
@@ -12,3 +12,4 @@ models:
           - type: mean_iou
             use_argmax: false
             presenter: print_scalar
+            reference: 0.7267

--- a/models/public/fastseg-small/accuracy-check.yml
+++ b/models/public/fastseg-small/accuracy-check.yml
@@ -12,3 +12,4 @@ models:
           - type: mean_iou
             use_argmax: false
             presenter: print_scalar
+            reference: 0.6715

--- a/models/public/fcrn-dp-nyu-depth-v2-tf/accuracy-check.yml
+++ b/models/public/fcrn-dp-nyu-depth-v2-tf/accuracy-check.yml
@@ -14,7 +14,10 @@ models:
           - type: resize_prediction_depth_map
         metrics:
           - type: rmse
+            reference: 0.573
           - type: log10_error
             name: log10
+            reference: 0.055
           - type: mape
             name: rel
+            reference: 0.127

--- a/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
@@ -13,9 +13,7 @@ models:
           - type: mae
             presenter: print_vector
             reference:
-              embeddings:
-                mean: 0
-                std: 0
-              duration:
-                mean: 0
-                std: 0
+              embeddings@mean: 0
+              embeddings@std: 0
+              duration@mean: 0
+              duration@std: 0

--- a/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
@@ -12,3 +12,10 @@ models:
         metrics:
           - type: mae
             presenter: print_vector
+            reference:
+              embeddings:
+                mean: 0
+                std: 0
+              duration:
+                mean: 0
+                std: 0

--- a/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
@@ -16,6 +16,5 @@ models:
           - type: mae
             presenter: print_vector
             reference:
-              mel:
-                mean: 1.134815
-                std: 0.048853
+              mel@mean: 1.134815
+              mel@std: 0.048853

--- a/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
@@ -15,3 +15,7 @@ models:
         metrics:
           - type: mae
             presenter: print_vector
+            reference:
+              mel:
+                mean: 1.134815
+                std: 0.048853

--- a/models/public/gmcnn-places2-tf/accuracy-check.yml
+++ b/models/public/gmcnn-places2-tf/accuracy-check.yml
@@ -20,9 +20,13 @@ models:
             scale_border: 0
             presenter: print_vector
             reference:
-                mean: 33.41
+              mean: 33.41
+              std: 4.47
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.991
+              std: 0.0079
 
   - name: gmcnn-places2-tf
 
@@ -46,5 +50,9 @@ models:
             presenter: print_vector
             reference:
               mean: 33.41
+              std: 4.47
           - type: ssim
             presenter: print_vector
+            reference:
+              mean: 0.991
+              std: 0.0079

--- a/models/public/gmcnn-places2-tf/accuracy-check.yml
+++ b/models/public/gmcnn-places2-tf/accuracy-check.yml
@@ -19,6 +19,8 @@ models:
           - type: psnr
             scale_border: 0
             presenter: print_vector
+            reference:
+                mean: 33.41
           - type: ssim
             presenter: print_vector
 
@@ -42,5 +44,7 @@ models:
           - type: psnr
             scale_border: 0
             presenter: print_vector
+            reference:
+              mean: 33.41
           - type: ssim
             presenter: print_vector

--- a/models/public/googlenet-v1-tf/accuracy-check.yml
+++ b/models/public/googlenet-v1-tf/accuracy-check.yml
@@ -16,7 +16,15 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
-
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.6981
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8961
 
   - name: googlenet-v1-tf
     launchers:
@@ -30,3 +38,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.6981
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8961

--- a/models/public/googlenet-v1/accuracy-check.yml
+++ b/models/public/googlenet-v1/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.68928
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89144
 
   - name: googlenet-v1
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.68928
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89144

--- a/models/public/googlenet-v2-tf/accuracy-check.yml
+++ b/models/public/googlenet-v2-tf/accuracy-check.yml
@@ -16,6 +16,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7409
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.918

--- a/models/public/googlenet-v2/accuracy-check.yml
+++ b/models/public/googlenet-v2/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.72024
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.90844
 
   - name: googlenet-v2
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.72024
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.90844

--- a/models/public/googlenet-v3-pytorch/accuracy-check.yml
+++ b/models/public/googlenet-v3-pytorch/accuracy-check.yml
@@ -27,6 +27,15 @@ models:
           - type: normalization
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7769
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.937
 
   - name: googlenet-v3-pytorch
 
@@ -51,3 +60,12 @@ models:
             use_pillow: true
           # Image channels must be swapped, because "pillow_imread" reads in RGB, but converted model expect BGR
           - type: rgb_to_bgr
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7769
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.937

--- a/models/public/googlenet-v3/accuracy-check.yml
+++ b/models/public/googlenet-v3/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.77904
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93808
 
   - name: googlenet-v3
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 299
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.77904
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93808

--- a/models/public/googlenet-v4-tf/accuracy-check.yml
+++ b/models/public/googlenet-v4-tf/accuracy-check.yml
@@ -16,7 +16,15 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 299
-
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8021
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.952
 
   - name: googlenet-v4-tf
     launchers:
@@ -30,3 +38,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 299
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8021
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.952

--- a/models/public/gpt-2/accuracy-check.yml
+++ b/models/public/gpt-2/accuracy-check.yml
@@ -21,6 +21,7 @@ models:
         metrics:
           - type: 'perplexity'
             name: 'Perplexity'
+            reference: 0.29
 
   - name: gpt-2
     launchers:
@@ -43,3 +44,4 @@ models:
         metrics:
           - type: 'perplexity'
             name: 'Perplexity'
+            reference: 0.29

--- a/models/public/hbonet-0.25/accuracy-check.yml
+++ b/models/public/hbonet-0.25/accuracy-check.yml
@@ -32,6 +32,15 @@ models:
           - type: normalization
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.573
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.798
 
   - name: hbonet-0.25
 
@@ -53,3 +62,12 @@ models:
 
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.573
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.798

--- a/models/public/hbonet-0.5/accuracy-check.yml
+++ b/models/public/hbonet-0.5/accuracy-check.yml
@@ -32,6 +32,15 @@ models:
           - type: normalization
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.67
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.869
 
   - name: hbonet-0.5
 
@@ -53,3 +62,12 @@ models:
 
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.67
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.869

--- a/models/public/hbonet-1.0/accuracy-check.yml
+++ b/models/public/hbonet-1.0/accuracy-check.yml
@@ -32,6 +32,15 @@ models:
           - type: normalization
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.731
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.91
 
   - name: hbonet-1.0
 
@@ -53,3 +62,12 @@ models:
 
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.731
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.91

--- a/models/public/higher-hrnet-w32-human-pose-estimation/accuracy-check.yml
+++ b/models/public/higher-hrnet-w32-human-pose-estimation/accuracy-check.yml
@@ -26,3 +26,4 @@ models:
         metrics:
           - name: AP
             type: coco_orig_keypoints_precision
+            reference: 0.6464

--- a/models/public/hrnet-v2-c1-segmentation/accuracy-check.yml
+++ b/models/public/hrnet-v2-c1-segmentation/accuracy-check.yml
@@ -27,9 +27,11 @@ models:
           - name: pix_accuracy
             type: segmentation_accuracy
             use_argmax: True
+            reference: 0.7769
           - name: mean_IoU
             type: mean_iou
             use_argmax: True
+            reference: 0.3302
 
   - name: hrnet-v2-c1-segmentation
 
@@ -54,6 +56,8 @@ models:
           - name: pix_accuracy
             type: segmentation_accuracy
             use_argmax: True
+            reference: 0.7769
           - name: mean_IoU
             type: mean_iou
             use_argmax: True
+            reference: 0.3302

--- a/models/public/human-pose-estimation-3d-0001/accuracy-check.yml
+++ b/models/public/human-pose-estimation-3d-0001/accuracy-check.yml
@@ -26,3 +26,4 @@ models:
 
         metrics:
           - type: mpjpe_multiperson
+            reference: 100.45

--- a/models/public/hybrid-cs-model-mri/accuracy-check.yml
+++ b/models/public/hybrid-cs-model-mri/accuracy-check.yml
@@ -1,5 +1,5 @@
 models:
-  - name: wnet_20
+  - name: hybrid-cs-model-mri
 
     launchers:
       - framework: dlsdk
@@ -16,3 +16,6 @@ models:
           - type: psnr
             scale_border: 0
             presenter: print_vector
+            reference:
+              mean: 34.272884
+              std: 4.607115

--- a/models/public/i3d-rgb-tf/accuracy-check.yml
+++ b/models/public/i3d-rgb-tf/accuracy-check.yml
@@ -24,6 +24,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.67
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.887

--- a/models/public/inception-resnet-v2-tf/accuracy-check.yml
+++ b/models/public/inception-resnet-v2-tf/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8014
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.951
 
   - name: inception-resnet-v2-tf
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 299
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.8014
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.951

--- a/models/public/license-plate-recognition-barrier-0007/accuracy-check.yml
+++ b/models/public/license-plate-recognition-barrier-0007/accuracy-check.yml
@@ -10,3 +10,4 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.98

--- a/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
@@ -17,4 +17,6 @@ models:
 
         metrics:
           - type: coco_orig_segm_precision
+            reference: 0.3536
           - type: coco_orig_precision
+            reference: 0.3986

--- a/models/public/mask_rcnn_inception_v2_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_inception_v2_coco/accuracy-check.yml
@@ -16,4 +16,6 @@ models:
 
         metrics:
           - type: coco_orig_segm_precision
+            reference: 0.2148
           - type: coco_orig_precision
+            reference: 0.2712

--- a/models/public/mask_rcnn_resnet101_atrous_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_resnet101_atrous_coco/accuracy-check.yml
@@ -17,4 +17,6 @@ models:
 
         metrics:
           - type: coco_orig_segm_precision
+            reference: 0.3130
           - type: coco_orig_precision
+            reference: 0.3492

--- a/models/public/mask_rcnn_resnet50_atrous_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_resnet50_atrous_coco/accuracy-check.yml
@@ -16,4 +16,6 @@ models:
       - name: ms_coco_mask_rcnn_short_91_classes
         metrics:
           - type: coco_orig_segm_precision
+            reference: 0.2746
           - type: coco_orig_precision
+            reference: 0.2975

--- a/models/public/midasnet/accuracy-check.yml
+++ b/models/public/midasnet/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
           - type: align_prediction_depth_map
         metrics:
           - type: rmse
+            reference: 0.07071

--- a/models/public/mixnet-l/accuracy-check.yml
+++ b/models/public/mixnet-l/accuracy-check.yml
@@ -22,6 +22,15 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.783
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9391
 
   - name: mixnet-l
 
@@ -39,3 +48,12 @@ models:
             size: 224
             use_pillow: True
             interpolation: BICUBIC
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.783
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9391

--- a/models/public/mobilefacedet-v1-mxnet/accuracy-check.yml
+++ b/models/public/mobilefacedet-v1-mxnet/accuracy-check.yml
@@ -45,3 +45,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: True
             use_filtered_tp: True
+            reference: 0.787488

--- a/models/public/mobilenet-ssd/accuracy-check.yml
+++ b/models/public/mobilenet-ssd/accuracy-check.yml
@@ -20,6 +20,7 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
+            reference: 0.67
 
   - name: mobilenet-ssd
     launchers:
@@ -38,3 +39,4 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
+            reference: 0.67

--- a/models/public/mobilenet-v1-0.25-128/accuracy-check.yml
+++ b/models/public/mobilenet-v1-0.25-128/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.4054
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.65
 
   - name: mobilenet-v1-0.25-128
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 128
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.4054
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.65

--- a/models/public/mobilenet-v1-0.50-160/accuracy-check.yml
+++ b/models/public/mobilenet-v1-0.50-160/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.5986
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8204
 
   - name: mobilenet-v1-0.50-160
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 160
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.5986
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8204

--- a/models/public/mobilenet-v1-0.50-224/accuracy-check.yml
+++ b/models/public/mobilenet-v1-0.50-224/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.63042
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.84934
 
   - name: mobilenet-v1-0.50-224
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.63042
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.84934

--- a/models/public/mobilenet-v1-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v1-1.0-224-tf/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7103
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8994
 
   - name: mobilenet-v1-1.0-224-tf
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7103
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8994

--- a/models/public/mobilenet-v1-1.0-224/accuracy-check.yml
+++ b/models/public/mobilenet-v1-1.0-224/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.69496
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89224
 
   - name: mobilenet-v1-1.0-224
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.69496
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89224

--- a/models/public/mobilenet-v2-1.0-224/accuracy-check.yml
+++ b/models/public/mobilenet-v2-1.0-224/accuracy-check.yml
@@ -18,6 +18,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7185
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9069
 
   - name: mobilenet-v2-1.0-224
     launchers:
@@ -31,3 +40,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7185
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9069

--- a/models/public/mobilenet-v2-1.4-224/accuracy-check.yml
+++ b/models/public/mobilenet-v2-1.4-224/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7409
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9197
 
   - name: mobilenet-v2-1.4-224
     launchers:
@@ -30,3 +39,12 @@ models:
             central_fraction: 0.875
           - type: resize
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7409
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9197

--- a/models/public/mobilenet-v2-pytorch/accuracy-check.yml
+++ b/models/public/mobilenet-v2-pytorch/accuracy-check.yml
@@ -37,6 +37,16 @@ models:
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
 
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.719
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.903
+
   - name: mobilenet-v2-pytorch
 
     # list of launchers for MobileNetV2.
@@ -62,3 +72,13 @@ models:
 
           # Image channels must be swapped, because "pillow_imread" reads in RGB, but converted model expect BGR
           - type: rgb_to_bgr
+
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.719
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.903

--- a/models/public/mobilenet-v2/accuracy-check.yml
+++ b/models/public/mobilenet-v2/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
           - type: normalization
             mean: 103.94, 116.78, 123.68
             std: 58.8235294
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71218
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.90178
 
   - name: mobilenet-v2
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71218
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.90178

--- a/models/public/mobilenet-v3-large-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.757
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9276
 
   - name: mobilenet-v3-large-1.0-224-tf
     launchers:
@@ -30,3 +39,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.757
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9276

--- a/models/public/mobilenet-v3-small-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v3-small-1.0-224-tf/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 127.5
             std: 127.5
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.6736
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8745
 
   - name: mobilenet-v3-small-1.0-224-tf
     launchers:
@@ -30,3 +39,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.6736
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8745

--- a/models/public/mobilenet-yolo-v4-syg/accuracy-check.yml
+++ b/models/public/mobilenet-yolo-v4-syg/accuracy-check.yml
@@ -50,6 +50,7 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter:  print_scalar
+            reference: 0.8711
 
   - name: mobilenet-yolo-v4-syg
     launchers:
@@ -86,3 +87,4 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter:  print_scalar
+            reference: 0.8711

--- a/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml
+++ b/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml
@@ -57,3 +57,4 @@ models:
             step: 16
         metrics:
           - type: wer
+            reference: 0.0893

--- a/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml
+++ b/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml
@@ -57,3 +57,4 @@ models:
             step: 16
         metrics:
           - type: wer
+            reference: 0.0839

--- a/models/public/mtcnn/accuracy-check.yml
+++ b/models/public/mtcnn/accuracy-check.yml
@@ -74,12 +74,14 @@ evaluations:
               include_boundaries: True
               allow_multiple_matches_per_ignored: True
               distinct_conf: False
+              reference: 0.622625
 
             - type: map
               ignore_difficult: True
               include_boundaries: True
               allow_multiple_matches_per_ignored: True
               distinct_conf: False
+              reference: 0.481308
 
   - name: mtcnn
     module: custom_evaluators.mtcnn_evaluator.MTCNNEvaluator
@@ -141,9 +143,11 @@ evaluations:
               include_boundaries: True
               allow_multiple_matches_per_ignored: True
               distinct_conf: False
+              reference: 0.622625
 
             - type: map
               ignore_difficult: True
               include_boundaries: True
               allow_multiple_matches_per_ignored: True
               distinct_conf: False
+              reference: 0.481308

--- a/models/public/netvlad-tf/accuracy-check.yml
+++ b/models/public/netvlad-tf/accuracy-check.yml
@@ -15,3 +15,4 @@ models:
 
         metrics:
           - type: localization_recall
+            reference: 0.820321

--- a/models/public/nfnet-f0/accuracy-check.yml
+++ b/models/public/nfnet-f0/accuracy-check.yml
@@ -27,9 +27,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.8334
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9656
 
   - name: nfnet-f0
 
@@ -56,6 +58,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.8334
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9656

--- a/models/public/octave-densenet-121-0.125/accuracy-check.yml
+++ b/models/public/octave-densenet-121-0.125/accuracy-check.yml
@@ -28,6 +28,15 @@ models:
           - type: normalization
             mean: (124,117,104)
             std: 59.88
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76066
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93044
 
             # Using accuracy metric, achieved result of public model - 76.1 / 93.0 (top 1 and top 5 respectively)
 
@@ -52,3 +61,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 76.1 / 93.0 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76066
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93044

--- a/models/public/octave-resnet-101-0.125/accuracy-check.yml
+++ b/models/public/octave-resnet-101-0.125/accuracy-check.yml
@@ -30,6 +30,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 79.2 / 94.4 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.79182
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9442
 
   # DLSDK inference
   - name: octave-resnet-101-0.125
@@ -52,3 +61,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 79.2 / 94.4 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.79182
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9442

--- a/models/public/octave-resnet-200-0.125/accuracy-check.yml
+++ b/models/public/octave-resnet-200-0.125/accuracy-check.yml
@@ -30,6 +30,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 80.0 / 94.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7999
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94866
 
   # DLSDK inference
   - name: octave-resnet-200-0.125
@@ -52,3 +61,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 80.0 / 94.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7999
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94866

--- a/models/public/octave-resnet-26-0.25/accuracy-check.yml
+++ b/models/public/octave-resnet-26-0.25/accuracy-check.yml
@@ -31,6 +31,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 76.1 / 92.6 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76076
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92584
 
   # DLSDK inference
   - name: octave-resnet-26-0.25
@@ -53,3 +62,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 76.1 / 92.6 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76076
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92584

--- a/models/public/octave-resnet-50-0.125/accuracy-check.yml
+++ b/models/public/octave-resnet-50-0.125/accuracy-check.yml
@@ -30,6 +30,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 78.2 / 93.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7819
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93862
 
   # DLSDK inference
   - name: octave-resnet-50-0.125
@@ -52,3 +61,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 78.2 / 93.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7819
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93862

--- a/models/public/octave-resnext-101-0.25/accuracy-check.yml
+++ b/models/public/octave-resnext-101-0.25/accuracy-check.yml
@@ -31,6 +31,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 79.6 / 94.5 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.79556
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94444
 
   # DLSDK inference
   - name: octave-resnext-101-0.25
@@ -53,3 +62,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 79.6 / 94.5 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.79556
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94444

--- a/models/public/octave-resnext-50-0.25/accuracy-check.yml
+++ b/models/public/octave-resnext-50-0.25/accuracy-check.yml
@@ -31,6 +31,15 @@ models:
             std: 59.88
 
             # Using accuracy metric, achieved result of public model - 78.8 / 94.2 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78772
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9418
 
   # DLSDK inference
   - name: octave-resnext-50-0.25
@@ -53,3 +62,12 @@ models:
             size: 224
 
             # Using accuracy metric, achieved result of public model - 78.8 / 94.2 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78772
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9418

--- a/models/public/octave-se-resnet-50-0.125/accuracy-check.yml
+++ b/models/public/octave-se-resnet-50-0.125/accuracy-check.yml
@@ -30,6 +30,15 @@ models:
             mean: (124,117,104)
             std: 59.88
             # Using accuracy metric, achieved result of public model - 78.2 / 93.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78706
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9409
 
   # DLSDK inference
   - name: octave-se-resnet-50-0.125
@@ -50,3 +59,12 @@ models:
           - type: crop
             size: 224
             # Using accuracy metric, achieved result of public model - 78.2 / 93.9 (top 1 and top 5 respectively)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78706
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9409

--- a/models/public/open-closed-eye-0001/accuracy-check.yml
+++ b/models/public/open-closed-eye-0001/accuracy-check.yml
@@ -14,6 +14,8 @@ models:
             std: 255.0, 255.0, 255.0
         metrics:
           - type: accuracy
+            reference: 0.9584
+
   - name: open-closed-eye-0001
     launchers:
       - framework: dlsdk
@@ -25,3 +27,4 @@ models:
             size: 32
         metrics:
           - type: accuracy
+            reference: 0.9584

--- a/models/public/pelee-coco/accuracy-check.yml
+++ b/models/public/pelee-coco/accuracy-check.yml
@@ -19,3 +19,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.219761

--- a/models/public/pspnet-pytorch/accuracy-check.yml
+++ b/models/public/pspnet-pytorch/accuracy-check.yml
@@ -25,3 +25,4 @@ models:
           - type: mean_iou
             use_argmax: false
             presenter: print_scalar
+            reference: 0.706

--- a/models/public/quartznet-15x5-en/accuracy-check.yml
+++ b/models/public/quartznet-15x5-en/accuracy-check.yml
@@ -16,3 +16,4 @@ models:
         reader: numpy_reader
         metrics:
           - type: wer
+            reference: 0.0386

--- a/models/public/regnetx-3.2gf/accuracy-check.yml
+++ b/models/public/regnetx-3.2gf/accuracy-check.yml
@@ -24,6 +24,15 @@ models:
           - type: normalization
             mean: (103.53,116.28,123.675)
             std: (57.375,57.12,58.395)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7815
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9409
 
   - name: regnetx-3.2gf
 
@@ -42,3 +51,12 @@ models:
           - type: crop
             size: 224
             use_pillow: True
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7815
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9409

--- a/models/public/repvgg-a0/accuracy-check.yml
+++ b/models/public/repvgg-a0/accuracy-check.yml
@@ -27,9 +27,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.724
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9049
 
   - name: repvgg-a0
 
@@ -56,6 +58,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.724
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9049

--- a/models/public/repvgg-b1/accuracy-check.yml
+++ b/models/public/repvgg-b1/accuracy-check.yml
@@ -27,9 +27,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7837
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9409
 
   - name: repvgg-b1
 
@@ -56,6 +58,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7837
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9409

--- a/models/public/repvgg-b3/accuracy-check.yml
+++ b/models/public/repvgg-b3/accuracy-check.yml
@@ -27,9 +27,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.805
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9525
 
   - name: repvgg-b3
 
@@ -56,6 +58,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.805
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9525

--- a/models/public/resnest-50-pytorch/accuracy-check.yml
+++ b/models/public/resnest-50-pytorch/accuracy-check.yml
@@ -24,6 +24,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.8111
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9536

--- a/models/public/resnet-18-pytorch/accuracy-check.yml
+++ b/models/public/resnet-18-pytorch/accuracy-check.yml
@@ -38,6 +38,15 @@ models:
             std: (0.229, 0.224, 0.225)
 
             # Reference metric from PyTorch (pytorch v1.3.1, torchvision v0.4.2) top-1 69.76% top-5 89.08%
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.69754
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89088
 
   - name: resnet-18-pytorch
 
@@ -60,3 +69,12 @@ models:
             size: 224
             use_pillow: True
           - type: rgb_to_bgr
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.69754
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89088

--- a/models/public/resnet-34-pytorch/accuracy-check.yml
+++ b/models/public/resnet-34-pytorch/accuracy-check.yml
@@ -30,6 +30,15 @@ models:
           - type: normalization
             mean: (0.485, 0.456, 0.406)
             std: (0.229, 0.224, 0.225)
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.733
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9142
 
   - name: resnet-34-pytorch
 
@@ -51,3 +60,12 @@ models:
             size: 224
             use_pillow: True
           - type: rgb_to_bgr
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.733
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9142

--- a/models/public/resnet-50-caffe2/accuracy-check.yml
+++ b/models/public/resnet-50-caffe2/accuracy-check.yml
@@ -17,6 +17,15 @@ models:
           - type: normalization
             mean: 103.53, 116.28, 123.675
             std: 57.375, 57.12, 58.395
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7638
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93188
 
   - name: resnet-50-caffe2
     launchers:
@@ -31,3 +40,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7638
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.93188

--- a/models/public/resnet-50-pytorch/accuracy-check.yml
+++ b/models/public/resnet-50-pytorch/accuracy-check.yml
@@ -38,6 +38,15 @@ models:
             std: (0.229, 0.224, 0.225)
 
             # Reference metric from PyTorch (pytorch v1.0.1, torchvision v0.2.2) top-1 76.13% top-5 92.862%
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76128
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92858
 
   - name: resnet-50-pytorch
 
@@ -62,3 +71,12 @@ models:
           # Image channels must be swapped, because "pillow_imread" reads in RGB, but converted model expect BGR
           - type: rgb_to_bgr
           # Reference metric from PyTorch (pytorch v1.0.1, torchvision v0.2.2) top-1 76.13% top-5 92.862%
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.76128
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92858

--- a/models/public/resnet-50-tf/accuracy-check.yml
+++ b/models/public/resnet-50-tf/accuracy-check.yml
@@ -19,7 +19,15 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
-
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7645
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9305
 
   - name: resnet-50-tf
     launchers:
@@ -34,3 +42,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.7645
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9305

--- a/models/public/retinaface-resnet50-pytorch/accuracy-check.yml
+++ b/models/public/retinaface-resnet50-pytorch/accuracy-check.yml
@@ -27,3 +27,4 @@ models:
             include_boundaries: False
             allow_multiple_matches_per_ignored: False
             distinct_conf: False
+            reference: 0.9178

--- a/models/public/retinanet-tf/accuracy-check.yml
+++ b/models/public/retinanet-tf/accuracy-check.yml
@@ -24,3 +24,4 @@ models:
 
         metrics:
           - type: coco_precision
+            reference: 0.3315

--- a/models/public/rexnet-v1-x1.0/accuracy-check.yml
+++ b/models/public/rexnet-v1-x1.0/accuracy-check.yml
@@ -30,9 +30,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7786
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9387
 
   - name: rexnet-v1-x1.0
 
@@ -59,6 +61,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.7786
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9387

--- a/models/public/rfcn-resnet101-coco-tf/accuracy-check.yml
+++ b/models/public/rfcn-resnet101-coco-tf/accuracy-check.yml
@@ -29,3 +29,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.284

--- a/models/public/se-inception/accuracy-check.yml
+++ b/models/public/se-inception/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.75996
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92964
 
   - name: se-inception
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.75996
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.92964

--- a/models/public/se-resnet-101/accuracy-check.yml
+++ b/models/public/se-resnet-101/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78252
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94206
 
   - name: se-resnet-101
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78252
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.94206

--- a/models/public/se-resnet-152/accuracy-check.yml
+++ b/models/public/se-resnet-152/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78506
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9445
 
   - name: se-resnet-152
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78506
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9445

--- a/models/public/se-resnet-50/accuracy-check.yml
+++ b/models/public/se-resnet-50/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.77596
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9385
 
   - name: se-resnet-50
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.77596
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9385

--- a/models/public/se-resnext-101/accuracy-check.yml
+++ b/models/public/se-resnext-101/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.80168
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9519
 
   - name: se-resnext-101
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.80168
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9519

--- a/models/public/se-resnext-50/accuracy-check.yml
+++ b/models/public/se-resnext-50/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78968
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9463
 
   - name: se-resnext-50
     launchers:
@@ -28,3 +37,12 @@ models:
             size: 256
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.78968
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.9463

--- a/models/public/shufflenet-v2-x0.5/accuracy-check.yml
+++ b/models/public/shufflenet-v2-x0.5/accuracy-check.yml
@@ -17,3 +17,12 @@ models:
             interpolation: BILINEAR
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.588
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8113

--- a/models/public/shufflenet-v2-x1.0/accuracy-check.yml
+++ b/models/public/shufflenet-v2-x1.0/accuracy-check.yml
@@ -24,6 +24,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.6936
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.8832

--- a/models/public/single-human-pose-estimation-0001/accuracy-check.yml
+++ b/models/public/single-human-pose-estimation-0001/accuracy-check.yml
@@ -16,3 +16,4 @@ models:
         metrics:
           - name: AP
             type: coco_orig_keypoints_precision
+            reference: 0.6904

--- a/models/public/squeezenet1.0/accuracy-check.yml
+++ b/models/public/squeezenet1.0/accuracy-check.yml
@@ -14,6 +14,15 @@ models:
             size: 227
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.57684
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8038
 
   - name: squeezenet1.0
     launchers:
@@ -27,3 +36,12 @@ models:
             size: 256
           - type: crop
             size: 227
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.57684
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.8038

--- a/models/public/squeezenet1.1-caffe2/accuracy-check.yml
+++ b/models/public/squeezenet1.1-caffe2/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 227
           - type: normalization
             mean: 103.96,116.78,123.68
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.56502
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.79576
 
   - name: squeezenet1.1-caffe2
     launchers:
@@ -29,3 +38,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 227
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.56502
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.79576

--- a/models/public/squeezenet1.1/accuracy-check.yml
+++ b/models/public/squeezenet1.1/accuracy-check.yml
@@ -14,6 +14,15 @@ models:
             size: 227
           - type: normalization
             mean: 104, 117, 123
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.58382
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.81
 
   - name: squeezenet1.1
     launchers:
@@ -27,3 +36,12 @@ models:
             size: 256
           - type: crop
             size: 227
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.58382
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.81

--- a/models/public/ssd-resnet34-1200-onnx/accuracy-check.yml
+++ b/models/public/ssd-resnet34-1200-onnx/accuracy-check.yml
@@ -21,3 +21,4 @@ models:
 
         metrics:
           - type: coco_precision
+            reference: 0.207198

--- a/models/public/ssd300/accuracy-check.yml
+++ b/models/public/ssd300/accuracy-check.yml
@@ -19,7 +19,7 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
-
+            reference: 0.8709
 
   - name: ssd300
     launchers:
@@ -38,3 +38,4 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
+            reference: 0.8709

--- a/models/public/ssd512/accuracy-check.yml
+++ b/models/public/ssd512/accuracy-check.yml
@@ -19,6 +19,7 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
+            reference: 0.9107
 
 
   - name: ssd512
@@ -38,3 +39,4 @@ models:
             integral: 11point
             ignore_difficult: True
             presenter: print_scalar
+            reference: 0.9107

--- a/models/public/ssd_mobilenet_v1_coco/accuracy-check.yml
+++ b/models/public/ssd_mobilenet_v1_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.233212

--- a/models/public/ssd_mobilenet_v1_fpn_coco/accuracy-check.yml
+++ b/models/public/ssd_mobilenet_v1_fpn_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.355453

--- a/models/public/ssd_mobilenet_v2_coco/accuracy-check.yml
+++ b/models/public/ssd_mobilenet_v2_coco/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.249452

--- a/models/public/ssd_resnet50_v1_fpn_coco/accuracy-check.yml
+++ b/models/public/ssd_resnet50_v1_fpn_coco/accuracy-check.yml
@@ -15,3 +15,4 @@ models:
         metrics:
           - type: coco_precision
             max_detections: 100
+            reference: 0.384557

--- a/models/public/ssdlite_mobilenet_v2/accuracy-check.yml
+++ b/models/public/ssdlite_mobilenet_v2/accuracy-check.yml
@@ -13,3 +13,4 @@ models:
           - type: resize_prediction_boxes
         metrics:
           - type: coco_precision
+            reference: 0.242946

--- a/models/public/swin-tiny-patch4-window7-224/accuracy-check.yml
+++ b/models/public/swin-tiny-patch4-window7-224/accuracy-check.yml
@@ -25,9 +25,11 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.8138
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9551
 
   - name: swin-tiny-patch4-window7-224
 
@@ -52,6 +54,8 @@ models:
           - name: accuracy@top1
             type: accuracy
             top_k: 1
+            reference: 0.8138
           - name: accuracy@top5
             type: accuracy
             top_k: 5
+            reference: 0.9551

--- a/models/public/text-recognition-resnet-fc/accuracy-check.yml
+++ b/models/public/text-recognition-resnet-fc/accuracy-check.yml
@@ -55,6 +55,7 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8883
 
       - name: SVT_recognition
         preprocessing:
@@ -65,6 +66,7 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8856
 
       - name: ICDAR2015_recognition
         preprocessing:
@@ -75,6 +77,7 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.7758
 
       - name: ICDAR03_recognition
         preprocessing:
@@ -85,6 +88,7 @@ models:
 
         metrics:
           - type: character_recognition_accuracy
+            refernce: 0.9296
 
       - name: ICDAR2013
         preprocessing:
@@ -94,3 +98,4 @@ models:
             dst_height: 32
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9044

--- a/models/public/ultra-lightweight-face-detection-rfb-320/accuracy-check.yml
+++ b/models/public/ultra-lightweight-face-detection-rfb-320/accuracy-check.yml
@@ -35,6 +35,7 @@ models:
           - type: map
             ignore_difficult: True
             include_boundaries: False
+            reference: 0.8478
 
   - name: ultra-lightweight-face-detection-rfb-320
 
@@ -67,3 +68,4 @@ models:
           - type: map
             ignore_difficult: True
             include_boundaries: False
+            reference: 0.8478

--- a/models/public/ultra-lightweight-face-detection-slim-320/accuracy-check.yml
+++ b/models/public/ultra-lightweight-face-detection-slim-320/accuracy-check.yml
@@ -35,6 +35,7 @@ models:
           - type: map
             ignore_difficult: True
             include_boundaries: False
+            reference: 0.8332
 
   - name: ultra-lightweight-face-detection-slim-320
 
@@ -67,3 +68,4 @@ models:
           - type: map
             ignore_difficult: True
             include_boundaries: False
+            reference: 0.8332

--- a/models/public/vehicle-license-plate-detection-barrier-0123/accuracy-check.yml
+++ b/models/public/vehicle-license-plate-detection-barrier-0123/accuracy-check.yml
@@ -38,3 +38,7 @@ models:
             allow_multiple_matches_per_ignored: True
             distinct_conf: False
             presenter: print_vector
+            reference:
+              mean: 0.9952
+              plate: 0.9913
+              vehicle: 0.999

--- a/models/public/vehicle-reid-0001/accuracy-check.yml
+++ b/models/public/vehicle-reid-0001/accuracy-check.yml
@@ -19,5 +19,7 @@ models:
           - name: rank@1
             type: cmc
             top_k: 1
+            reference: 0.9631
 
           - type: reid_map
+            reference: 0.8515

--- a/models/public/vgg16/accuracy-check.yml
+++ b/models/public/vgg16/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 103.939, 116.779, 123.68
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.70968
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89878
 
   - name: vgg16
     launchers:
@@ -29,3 +38,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.70968
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89878

--- a/models/public/vgg19-caffe2/accuracy-check.yml
+++ b/models/public/vgg19-caffe2/accuracy-check.yml
@@ -16,6 +16,15 @@ models:
             size: 224
           - type: normalization
             mean: 103.939, 116.779, 123.68
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71062
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89832
 
   - name: vgg19-caffe2
     launchers:
@@ -30,3 +39,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71062
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89832

--- a/models/public/vgg19/accuracy-check.yml
+++ b/models/public/vgg19/accuracy-check.yml
@@ -15,6 +15,15 @@ models:
             size: 224
           - type: normalization
             mean: 103.939, 116.779, 123.68
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71062
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89832
 
   - name: vgg19
     launchers:
@@ -29,3 +38,12 @@ models:
             aspect_ratio_scale: greater
           - type: crop
             size: 224
+        metrics:
+          - name: accuracy@top1
+            type: accuracy
+            top_k: 1
+            reference: 0.71062
+          - name: accuracy@top5
+            type: accuracy
+            top_k: 5
+            reference: 0.89832

--- a/models/public/vitstr-small-patch16-224/accuracy-check.yml
+++ b/models/public/vitstr-small-patch16-224/accuracy-check.yml
@@ -22,6 +22,7 @@ models:
             std: 255
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9034
 
       - name: SVT_recognition
         preprocessing:
@@ -32,6 +33,7 @@ models:
             std: 255
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8547
 
       - name: IIIT5K
         preprocessing:
@@ -42,6 +44,7 @@ models:
             std: 255
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8707
 
       - name: ICDAR2015_recognition
         preprocessing:
@@ -52,6 +55,7 @@ models:
             std: 255
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.7504
 
       - name: ICDAR03_recognition
         preprocessing:
@@ -62,6 +66,7 @@ models:
             std: 255
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9343
 
   - name: vitstr-small-patch16-224
     launchers:
@@ -83,6 +88,7 @@ models:
             size: 224
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9034
 
       - name: SVT_recognition
         preprocessing:
@@ -91,6 +97,7 @@ models:
             size: 224
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8547
 
       - name: IIIT5K
         preprocessing:
@@ -99,6 +106,7 @@ models:
             size: 224
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.8707
 
       - name: ICDAR2015_recognition
         preprocessing:
@@ -107,6 +115,7 @@ models:
             size: 224
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.7504
 
       - name: ICDAR03_recognition
         preprocessing:
@@ -115,3 +124,4 @@ models:
             size: 224
         metrics:
           - type: character_recognition_accuracy
+            reference: 0.9343

--- a/models/public/wav2vec2-base/accuracy-check.yml
+++ b/models/public/wav2vec2-base/accuracy-check.yml
@@ -18,3 +18,4 @@ models:
           - type: audio_normalization
         metrics:
           - type: wer
+            reference: 0.0339

--- a/models/public/wavernn/wavernn-rnn/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-rnn/accuracy-check.yml
@@ -39,3 +39,13 @@ models:
         metrics:
           - type: mae
             presenter: print_vector
+            reference:
+              logits:
+                mean: 1.350547
+                std: 0.472648
+              h1:
+                mean: 0
+                std: 0
+              h2:
+                mean: 0.08134
+                std: 0.00799

--- a/models/public/wavernn/wavernn-rnn/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-rnn/accuracy-check.yml
@@ -40,12 +40,9 @@ models:
           - type: mae
             presenter: print_vector
             reference:
-              logits:
-                mean: 1.350547
-                std: 0.472648
-              h1:
-                mean: 0
-                std: 0
-              h2:
-                mean: 0.08134
-                std: 0.00799
+              logits@mean: 1.350547
+              logits@std: 0.472648
+              h1@mean: 0
+              h1@std: 0
+              h2@mean: 0.08134
+              h2@std: 0.00799

--- a/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
@@ -25,9 +25,7 @@ models:
           - type: mae
             presenter: print_vector
             reference:
-              upsample_mels:
-                mean: 0
-                std: 0
-              aux:
-                mean: 0
-                std: 0
+              upsample_mels@mean: 0.0
+              upsample_mels@std: 0.0
+              aux@mean: 0.0
+              aux@std: 0.0

--- a/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
@@ -24,3 +24,10 @@ models:
         metrics:
           - type: mae
             presenter: print_vector
+            reference:
+              upsample_mels:
+                mean: 0
+                std: 0
+              aux:
+                mean: 0
+                std: 0

--- a/models/public/yolact-resnet50-fpn-pytorch/accuracy-check.yml
+++ b/models/public/yolact-resnet50-fpn-pytorch/accuracy-check.yml
@@ -22,9 +22,11 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.28
 
           - name: AP@boxes
             type: coco_precision
+            reference: 0.3069
 
   - name: yolact-resnet50-fpn-pytorch
     launchers:
@@ -44,6 +46,8 @@ models:
         metrics:
           - name: AP@masks
             type: coco_orig_segm_precision
+            reference: 0.28
 
           - name: AP@boxes
             type: coco_precision
+            reference: 0.3069

--- a/models/public/yolo-v1-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v1-tiny-tf/accuracy-check.yml
@@ -44,6 +44,7 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.5479
 
   - name: yolo-v1-tiny-tf
 
@@ -79,3 +80,4 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.5479

--- a/models/public/yolo-v2-tf/accuracy-check.yml
+++ b/models/public/yolo-v2-tf/accuracy-check.yml
@@ -40,9 +40,11 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.5315
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.565
 
   - name: yolo-v2-tf
 
@@ -79,6 +81,8 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.5315
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.565

--- a/models/public/yolo-v2-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v2-tiny-tf/accuracy-check.yml
@@ -38,9 +38,11 @@ models:
             integral: 11point
             ignore_difficult: False
             presenter: print_scalar
+            reference: 0.2734
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.2911
 
   - name: yolo-v2-tiny-tf
 
@@ -76,6 +78,8 @@ models:
             integral: 11point
             ignore_difficult: False
             presenter: print_scalar
+            reference: 0.2734
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.2911

--- a/models/public/yolo-v3-tf/accuracy-check.yml
+++ b/models/public/yolo-v3-tf/accuracy-check.yml
@@ -51,9 +51,11 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.6227
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.677
 
   - name: yolo-v3-tf
 
@@ -94,6 +96,8 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.6227
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.677

--- a/models/public/yolo-v3-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v3-tiny-tf/accuracy-check.yml
@@ -50,9 +50,11 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.359
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.397
 
   - name: yolo-v3-tiny-tf
 
@@ -91,6 +93,8 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.359
           - type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.397

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -50,14 +50,17 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.7123
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.774
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.5026
 
   - name: yolo-v4-tf
     launchers:
@@ -95,11 +98,14 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.7123
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.774
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.5026

--- a/models/public/yolo-v4-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tiny-tf/accuracy-check.yml
@@ -48,14 +48,17 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.4037
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.4636
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.2266
 
   - name: yolo-v4-tiny-tf
     launchers:
@@ -92,11 +95,14 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.4037
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.4636
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.2266

--- a/models/public/yolox-tiny/accuracy-check.yml
+++ b/models/public/yolox-tiny/accuracy-check.yml
@@ -30,14 +30,17 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.4785
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.5256
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.3182
 
   - name: yolox-tiny
     launchers:
@@ -65,11 +68,14 @@ models:
             integral: 11point
             ignore_difficult: true
             presenter: print_scalar
+            reference: 0.4785
           - name: AP@0.5
             type: coco_precision
             max_detections: 100
             threshold: 0.5
+            reference: 0.5256
           - name: AP@0.5:0.05:95
             type: coco_precision
             max_detections: 100
             threshold: '0.5:0.05:0.95'
+            reference: 0.3182


### PR DESCRIPTION
Model accuracy reference values will be kept in accuracy checker configuration file (in addition to model description file). This is useful for automated processing during validation on CI