### PR TITLE
GAPI: Returning include to IFD GAPI.

### DIFF
--- a/demos/interactive_face_detection_demo/cpp_gapi/face.hpp
+++ b/demos/interactive_face_detection_demo/cpp_gapi/face.hpp
@@ -4,6 +4,8 @@
 
 # pragma once
 
+#include <list>
+
 #include <opencv2/opencv.hpp>
 
 // -------------------------Describe detected face on a frame-------------------------------------------------


### PR DESCRIPTION
I hope, that this `#include <list>` was an unnecessary removal.