### PR TITLE
[Tests] Set precisions for model testing via --precisions parameter

### DIFF
--- a/demos/tests/args.py
+++ b/demos/tests/args.py
@@ -14,7 +14,6 @@
 
 import collections
 import shutil
-from itertools import cycle
 
 from pathlib import Path
 
@@ -56,21 +55,16 @@ class Arg:
 
 
 class ModelArg(Arg):
-    def __init__(self, name, precisions=[]):
+    def __init__(self, name, precision=None):
         self.name = name
-        self.precisions = precisions
-
-    def set_precisions(self, precisions):
-        if not self.precisions:
-            self.precisions = precisions
-        self.precision = cycle(self.precisions + self.precisions[::-1])
+        self.precision = precision
 
     def resolve(self, context):
-        return str(context.dl_dir / context.model_info[self.name]["subdirectory"] / next(self.precision) / (self.name + '.xml'))
+        return str(context.dl_dir / context.model_info[self.name]["subdirectory"] / self.precision / (self.name + '.xml'))
 
     @property
     def required_models(self):
-        return [RequestedModel(self.name, self.precisions)]
+        return [RequestedModel(self.name, [])]
 
 
 class ModelFileArg(Arg):

--- a/demos/tests/args.py
+++ b/demos/tests/args.py
@@ -14,6 +14,7 @@
 
 import collections
 import shutil
+from itertools import cycle
 
 from pathlib import Path
 
@@ -55,16 +56,21 @@ class Arg:
 
 
 class ModelArg(Arg):
-    def __init__(self, name, precision='FP32'):
+    def __init__(self, name, precisions=None):
         self.name = name
-        self.precision = precision
+        self.precisions = precisions
+
+    def set_precisions(self, precisions):
+        if self.precisions is None:
+            self.precisions = precisions
+        self.precision = cycle(self.precisions + self.precisions[::-1])
 
     def resolve(self, context):
-        return str(context.dl_dir / context.model_info[self.name]["subdirectory"] / self.precision / (self.name + '.xml'))
+        return str(context.dl_dir / context.model_info[self.name]["subdirectory"] / next(self.precision) / (self.name + '.xml'))
 
     @property
     def required_models(self):
-        return [RequestedModel(self.name, [self.precision])]
+        return [RequestedModel(self.name, self.precisions)]
 
 
 class ModelFileArg(Arg):

--- a/demos/tests/args.py
+++ b/demos/tests/args.py
@@ -56,12 +56,12 @@ class Arg:
 
 
 class ModelArg(Arg):
-    def __init__(self, name, precisions=None):
+    def __init__(self, name, precisions=[]):
         self.name = name
         self.precisions = precisions
 
     def set_precisions(self, precisions):
-        if self.precisions is None:
+        if not self.precisions:
             self.precisions = precisions
         self.precision = cycle(self.precisions + self.precisions[::-1])
 

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -50,19 +50,18 @@ class Demo:
     def get_models(self, case):
         return (case.options[key] for key in self.model_keys if key in case.options)
 
-    def set_precisions(self, precisions):
-        cases_to_repeat = []
+    def set_precisions(self, precisions, model_info):
         for case in self.test_cases:
-            case_to_add = True
+            add_case = True
             for model in self.get_models(case):
                 if isinstance(model, ModelArg):
-                    model.set_precisions(precisions)
+                    supported = list(set(precisions) & set(model_info[model.name]["precisions"]))
+                    model.set_precisions(supported)
+                    precisions_num = len(model.precisions)
                 else:
-                    case_to_add = False
-            if case_to_add:
-                cases_to_repeat.append(case)
-        if len(precisions) > 1:
-            self.test_cases += cases_to_repeat * (len(precisions) - 1)
+                    add_case = False
+            if add_case and precisions_num > 1:
+                self.test_cases += case * (precisions_num - 1)
 
 
 class CppDemo(Demo):

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -58,10 +58,10 @@ class Demo:
                 new_options = case.options.copy()
                 for (key, model_name) in updated_options[p]:
                     new_options[key] = ModelArg(model_name, p)
-                self.test_cases += [case._replace(options=new_options)]
+                self.test_cases.append(case._replace(options=new_options))
 
         for case in self.test_cases[:]:
-            updated_options = dict()
+            updated_options = {}
 
             for model, key in self.get_models(case):
                 if not isinstance(model, ModelArg):

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -52,16 +52,13 @@ class Demo:
 
     def set_precisions(self, precisions, model_info):
         for case in self.test_cases[:]:
-            add_case = True
             precisions_num = 0
             for model in self.get_models(case):
                 if isinstance(model, ModelArg):
                     supported = list(set(precisions) & set(model_info[model.name]["precisions"]))
                     model.set_precisions(supported)
                     precisions_num = len(model.precisions)
-                else:
-                    add_case = False
-            if add_case and precisions_num > 1:
+            if precisions_num > 1:
                 self.test_cases += [case] * (precisions_num - 1)
 
 

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -51,8 +51,9 @@ class Demo:
         return (case.options[key] for key in self.model_keys if key in case.options)
 
     def set_precisions(self, precisions, model_info):
-        for case in self.test_cases:
+        for case in self.test_cases[:]:
             add_case = True
+            precisions_num = 0
             for model in self.get_models(case):
                 if isinstance(model, ModelArg):
                     supported = list(set(precisions) & set(model_info[model.name]["precisions"]))
@@ -61,7 +62,7 @@ class Demo:
                 else:
                     add_case = False
             if add_case and precisions_num > 1:
-                self.test_cases += case * (precisions_num - 1)
+                self.test_cases += [case] * (precisions_num - 1)
 
 
 class CppDemo(Demo):
@@ -631,7 +632,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-small-uncased-whole-word-masking-squad-0002/vocab.txt'),
             }),
             TestCase(options={
-                '-m': ModelArg('bert-small-uncased-whole-word-masking-squad-int8-0002', precisions=['FP32-INT8']),
+                '-m': ModelArg('bert-small-uncased-whole-word-masking-squad-int8-0002', precisions=['FP16-INT8']),
                 '--input_names': 'input_ids,attention_mask,token_type_ids,position_ids',
                 '--output_names': 'output_s,output_e',
                 '--vocab':
@@ -644,7 +645,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-large-uncased-whole-word-masking-squad-0001/vocab.txt'),
             }),
             TestCase(options={
-                '-m': ModelArg('bert-large-uncased-whole-word-masking-squad-int8-0001', precisions=['FP32-INT8']),
+                '-m': ModelArg('bert-large-uncased-whole-word-masking-squad-int8-0001', precisions=['FP16-INT8']),
                 '--input_names': 'input_ids,attention_mask,token_type_ids',
                 '--output_names': 'output_s,output_e',
                 '--vocab':
@@ -672,7 +673,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/vocab.txt'),
             }),
             TestCase(options={
-                '-m_emb': ModelArg('bert-small-uncased-whole-word-masking-squad-emb-int8-0001', precisions=['FP32-INT8']),
+                '-m_emb': ModelArg('bert-small-uncased-whole-word-masking-squad-emb-int8-0001', precisions=['FP16-INT8']),
                 '--input_names_emb': 'input_ids,attention_mask,token_type_ids,position_ids',
                 '--vocab':
                     str(OMZ_DIR / 'models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/vocab.txt'),

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -50,12 +50,15 @@ class Demo:
     def get_models(self, case):
         return ((case.options[key], key) for key in self.model_keys if key in case.options)
 
-    def update_case(self, case, updated_options):
+    def update_case(self, case, updated_options, with_replace=False):
         if not updated_options: return
         new_options = case.options.copy()
         for key, value in updated_options.items():
             new_options[key] = value
-        return case._replace(options=new_options)
+        new_case = case._replace(options=new_options)
+        if with_replace:
+            self.test_cases.remove(case)
+        self.test_cases.append(new_case)
 
     def set_precisions(self, precisions, model_info):
         for case in self.test_cases[:]:
@@ -76,9 +79,7 @@ class Demo:
                     break
 
             for p in precisions:
-                new_case = self.update_case(case, updated_options[p])
-                if new_case:
-                    self.test_cases.append(new_case)
+                self.update_case(case, updated_options[p])
 
 
 class CppDemo(Demo):

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -47,6 +47,23 @@ class Demo:
             return {'CPU': []}
         return {device: [arg for key in self.device_keys for arg in [key, device]] for device in device_list}
 
+    def get_models(self, case):
+        return (case.options[key] for key in self.model_keys if key in case.options)
+
+    def set_precisions(self, precisions):
+        cases_to_repeat = []
+        for case in self.test_cases:
+            case_to_add = True
+            for model in self.get_models(case):
+                if isinstance(model, ModelArg):
+                    model.set_precisions(precisions)
+                else:
+                    case_to_add = False
+            if case_to_add:
+                cases_to_repeat.append(case)
+        if len(precisions) > 1:
+            self.test_cases += cases_to_repeat * (len(precisions) - 1)
+
 
 class CppDemo(Demo):
     def __init__(self, name, implementation='cpp', model_keys=None, device_keys=None, test_cases=None):
@@ -615,7 +632,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-small-uncased-whole-word-masking-squad-0002/vocab.txt'),
             }),
             TestCase(options={
-                '-m': ModelArg('bert-small-uncased-whole-word-masking-squad-int8-0002', precision='FP32-INT8'),
+                '-m': ModelArg('bert-small-uncased-whole-word-masking-squad-int8-0002', precisions=['FP32-INT8']),
                 '--input_names': 'input_ids,attention_mask,token_type_ids,position_ids',
                 '--output_names': 'output_s,output_e',
                 '--vocab':
@@ -628,7 +645,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-large-uncased-whole-word-masking-squad-0001/vocab.txt'),
             }),
             TestCase(options={
-                '-m': ModelArg('bert-large-uncased-whole-word-masking-squad-int8-0001', precision='FP32-INT8'),
+                '-m': ModelArg('bert-large-uncased-whole-word-masking-squad-int8-0001', precisions=['FP32-INT8']),
                 '--input_names': 'input_ids,attention_mask,token_type_ids',
                 '--output_names': 'output_s,output_e',
                 '--vocab':
@@ -656,7 +673,7 @@ PYTHON_DEMOS = [
                 '--vocab': str(OMZ_DIR / 'models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/vocab.txt'),
             }),
             TestCase(options={
-                '-m_emb': ModelArg('bert-small-uncased-whole-word-masking-squad-emb-int8-0001', precision='FP32-INT8'),
+                '-m_emb': ModelArg('bert-small-uncased-whole-word-masking-squad-emb-int8-0001', precisions=['FP32-INT8']),
                 '--input_names_emb': 'input_ids,attention_mask,token_type_ids,position_ids',
                 '--vocab':
                     str(OMZ_DIR / 'models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/vocab.txt'),

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -65,7 +65,7 @@ def parse_args():
         help='path to report file')
     parser.add_argument('--suppressed-devices', type=Path, required=False,
         help='path to file with suppressed devices for each model')
-    parser.add_argument('--precisions', type=str, nargs='+', default=['FP16', 'FP16-INT8'],
+    parser.add_argument('--precisions', type=str, nargs='+', default=['FP16'],
         help='IR precisions for all models. By default, models are tested in FP16 precision')
     return parser.parse_args()
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -65,8 +65,8 @@ def parse_args():
         help='path to report file')
     parser.add_argument('--suppressed-devices', type=Path, required=False,
         help='path to file with suppressed devices for each model')
-    parser.add_argument('--precisions', type=str, nargs='+', default=['FP16', 'FP32'],
-        help='IR precisions for all models. By default, models are tested in FP32 precision')
+    parser.add_argument('--precisions', type=str, nargs='+', default=['FP16', 'FP16-INT8'],
+        help='IR precisions for all models. By default, models are tested in FP16 precision')
     return parser.parse_args()
 
 
@@ -86,9 +86,9 @@ def temp_dir_as_path():
         yield Path(temp_dir)
 
 
-def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test):
+def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test, model_precisions):
     model_names = set()
-    model_precisions = set()
+    model_precisions = set(model_precisions)
 
     for demo in demos_to_test:
         for case in demo.test_cases:
@@ -182,11 +182,8 @@ def main():
     else:
         demos_to_test = DEMOS
 
-    for demo in demos_to_test:
-        demo.set_precisions(args.precisions)
-
     with temp_dir_as_path() as global_temp_dir:
-        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test)
+        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test, args.precisions)
 
         num_failures = 0
 
@@ -197,6 +194,7 @@ def main():
         }
 
         for demo in demos_to_test:
+            demo.set_precisions(args.precisions, model_info)
             print('Testing {}...'.format(demo.subdirectory))
             print()
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -96,7 +96,6 @@ def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_di
                 if isinstance(arg, Arg):
                     for model_request in arg.required_models:
                         model_names.add(model_request.name)
-                        model_precisions.update(model_request.precisions)
 
     dl_dir = global_temp_dir / 'models'
     complete_models_lst_path = global_temp_dir / 'models.lst'
@@ -194,9 +193,9 @@ def main():
         }
 
         for demo in demos_to_test:
-            demo.set_precisions(args.precisions, model_info)
             print('Testing {}...'.format(demo.subdirectory))
             print()
+            demo.set_precisions(args.precisions, model_info)
 
             declared_model_names = {model['name']
                 for model in json.loads(subprocess.check_output(

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -65,6 +65,8 @@ def parse_args():
         help='path to report file')
     parser.add_argument('--suppressed-devices', type=Path, required=False,
         help='path to file with suppressed devices for each model')
+    parser.add_argument('--precisions', type=str, nargs='+', default=['FP16', 'FP32'],
+        help='IR precisions for all models. By default, models are tested in FP32 precision')
     return parser.parse_args()
 
 
@@ -84,9 +86,9 @@ def temp_dir_as_path():
         yield Path(temp_dir)
 
 
-def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test):
+def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test, precisions):
     model_names = set()
-    model_precisions = set()
+    model_precisions = set(precisions)
 
     for demo in demos_to_test:
         for case in demo.test_cases:
@@ -95,9 +97,6 @@ def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_di
                     for model_request in arg.required_models:
                         model_names.add(model_request.name)
                         model_precisions.update(model_request.precisions)
-
-    if not model_precisions:
-        model_precisions.add('FP32')
 
     dl_dir = global_temp_dir / 'models'
     complete_models_lst_path = global_temp_dir / 'models.lst'
@@ -183,8 +182,11 @@ def main():
     else:
         demos_to_test = DEMOS
 
+    for demo in demos_to_test:
+        demo.set_precisions(args.precisions)
+
     with temp_dir_as_path() as global_temp_dir:
-        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test)
+        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test, args.precisions)
 
         num_failures = 0
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -86,9 +86,9 @@ def temp_dir_as_path():
         yield Path(temp_dir)
 
 
-def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test, precisions):
+def prepare_models(auto_tools_dir, downloader_cache_dir, mo_path, global_temp_dir, demos_to_test):
     model_names = set()
-    model_precisions = set(precisions)
+    model_precisions = set()
 
     for demo in demos_to_test:
         for case in demo.test_cases:
@@ -186,7 +186,7 @@ def main():
         demo.set_precisions(args.precisions)
 
     with temp_dir_as_path() as global_temp_dir:
-        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test, args.precisions)
+        dl_dir = prepare_models(auto_tools_dir, args.downloader_cache_dir, args.mo, global_temp_dir, demos_to_test)
 
         num_failures = 0
 


### PR DESCRIPTION
Added the setting of specific precisions (one/many) for testing the models in `.xml` format via the `--precisions` key and `set_precisions()` function.  

For every model the supported precisions (the info is located in `model_info[model_name].precisions`) are compared with precisions we want to test. For example, if the --precisions are set as following: [FP16, FP16-INT8], the models, which do not have IRs for FP16-INT8, are tested only in FP16 precision.
If a model does not support ANY of required precisions, the model is not tested at all.