### PR TITLE
[Do Not Merge] Enable AUTO, AUTO:CPU and AUTO:GPU as loaded device

### DIFF
--- a/demos/multi_channel_common/cpp/graph.hpp
+++ b/demos/multi_channel_common/cpp/graph.hpp
@@ -44,6 +44,7 @@ private:
 
     bool printPerfReport;
     std::string deviceName;
+    std::string perf_hint;
 
     InferenceEngine::Core ie;
     std::queue<InferenceEngine::InferRequest::Ptr> availableRequests;
@@ -56,6 +57,7 @@ private:
     std::queue<BatchRequestDesc> busyBatchRequests;
 
     std::size_t maxRequests = 0;
+
 
     std::atomic_bool terminate = {false};
     std::mutex mtxAvalableRequests;
@@ -84,6 +86,7 @@ public:
         std::string cldnnConfigPath;
         std::string deviceName;
         PostLoadFunc postLoadFunc = nullptr;
+        std::string perf_hint = "tput";
     };
 
     explicit IEGraph(const InitParams& p);

--- a/demos/multi_channel_common/cpp/multichannel_params.hpp
+++ b/demos/multi_channel_common/cpp/multichannel_params.hpp
@@ -33,6 +33,7 @@ static const char num_sampling_periods[] = "Optional. Number of sampling periods
 static const char show_statistics[] = "Optional. Enable statistics report";
 static const char real_input_fps[] = "Optional. Disable input frames caching, for maximum throughput pipeline";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+static const char hint_message[] = "Optional. Enable throughput.";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", input_message);
@@ -52,3 +53,4 @@ DEFINE_uint32(n_sp, 10, num_sampling_periods);
 DEFINE_bool(show_stats, false, show_statistics);
 DEFINE_bool(real_input_fps, false, real_input_fps);
 DEFINE_string(u, "", utilization_monitors_message);
+DEFINE_string(hint, "", hint_message);


### PR DESCRIPTION
Signed-off-by: Wang, Yang <yang4.wang@intel.com>

Details:

  - Enable AUTO, AUTO:CPU and AUTO:GPU for loaded device
  - Add additional displaying including FPS, device name and duration time of loading network. 
Tickets:

  - CVS-69029