### PR TITLE
Fixed compilation with forward declaration

### DIFF
--- a/demos/common/cpp/models/src/detection_model_yolo.cpp
+++ b/demos/common/cpp/models/src/detection_model_yolo.cpp
@@ -14,9 +14,9 @@
 // limitations under the License.
 */
 
+#include <ngraph/ngraph.hpp>
 #include "models/detection_model_yolo.h"
 #include <utils/common.hpp>
-#include <ngraph/ngraph.hpp>
 #include <iostream>
 
 std::vector<float> defaultAnchors[] = {


### PR DESCRIPTION
See https://openvino-ci.intel.com/blue/organizations/jenkins/private-ci%2Fie%2Fbuild-linux-centos76/detail/build-linux-centos76/52237/pipeline/

For some reason this code from OMZ:
```c++
namespace ngraph {
    namespace op {
        namespace v0 {
            class RegionYolo;
        }
        using v0::RegionYolo;
    }
}
```

And this from ngraph:
```c++
namespace ngraph {
namespace op {
namespace v0 {
using ov::op::v0::RegionYolo;
}  // namespace v0
using v0::RegionYolo;
}  // namespace op
}  // namespace ngraph
```
Are conflicting with errors:
```sh
[ 77%] Building CXX object common/cpp/models/CMakeFiles/models.dir/src/detection_model_yolo.cpp.o
In file included from /home/sandye51/Documents/Programming/git_repo/dldt/ngraph/core/include/ngraph/ops.hpp:126:0,
                 from /home/sandye51/Documents/Programming/git_repo/dldt/ngraph/core/include/ngraph/ngraph.hpp:74,
                 from /home/sandye51/Documents/Programming/git_repo/open_model_zoo/demos/common/cpp/models/src/detection_model_yolo.cpp:19:
/home/sandye51/Documents/Programming/git_repo/dldt/ngraph/core/include/ngraph/op/region_yolo.hpp:13:19: error: ‘RegionYolo’ is already declared in this scope
 using ov::op::v0::RegionYolo;
                   ^
/home/sandye51/Documents/Programming/git_repo/dldt/ngraph/core/include/ngraph/op/region_yolo.hpp:15:11: error: ‘RegionYolo’ is already declared in this scope
 using v0::RegionYolo;
           ^
/home/sandye51/Documents/Programming/git_repo/open_model_zoo/demos/common/cpp/models/src/detection_model_yolo.cpp: In member function ‘virtual void ModelYolo::prepareInputsOutputs(InferenceEngine::CNNNetwork&)’:
/home/sandye51/Documents/Programming/git_repo/open_model_zoo/demos/common/cpp/models/src/detection_model_yolo.cpp:124:74: error: no matching function for call to ‘ModelYolo::Region::Region(std::shared_ptr<ov::op::v0::RegionYolo>&)’
                     regions.emplace(outputLayer->first, Region(regionYolo));
```