### PR TITLE
model_tools: support injection of hash algorithms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Downloadable files. Each file is described by:
 
 * `name` - sets a file name after downloading
 * `size` - sets a file size
-* `sha384`  - sets a file hash sum
+* `checksum`  - sets a file hash sum
 * `source` - sets a direct link to a file *OR* describes a file access parameters
 
 > **TIP**: You can obtain a hash sum using the `sha384sum <file_name>` command on Linux\*.
@@ -155,7 +155,7 @@ task_type: classification
 files:
   - name: tf-densenet121.tar.gz
     size: 30597420
-    sha384: dcd6d36f6b07e0843ee35b1dce2c587204c8816d6ba25b7e1dbf2dc25fe2b51f49a2b9327579ce07904575f9325be8b6
+    checksum: dcd6d36f6b07e0843ee35b1dce2c587204c8816d6ba25b7e1dbf2dc25fe2b51f49a2b9327579ce07904575f9325be8b6
     source:
       $type: google_drive
       id: 0B_fUSpodN0t0eW1sVk1aeWREaDA

--- a/models/intel/action-recognition-0001/action-recognition-0001-decoder/model.yml
+++ b/models/intel/action-recognition-0001/action-recognition-0001-decoder/model.yml
@@ -19,27 +19,27 @@ task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-decoder.xml
     size: 192871
-    sha384: 68b426039f98b7471b62d77c1264dd2ceaccd937aa39cbbaf492621ae534f24c7ca228e209e80bb79cc342fe70f0ebc0
+    checksum: 68b426039f98b7471b62d77c1264dd2ceaccd937aa39cbbaf492621ae534f24c7ca228e209e80bb79cc342fe70f0ebc0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
   - name: FP32/action-recognition-0001-decoder.bin
     size: 30238732
-    sha384: b574c93a949be5619e53601d8c7062ce0a6c06a4b32ad9cc9fc8e40198c56838bab964a566c3485bcb1eda15563fac7c
+    checksum: b574c93a949be5619e53601d8c7062ce0a6c06a4b32ad9cc9fc8e40198c56838bab964a566c3485bcb1eda15563fac7c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
   - name: FP16/action-recognition-0001-decoder.xml
     size: 192819
-    sha384: 357050399862b19de6a9be6c089fa557748e2777b8889c04ed0eb561a2561dcdf05cb6df803e642b1d81d343d92ffc70
+    checksum: 357050399862b19de6a9be6c089fa557748e2777b8889c04ed0eb561a2561dcdf05cb6df803e642b1d81d343d92ffc70
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.xml
   - name: FP16/action-recognition-0001-decoder.bin
     size: 15119468
-    sha384: 9de9080d93325b20ec6de71ffe426aad16cbf4aeadbd9bf0afdcb35f77934f5db80aa024c91d363211ed98f3d0e05a35
+    checksum: 9de9080d93325b20ec6de71ffe426aad16cbf4aeadbd9bf0afdcb35f77934f5db80aa024c91d363211ed98f3d0e05a35
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16/action-recognition-0001-decoder.bin
   - name: FP16-INT8/action-recognition-0001-decoder.xml
     size: 309486
-    sha384: 25a16727f24c0484b10e42e23f5247c2f13164c950db7c1449448803735de8201faf11f5003a07bd7f85c87834190389
+    checksum: 25a16727f24c0484b10e42e23f5247c2f13164c950db7c1449448803735de8201faf11f5003a07bd7f85c87834190389
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.xml
   - name: FP16-INT8/action-recognition-0001-decoder.bin
     size: 7406600
-    sha384: 441ef1f1211736a7651d4bdc6c62dd9adfd64e9a7d41b887e18d36882e7fc5e11d27f33c5bee6e88ffccc4179630350e
+    checksum: 441ef1f1211736a7651d4bdc6c62dd9adfd64e9a7d41b887e18d36882e7fc5e11d27f33c5bee6e88ffccc4179630350e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-decoder/FP16-INT8/action-recognition-0001-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/action-recognition-0001/action-recognition-0001-encoder/model.yml
+++ b/models/intel/action-recognition-0001/action-recognition-0001-encoder/model.yml
@@ -19,27 +19,27 @@ task_type: action_recognition
 files:
   - name: FP32/action-recognition-0001-encoder.xml
     size: 105014
-    sha384: 52fd000140ccb06cd515bfb2692b60b6459bb7db0d3ca6f555212a2c0b4cfc72a924118c2f9b85dbeae1c09e5e1c2deb
+    checksum: 52fd000140ccb06cd515bfb2692b60b6459bb7db0d3ca6f555212a2c0b4cfc72a924118c2f9b85dbeae1c09e5e1c2deb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
   - name: FP32/action-recognition-0001-encoder.bin
     size: 85104664
-    sha384: 61321c5af18f4dc601e9d5d525a2013377e12d72130cbe232ff33a55f5181d8c49d07196f24be65362a7a29a11321dab
+    checksum: 61321c5af18f4dc601e9d5d525a2013377e12d72130cbe232ff33a55f5181d8c49d07196f24be65362a7a29a11321dab
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
   - name: FP16/action-recognition-0001-encoder.xml
     size: 104974
-    sha384: e6ac8c62ab80ef9240f28b154be039a4cc57af5913b87ac0c935ef372bf9602ca37f07b5d9a0c689853e67341376b9dd
+    checksum: e6ac8c62ab80ef9240f28b154be039a4cc57af5913b87ac0c935ef372bf9602ca37f07b5d9a0c689853e67341376b9dd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.xml
   - name: FP16/action-recognition-0001-encoder.bin
     size: 42552332
-    sha384: bb1ad5b71258ad8e9117de1fb71e928003ec39bf07e024b6d6987448047e1af37c7c0c6fa426368fad45859a9d8fbcc4
+    checksum: bb1ad5b71258ad8e9117de1fb71e928003ec39bf07e024b6d6987448047e1af37c7c0c6fa426368fad45859a9d8fbcc4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16/action-recognition-0001-encoder.bin
   - name: FP16-INT8/action-recognition-0001-encoder.xml
     size: 278546
-    sha384: 40b6d4321e990f0f0ea222b68bf80ec431b20c777d2d7d2b2ea92e992b2d27f42c0f7dc80e1edbb3b26957efecca2abc
+    checksum: 40b6d4321e990f0f0ea222b68bf80ec431b20c777d2d7d2b2ea92e992b2d27f42c0f7dc80e1edbb3b26957efecca2abc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.xml
   - name: FP16-INT8/action-recognition-0001-encoder.bin
     size: 21309656
-    sha384: edc7cbdb2ed6867cb37ec4d533d2c756ca6fe87addf73f2216fdfc7bde76f3d796eda5d49e857c74dbbc31d07fee9c02
+    checksum: edc7cbdb2ed6867cb37ec4d533d2c756ca6fe87addf73f2216fdfc7bde76f3d796eda5d49e857c74dbbc31d07fee9c02
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/action-recognition-0001/action-recognition-0001-encoder/FP16-INT8/action-recognition-0001-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/age-gender-recognition-retail-0013/model.yml
+++ b/models/intel/age-gender-recognition-retail-0013/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/age-gender-recognition-retail-0013.xml
     size: 31536
-    sha384: f7d042e1b5fec35ea29766f9544fac24a4fb17cd22973914310f96744afda9e582c12761766cfd218f467ac834a75e49
+    checksum: f7d042e1b5fec35ea29766f9544fac24a4fb17cd22973914310f96744afda9e582c12761766cfd218f467ac834a75e49
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.xml
   - name: FP32/age-gender-recognition-retail-0013.bin
     size: 8552076
-    sha384: f00e708403ab7cf2a473351ec57d7fe65e15488b4baa8f8cf8fa9b5bdf90da3594bcbc689794993c1b08a51889488a13
+    checksum: f00e708403ab7cf2a473351ec57d7fe65e15488b4baa8f8cf8fa9b5bdf90da3594bcbc689794993c1b08a51889488a13
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP32/age-gender-recognition-retail-0013.bin
   - name: FP16/age-gender-recognition-retail-0013.xml
     size: 31526
-    sha384: 164d57fab84782a44297bf589f9b738d75ef619da7c564d8df9c126748e0a74378d2b107f90cbb607f70d91903940a26
+    checksum: 164d57fab84782a44297bf589f9b738d75ef619da7c564d8df9c126748e0a74378d2b107f90cbb607f70d91903940a26
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.xml
   - name: FP16/age-gender-recognition-retail-0013.bin
     size: 4276038
-    sha384: 0afe49d995b2b28087f8705d25d8e3e363d1833d1036de47005174637734b6c3edb789ce840098bc3fcc5e7def77723a
+    checksum: 0afe49d995b2b28087f8705d25d8e3e363d1833d1036de47005174637734b6c3edb789ce840098bc3fcc5e7def77723a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16/age-gender-recognition-retail-0013.bin
   - name: FP16-INT8/age-gender-recognition-retail-0013.xml
     size: 72552
-    sha384: fc2a4e56723ea0eac8c6d41e70e2ab858d4e9517a3daad2d37b1f27399f0d3a60ee37b40ca2f119e67e8b24d902e2921
+    checksum: fc2a4e56723ea0eac8c6d41e70e2ab858d4e9517a3daad2d37b1f27399f0d3a60ee37b40ca2f119e67e8b24d902e2921
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.xml
   - name: FP16-INT8/age-gender-recognition-retail-0013.bin
     size: 2150120
-    sha384: bbec50f46cd0ccd798e6602da48b061ff4d41c10e666aefe566eaadf404af6569f2bba9a17a8f18702c7aa436b79334d
+    checksum: bbec50f46cd0ccd798e6602da48b061ff4d41c10e666aefe566eaadf404af6569f2bba9a17a8f18702c7aa436b79334d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/age-gender-recognition-retail-0013/FP16-INT8/age-gender-recognition-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/asl-recognition-0004/model.yml
+++ b/models/intel/asl-recognition-0004/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/asl-recognition-0004.xml
     size: 296552
-    sha384: 3563b1c3892b446bcf932bb6787b76b05a6a2e30d3aba997198f9a423c17572bd46e5e1aaae5ff92774796dc0cb6450a
+    checksum: 3563b1c3892b446bcf932bb6787b76b05a6a2e30d3aba997198f9a423c17572bd46e5e1aaae5ff92774796dc0cb6450a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP32/asl-recognition-0004.xml
   - name: FP32/asl-recognition-0004.bin
     size: 16530600
-    sha384: 92b031d627246e74b13aea6eb4e3b728f15ba8ee3288b0b5e642ca07036e21065096654eb897bf14e4c3f62446644a7a
+    checksum: 92b031d627246e74b13aea6eb4e3b728f15ba8ee3288b0b5e642ca07036e21065096654eb897bf14e4c3f62446644a7a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP32/asl-recognition-0004.bin
   - name: FP16/asl-recognition-0004.xml
     size: 296401
-    sha384: b0deda00dca26c9a7f10f7ab53bb4c19c8c672acf814bd4afe789b9da8914b2c9b77181c5d00163c03b2fca058b11e66
+    checksum: b0deda00dca26c9a7f10f7ab53bb4c19c8c672acf814bd4afe789b9da8914b2c9b77181c5d00163c03b2fca058b11e66
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP16/asl-recognition-0004.xml
   - name: FP16/asl-recognition-0004.bin
     size: 8265312
-    sha384: 33d518c6faceac4740280144d972c3576ae4fea64df9aa2a81625702179bfc6119f665450a66f1984632203e98943131
+    checksum: 33d518c6faceac4740280144d972c3576ae4fea64df9aa2a81625702179bfc6119f665450a66f1984632203e98943131
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP16/asl-recognition-0004.bin
   - name: FP16-INT8/asl-recognition-0004.xml
     size: 691459
-    sha384: 4a79dc5f76d8038c16e0195bc66ff73c9a04268190253fc7a89d8a2a18881bff07bfa0869eafca0e39f822db165eeade
+    checksum: 4a79dc5f76d8038c16e0195bc66ff73c9a04268190253fc7a89d8a2a18881bff07bfa0869eafca0e39f822db165eeade
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP16-INT8/asl-recognition-0004.xml
   - name: FP16-INT8/asl-recognition-0004.bin
     size: 4290197
-    sha384: da193cca0c03dd955edf278f2548278bb57b59b2ab0925c62185250a78f3f782aef22e90e689bfc78886928f82b0b3cd
+    checksum: da193cca0c03dd955edf278f2548278bb57b59b2ab0925c62185250a78f3f782aef22e90e689bfc78886928f82b0b3cd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/asl-recognition-0004/FP16-INT8/asl-recognition-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-0001/model.yml
@@ -19,19 +19,19 @@ task_type: question_answering
 files:
   - name: FP32/bert-large-uncased-whole-word-masking-squad-0001.xml
     size: 1316805
-    sha384: 0a8fbe4593dbf64e777e97af7cee52ad101aa2e26b1b2cf663e1c69e24ca2d8beed22cc5931a863ef0eda1753ed35c0d
+    checksum: 0a8fbe4593dbf64e777e97af7cee52ad101aa2e26b1b2cf663e1c69e24ca2d8beed22cc5931a863ef0eda1753ed35c0d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-0001/FP32/bert-large-uncased-whole-word-masking-squad-0001.xml
   - name: FP32/bert-large-uncased-whole-word-masking-squad-0001.bin
     size: 1336377584
-    sha384: 0a762c4f17991d6f564fcc24ba588ab70e19c84243e6b529fc3156b91b4f55526fda0df20ac7ecc34c24c1b7d5d131a4
+    checksum: 0a762c4f17991d6f564fcc24ba588ab70e19c84243e6b529fc3156b91b4f55526fda0df20ac7ecc34c24c1b7d5d131a4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-0001/FP32/bert-large-uncased-whole-word-masking-squad-0001.bin
   - name: FP16/bert-large-uncased-whole-word-masking-squad-0001.xml
     size: 1315563
-    sha384: 5495f01494ee5a61096beb9fd76ad55970d4e49d707a2f8943eb17709f1c84130136796967f41815c5fa99fd3b258830
+    checksum: 5495f01494ee5a61096beb9fd76ad55970d4e49d707a2f8943eb17709f1c84130136796967f41815c5fa99fd3b258830
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-0001/FP16/bert-large-uncased-whole-word-masking-squad-0001.xml
   - name: FP16/bert-large-uncased-whole-word-masking-squad-0001.bin
     size: 668188872
-    sha384: 7ec8b5ec15dac76214075add12ab88a5248ba1358f3104cf7ad8e5c0ef6bdfadb420b6864322111496706337a72d00ac
+    checksum: 7ec8b5ec15dac76214075add12ab88a5248ba1358f3104cf7ad8e5c0ef6bdfadb420b6864322111496706337a72d00ac
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-0001/FP16/bert-large-uncased-whole-word-masking-squad-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/model.yml
@@ -20,19 +20,19 @@ task_type: question_answering
 files:
   - name: FP32/bert-large-uncased-whole-word-masking-squad-emb-0001.xml
     size: 1301867
-    sha384: 3873a8036617913ca66a5ec26b4a241ddb2bb0395e8440dde4307ea0e8b19fdcb20fc177e2b5163f0d0c4171e681fdc5
+    checksum: 3873a8036617913ca66a5ec26b4a241ddb2bb0395e8440dde4307ea0e8b19fdcb20fc177e2b5163f0d0c4171e681fdc5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-emb-0001/FP32/bert-large-uncased-whole-word-masking-squad-emb-0001.xml
   - name: FP32/bert-large-uncased-whole-word-masking-squad-emb-0001.bin
     size: 1340567764
-    sha384: a026cb215aea6e133f0dceb781487c05bf190412f427987bf31b57c55cf730819ccd208865d47b0ffd7f2d62f3a59b3a
+    checksum: a026cb215aea6e133f0dceb781487c05bf190412f427987bf31b57c55cf730819ccd208865d47b0ffd7f2d62f3a59b3a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-emb-0001/FP32/bert-large-uncased-whole-word-masking-squad-emb-0001.bin
   - name: FP16/bert-large-uncased-whole-word-masking-squad-emb-0001.xml
     size: 1300638
-    sha384: a80f3d290900270526b8773a41e8776e91dcde600948ad6e0eb1d362f3a926b9085acfd80a8f4aca049991f572bf65b0
+    checksum: a80f3d290900270526b8773a41e8776e91dcde600948ad6e0eb1d362f3a926b9085acfd80a8f4aca049991f572bf65b0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-emb-0001/FP16/bert-large-uncased-whole-word-masking-squad-emb-0001.xml
   - name: FP16/bert-large-uncased-whole-word-masking-squad-emb-0001.bin
     size: 670283952
-    sha384: 923d86ac390cd69f86acf7b20bda7b07663a25cf72616ec303fd881f51778b215a789d7df9f9256ba5768cc1fa575895
+    checksum: 923d86ac390cd69f86acf7b20bda7b07663a25cf72616ec303fd881f51778b215a789d7df9f9256ba5768cc1fa575895
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-emb-0001/FP16/bert-large-uncased-whole-word-masking-squad-emb-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/model.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/model.yml
@@ -20,19 +20,19 @@ task_type: question_answering
 files:
   - name: FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
     size: 2081295
-    sha384: cdda1c70ec061237fd4a53a959ea08f389346430f480b71c9ee17e59319d955c6e2f07d28eb380f6192b47d7eac5fea1
+    checksum: cdda1c70ec061237fd4a53a959ea08f389346430f480b71c9ee17e59319d955c6e2f07d28eb380f6192b47d7eac5fea1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
   - name: FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
     size: 430404052
-    sha384: c24c885b3f2dddb146f73169eb005c9072ebfa72e47bc2d3669ce417d0cae25c40780faa1e99bbb9869a8ea9a3f2690b
+    checksum: c24c885b3f2dddb146f73169eb005c9072ebfa72e47bc2d3669ce417d0cae25c40780faa1e99bbb9869a8ea9a3f2690b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP32-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
   - name: FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
     size: 2079957
-    sha384: 25591b1d23dfe01f6767be951da1dd434e5ceb597d745e4a6c707e773a7c4cae70c7ee887848665b401e58d6864e33c8
+    checksum: 25591b1d23dfe01f6767be951da1dd434e5ceb597d745e4a6c707e773a7c4cae70c7ee887848665b401e58d6864e33c8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.xml
   - name: FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
     size: 366198058
-    sha384: 584214fe1e4cad2540cb1015c2ebf4021b1262e7816f46622516b8968308cb5bb2e8a67de3684216c16f8bbf71257f4e
+    checksum: 584214fe1e4cad2540cb1015c2ebf4021b1262e7816f46622516b8968308cb5bb2e8a67de3684216c16f8bbf71257f4e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-large-uncased-whole-word-masking-squad-int8-0001/FP16-INT8/bert-large-uncased-whole-word-masking-squad-int8-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0001/model.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0001/model.yml
@@ -21,19 +21,19 @@ task_type: question_answering
 files:
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0001.xml
     size: 729748
-    sha384: b379300803ee659466a3da34e62da43db6abcc263d14918207cac8a5300b6a8f88207c6ec27ce3194ba32fa8ad11a1c2
+    checksum: b379300803ee659466a3da34e62da43db6abcc263d14918207cac8a5300b6a8f88207c6ec27ce3194ba32fa8ad11a1c2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.xml
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0001.bin
     size: 232298716
-    sha384: 0e38dd880640991f9c8e10558f31996331eacff967845903d06f208fede1eb5337794087092bdf19377fa8ad78330869
+    checksum: 0e38dd880640991f9c8e10558f31996331eacff967845903d06f208fede1eb5337794087092bdf19377fa8ad78330869
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP32/bert-small-uncased-whole-word-masking-squad-0001.bin
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0001.xml
     size: 728952
-    sha384: e3617ee4e3b549faa87e164825589b5ae15e543a559e78877eb67ee42887705a8d0c3f10d72f55894e4c395c3ea33e94
+    checksum: e3617ee4e3b549faa87e164825589b5ae15e543a559e78877eb67ee42887705a8d0c3f10d72f55894e4c395c3ea33e94
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.xml
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0001.bin
     size: 116149444
-    sha384: 29e7591af9fad52659de14dde3fbed3bf56f770f4a4ff90c21378741bea77e1cc4bbac9a22b9da21c0c4f719ed62b908
+    checksum: 29e7591af9fad52659de14dde3fbed3bf56f770f4a4ff90c21378741bea77e1cc4bbac9a22b9da21c0c4f719ed62b908
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0001/FP16/bert-small-uncased-whole-word-masking-squad-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0002/model.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0002/model.yml
@@ -21,19 +21,19 @@ task_type: question_answering
 files:
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0002.xml
     size: 716185
-    sha384: ef7d8a8fce02fc7ef656251d63f575ff812315e0a8b0c46f762b9e088983fcd00ab3bf339fad70ad36a15daaf9cbcbc0
+    checksum: ef7d8a8fce02fc7ef656251d63f575ff812315e0a8b0c46f762b9e088983fcd00ab3bf339fad70ad36a15daaf9cbcbc0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0002/FP32/bert-small-uncased-whole-word-masking-squad-0002.xml
   - name: FP32/bert-small-uncased-whole-word-masking-squad-0002.bin
     size: 164528332
-    sha384: 0c80fbd28bfb9336722a716bdba02a39feacec0aef81bdf055a506a808899e2c191e2440f10dcd7923bfd6c91bf385e4
+    checksum: 0c80fbd28bfb9336722a716bdba02a39feacec0aef81bdf055a506a808899e2c191e2440f10dcd7923bfd6c91bf385e4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0002/FP32/bert-small-uncased-whole-word-masking-squad-0002.bin
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0002.xml
     size: 715930
-    sha384: fb200362fae9f24d1f76f681492f80d45e1f0eb2b714fe4bee1cd0607b870c5a41b49acc2be492b7d8719f2c9f189fe6
+    checksum: fb200362fae9f24d1f76f681492f80d45e1f0eb2b714fe4bee1cd0607b870c5a41b49acc2be492b7d8719f2c9f189fe6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0002/FP16/bert-small-uncased-whole-word-masking-squad-0002.xml
   - name: FP16/bert-small-uncased-whole-word-masking-squad-0002.bin
     size: 82264244
-    sha384: 2793b3a6df64023783cc2e5ab2ee83a9719f4417d6bb41912b2a3f67025d552a908d8e1f469d9dc2617859e52196df9a
+    checksum: 2793b3a6df64023783cc2e5ab2ee83a9719f4417d6bb41912b2a3f67025d552a908d8e1f469d9dc2617859e52196df9a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-0002/FP16/bert-small-uncased-whole-word-masking-squad-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/model.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/model.yml
@@ -22,19 +22,19 @@ task_type: question_answering
 files:
   - name: FP32-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.xml
     size: 1180008
-    sha384: 88969417b0b7aec629eb2789c861281a2e275a9247127ca327993c6dfdc0ee483ee20d27b314759c5df6e43ae0b7b205
+    checksum: 88969417b0b7aec629eb2789c861281a2e275a9247127ca327993c6dfdc0ee483ee20d27b314759c5df6e43ae0b7b205
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/FP32-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.xml
   - name: FP32-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.bin
     size: 41893204
-    sha384: c8f3d484b7464c50d4fc6e9b7089cc5fc3a0376f4a56176a975d5c0b708e76be65b00e2bd9968e6f86cf09767189225a
+    checksum: c8f3d484b7464c50d4fc6e9b7089cc5fc3a0376f4a56176a975d5c0b708e76be65b00e2bd9968e6f86cf09767189225a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/FP32-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.bin
   - name: FP16-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.xml
     size: 1180008
-    sha384: bc1cc846e1485ff2e6d716e6fd0ac688c5e56debea59727bcf73e96d712314ad705c199feea40fe8e017bdf42c722500
+    checksum: bc1cc846e1485ff2e6d716e6fd0ac688c5e56debea59727bcf73e96d712314ad705c199feea40fe8e017bdf42c722500
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/FP16-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.xml
   - name: FP16-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.bin
     size: 41736942
-    sha384: 96dd099688cea4b23f955c55a83026e81cf69095daaa83cab549bd108d67420bfd7690307087909d9eb73e88fe04e712
+    checksum: 96dd099688cea4b23f955c55a83026e81cf69095daaa83cab549bd108d67420bfd7690307087909d9eb73e88fe04e712
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/FP16-INT8/bert-small-uncased-whole-word-masking-squad-emb-int8-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/model.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/model.yml
@@ -21,19 +21,19 @@ task_type: question_answering
 files:
   - name: FP32-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.xml
     size: 1186181
-    sha384: 199925fee288c7e8935cf95e8db608385a0a01845c962a4ff7962a63575457494544d60bc5594b78b37b6e60bba1a214
+    checksum: 199925fee288c7e8935cf95e8db608385a0a01845c962a4ff7962a63575457494544d60bc5594b78b37b6e60bba1a214
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-int8-0002/FP32-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.xml
   - name: FP32-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.bin
     size: 41357676
-    sha384: 793631b516d1444bfaf8e3944ed8de2494b7a3cfce7388aaf1141fdf65c84c9dad42a9e090ea4b8b830980e8ba8422f8
+    checksum: 793631b516d1444bfaf8e3944ed8de2494b7a3cfce7388aaf1141fdf65c84c9dad42a9e090ea4b8b830980e8ba8422f8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-int8-0002/FP32-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.bin
   - name: FP16-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.xml
     size: 1186181
-    sha384: 90361449eed5d3659569c9a71247b75493afaac488875a2e82b650f961e291dcb7f8df4d72a181593bd972d9347e0000
+    checksum: 90361449eed5d3659569c9a71247b75493afaac488875a2e82b650f961e291dcb7f8df4d72a181593bd972d9347e0000
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-int8-0002/FP16-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.xml
   - name: FP16-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.bin
     size: 41207550
-    sha384: 78f053153075919afc185908c64afa672e57272f2c8eae69fa4e4620d65d145b5c43b2e0ef9c39491c265180cb6b51df
+    checksum: 78f053153075919afc185908c64afa672e57272f2c8eae69fa4e4620d65d145b5c43b2e0ef9c39491c265180cb6b51df
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/bert-small-uncased-whole-word-masking-squad-int8-0002/FP16-INT8/bert-small-uncased-whole-word-masking-squad-int8-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/common-sign-language-0002/model.yml
+++ b/models/intel/common-sign-language-0002/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/common-sign-language-0002.xml
     size: 255979
-    sha384: 151ce59371d7f94d7cb6815cd53589ab15f37141f4ffa80ef7322aca4fcd38cf10c53e0b6e2119508cf4c523913366f3
+    checksum: 151ce59371d7f94d7cb6815cd53589ab15f37141f4ffa80ef7322aca4fcd38cf10c53e0b6e2119508cf4c523913366f3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP32/common-sign-language-0002.xml
   - name: FP32/common-sign-language-0002.bin
     size: 16425108
-    sha384: fd0804b77073049f985403435a10434d287901cce8dbab1a9fc4162e2b898442e62def0c42ff2ddd48bb1fb300029316
+    checksum: fd0804b77073049f985403435a10434d287901cce8dbab1a9fc4162e2b898442e62def0c42ff2ddd48bb1fb300029316
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP32/common-sign-language-0002.bin
   - name: FP16/common-sign-language-0002.xml
     size: 255847
-    sha384: 6ba10d98e0f4a43195f5c6f1efb67b06803c1712a218463344cb959c97d6abf0f22ab910836f2c6891f73d1437efd7cd
+    checksum: 6ba10d98e0f4a43195f5c6f1efb67b06803c1712a218463344cb959c97d6abf0f22ab910836f2c6891f73d1437efd7cd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP16/common-sign-language-0002.xml
   - name: FP16/common-sign-language-0002.bin
     size: 8212566
-    sha384: dbb3699f68d5098f55f0d15f47d60ee8c805d0b1dc52ce7c67501113909e01109808328151aa80f95e9313f7136b7e74
+    checksum: dbb3699f68d5098f55f0d15f47d60ee8c805d0b1dc52ce7c67501113909e01109808328151aa80f95e9313f7136b7e74
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP16/common-sign-language-0002.bin
   - name: FP16-INT8/common-sign-language-0002.xml
     size: 597327
-    sha384: 76dbf8b4304e0b5eec22e14beb5c3d6dcbfcd8e534ac68e93496d4f46b8406cb982eeb45081b7eff31e17e71df9ccf99
+    checksum: 76dbf8b4304e0b5eec22e14beb5c3d6dcbfcd8e534ac68e93496d4f46b8406cb982eeb45081b7eff31e17e71df9ccf99
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP16-INT8/common-sign-language-0002.xml
   - name: FP16-INT8/common-sign-language-0002.bin
     size: 4214796
-    sha384: 68316a0e6219abb601f6b8dc44acee31bd33835689f7d48bb1bfcf250b0de7fe2919a76e9e0407368390da8db43bf74b
+    checksum: 68316a0e6219abb601f6b8dc44acee31bd33835689f7d48bb1bfcf250b0de7fe2919a76e9e0407368390da8db43bf74b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/common-sign-language-0002/FP16-INT8/common-sign-language-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-decoder.xml
     size: 227876
-    sha384: 8e75716f38ab02777010f070e193579cfa5e1af03656f6210867c1aff15c14f75b85453fb3eb315d8a1ba3009d569d2b
+    checksum: 8e75716f38ab02777010f070e193579cfa5e1af03656f6210867c1aff15c14f75b85453fb3eb315d8a1ba3009d569d2b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.xml
   - name: FP32/driver-action-recognition-adas-0002-decoder.bin
     size: 29436380
-    sha384: 92d82e56691bdf84a0088233626fbe74a126e5737d5f08b45c8725cbc68a22c8d7b1b7c5dab7a9121dbaee107b2b501d
+    checksum: 92d82e56691bdf84a0088233626fbe74a126e5737d5f08b45c8725cbc68a22c8d7b1b7c5dab7a9121dbaee107b2b501d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP32/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16/driver-action-recognition-adas-0002-decoder.xml
     size: 227840
-    sha384: 07da59fd88d0a78596e49734578b1fbbb8cfccc5bd472e916d2af04e5f2cc5530fa221e4c5d32c01ca14e1b84a4bb7e5
+    checksum: 07da59fd88d0a78596e49734578b1fbbb8cfccc5bd472e916d2af04e5f2cc5530fa221e4c5d32c01ca14e1b84a4bb7e5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16/driver-action-recognition-adas-0002-decoder.bin
     size: 14718282
-    sha384: 28107025567e706b5b18b20fe114a560c431ceafa32cdd3b1d198009ecdf2bef58e3eebb2e4eb3bc88f530a514faf08e
+    checksum: 28107025567e706b5b18b20fe114a560c431ceafa32cdd3b1d198009ecdf2bef58e3eebb2e4eb3bc88f530a514faf08e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16/driver-action-recognition-adas-0002-decoder.bin
   - name: FP16-INT8/driver-action-recognition-adas-0002-decoder.xml
     size: 344744
-    sha384: da322c036ff69ce0594564d9c5d44ff4578672feb24a8f22d5ac696d5ff45aac56d3bfab07fea639951b118bf016ba5e
+    checksum: da322c036ff69ce0594564d9c5d44ff4578672feb24a8f22d5ac696d5ff45aac56d3bfab07fea639951b118bf016ba5e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.xml
   - name: FP16-INT8/driver-action-recognition-adas-0002-decoder.bin
     size: 6905290
-    sha384: 7b0dccf383e21494a302cf2e40fde7d0ddeedd0963dcfd45a0fcc8e6a1e257f2e34525816a03633d86ac7314ace55b88
+    checksum: 7b0dccf383e21494a302cf2e40fde7d0ddeedd0963dcfd45a0fcc8e6a1e257f2e34525816a03633d86ac7314ace55b88
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-decoder/FP16-INT8/driver-action-recognition-adas-0002-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/model.yml
+++ b/models/intel/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/driver-action-recognition-adas-0002-encoder.xml
     size: 136693
-    sha384: a416c35e01f82f8f07fcbe61f42ca1863c9e448ff5225bb3b22d91f09b7163e544731597f37062dd5390ce40b07da3bb
+    checksum: a416c35e01f82f8f07fcbe61f42ca1863c9e448ff5225bb3b22d91f09b7163e544731597f37062dd5390ce40b07da3bb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.xml
   - name: FP32/driver-action-recognition-adas-0002-encoder.bin
     size: 11450776
-    sha384: 3f9d93fa74ad5618b58c4de02633ed3c17d242a61b3f6fdfed578be0f3b6b04f3601f2102835f7885c5c775e777aa4b8
+    checksum: 3f9d93fa74ad5618b58c4de02633ed3c17d242a61b3f6fdfed578be0f3b6b04f3601f2102835f7885c5c775e777aa4b8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP32/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16/driver-action-recognition-adas-0002-encoder.xml
     size: 136633
-    sha384: 9d29d08b9ddf34b21d6c9e38a6985c6c8eebd6fd76f1529727ca7ffe14ec872461f071cd68a3fde9de55638ba291d330
+    checksum: 9d29d08b9ddf34b21d6c9e38a6985c6c8eebd6fd76f1529727ca7ffe14ec872461f071cd68a3fde9de55638ba291d330
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16/driver-action-recognition-adas-0002-encoder.bin
     size: 5725388
-    sha384: bdf5d4e5340ff0c4ea76ed3d9883d3c513fd89c3d975f74cc79cafb77599ea56543d5ec214afeb3b64b967c80bd4337f
+    checksum: bdf5d4e5340ff0c4ea76ed3d9883d3c513fd89c3d975f74cc79cafb77599ea56543d5ec214afeb3b64b967c80bd4337f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16/driver-action-recognition-adas-0002-encoder.bin
   - name: FP16-INT8/driver-action-recognition-adas-0002-encoder.xml
     size: 394179
-    sha384: adef64bd51921e4c571048eb039ce692a3ecead945f5f5e80256b3a9045a0634c7314cf743ddcaa9bdad66ccf577a00b
+    checksum: adef64bd51921e4c571048eb039ce692a3ecead945f5f5e80256b3a9045a0634c7314cf743ddcaa9bdad66ccf577a00b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.xml
   - name: FP16-INT8/driver-action-recognition-adas-0002-encoder.bin
     size: 2960345
-    sha384: bb05153ae864307801f47e8e917a3ec29daa99fd2122d7913bb8e01ef876f9f83347b29922c3a2eb5cff5e80c5932960
+    checksum: bb05153ae864307801f47e8e917a3ec29daa99fd2122d7913bb8e01ef876f9f83347b29922c3a2eb5cff5e80c5932960
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/driver-action-recognition-adas-0002/driver-action-recognition-adas-0002-encoder/FP16-INT8/driver-action-recognition-adas-0002-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/emotions-recognition-retail-0003/model.yml
+++ b/models/intel/emotions-recognition-retail-0003/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/emotions-recognition-retail-0003.xml
     size: 40242
-    sha384: 09292370295354e17507f4e718b235a626680c39ee6be525656e3874d58a5e22f1a7acee55929515e5b98fcf3f8c2e08
+    checksum: 09292370295354e17507f4e718b235a626680c39ee6be525656e3874d58a5e22f1a7acee55929515e5b98fcf3f8c2e08
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.xml
   - name: FP32/emotions-recognition-retail-0003.bin
     size: 9930028
-    sha384: 56a7e92575a3f9fede0f18f9ebc6f1fe479a7b7f826b50917eb0bbfd484b3e65693be27f61e36e3459ffeff6a6a81d16
+    checksum: 56a7e92575a3f9fede0f18f9ebc6f1fe479a7b7f826b50917eb0bbfd484b3e65693be27f61e36e3459ffeff6a6a81d16
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP32/emotions-recognition-retail-0003.bin
   - name: FP16/emotions-recognition-retail-0003.xml
     size: 40225
-    sha384: af03286b3cd2faf978f7e69f65a9a4fe4004d517156c493334d3cf5e68be82d2a252c734b8f07d42f1a2c8a4c5358389
+    checksum: af03286b3cd2faf978f7e69f65a9a4fe4004d517156c493334d3cf5e68be82d2a252c734b8f07d42f1a2c8a4c5358389
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.xml
   - name: FP16/emotions-recognition-retail-0003.bin
     size: 4965014
-    sha384: 1fda2fff394cc6be6901465c793c93133faff98b1cbccd3f86869202961c9988ecb92a2fb7cef5a1ef6dd275808b65fa
+    checksum: 1fda2fff394cc6be6901465c793c93133faff98b1cbccd3f86869202961c9988ecb92a2fb7cef5a1ef6dd275808b65fa
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP16/emotions-recognition-retail-0003.bin
   - name: FP16-INT8/emotions-recognition-retail-0003.xml
     size: 113682
-    sha384: a66c2bd579ba8fa1d7c0608eff6f1cd565baab794e847f15e23a4f5b72d2bc7cc36e9ff8c3559ee17469859be4be86a8
+    checksum: a66c2bd579ba8fa1d7c0608eff6f1cd565baab794e847f15e23a4f5b72d2bc7cc36e9ff8c3559ee17469859be4be86a8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.xml
   - name: FP16-INT8/emotions-recognition-retail-0003.bin
     size: 2494126
-    sha384: 2cb63a32656e6af79b829e59142090fd47e4a9e6000fc2f6af2f3efdea372ffe2dbdbe54a044ec4adb66b52a806279c6
+    checksum: 2cb63a32656e6af79b829e59142090fd47e4a9e6000fc2f6af2f3efdea372ffe2dbdbe54a044ec4adb66b52a806279c6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/emotions-recognition-retail-0003/FP16-INT8/emotions-recognition-retail-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0200/model.yml
+++ b/models/intel/face-detection-0200/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0200.xml
     size: 200411
-    sha384: b1c92f28b68c3ca9d19dd5de0695c77707ae134cf4df7814e801a5b163d85fd31db636c63617a328e72f35fac22cbe80
+    checksum: b1c92f28b68c3ca9d19dd5de0695c77707ae134cf4df7814e801a5b163d85fd31db636c63617a328e72f35fac22cbe80
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP32/face-detection-0200.xml
   - name: FP32/face-detection-0200.bin
     size: 7269168
-    sha384: 1fdad850782a96eb0453114ec3cd7a4ec5df570d365a07bb85738a2ed1382382abed2e88139a921d1767746ad1b21e2e
+    checksum: 1fdad850782a96eb0453114ec3cd7a4ec5df570d365a07bb85738a2ed1382382abed2e88139a921d1767746ad1b21e2e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP32/face-detection-0200.bin
   - name: FP16/face-detection-0200.xml
     size: 200348
-    sha384: a0bb49fed1d17ca37e28afe464805271b98e91b07056ac59df06c9084655ca092f641a45f635826ec4f8544f94ec34d6
+    checksum: a0bb49fed1d17ca37e28afe464805271b98e91b07056ac59df06c9084655ca092f641a45f635826ec4f8544f94ec34d6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP16/face-detection-0200.xml
   - name: FP16/face-detection-0200.bin
     size: 3634626
-    sha384: 5022a82f68787a6199e7fbf36fd8b1930f7c3d418cbde818b65e38adad77db43154cad6157ae87ec408ac1f71db08d44
+    checksum: 5022a82f68787a6199e7fbf36fd8b1930f7c3d418cbde818b65e38adad77db43154cad6157ae87ec408ac1f71db08d44
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP16/face-detection-0200.bin
   - name: FP16-INT8/face-detection-0200.xml
     size: 482487
-    sha384: 9ab49d9e7f29ca562a8074563f62714085d627fcea9625e8a1deca1a70eb052939c99870bcc06e0ef32b8ef6504355b7
+    checksum: 9ab49d9e7f29ca562a8074563f62714085d627fcea9625e8a1deca1a70eb052939c99870bcc06e0ef32b8ef6504355b7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP16-INT8/face-detection-0200.xml
   - name: FP16-INT8/face-detection-0200.bin
     size: 1921614
-    sha384: b7f8469657e300265d068e551efb56a8bb762df94c3d0df14af0cdceff296f040325d037430a12326c2d5172e1d41d0f
+    checksum: b7f8469657e300265d068e551efb56a8bb762df94c3d0df14af0cdceff296f040325d037430a12326c2d5172e1d41d0f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0200/FP16-INT8/face-detection-0200.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0202/model.yml
+++ b/models/intel/face-detection-0202/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0202.xml
     size: 200594
-    sha384: 4aa6a03972c4e0dec8c1db810b7d7e0fc9e305d2664d0763a9a800bbd4495b2bd5bb65681d7b44ab632b11369da7de34
+    checksum: 4aa6a03972c4e0dec8c1db810b7d7e0fc9e305d2664d0763a9a800bbd4495b2bd5bb65681d7b44ab632b11369da7de34
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP32/face-detection-0202.xml
   - name: FP32/face-detection-0202.bin
     size: 7269168
-    sha384: 5c1ad0d39f76f7b3b0ca65619ffc09e673dda95f4c173cc62bf71f7d7b6fc9bbe32d5ab0297e7688ec830f9a1694d201
+    checksum: 5c1ad0d39f76f7b3b0ca65619ffc09e673dda95f4c173cc62bf71f7d7b6fc9bbe32d5ab0297e7688ec830f9a1694d201
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP32/face-detection-0202.bin
   - name: FP16/face-detection-0202.xml
     size: 200531
-    sha384: 3853adb33376ec74ea869dac16d2a63e16f3a8929b6e0df781607cbb07bb8f56a2a8929394e4ae0db243729e0cb24657
+    checksum: 3853adb33376ec74ea869dac16d2a63e16f3a8929b6e0df781607cbb07bb8f56a2a8929394e4ae0db243729e0cb24657
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP16/face-detection-0202.xml
   - name: FP16/face-detection-0202.bin
     size: 3634626
-    sha384: dd1b4361bceb05db54e4237227d0ebef5ec0add8965a9ca15e3f42391a1d0c8832dfa70d67708d4773d81db2e789a9a1
+    checksum: dd1b4361bceb05db54e4237227d0ebef5ec0add8965a9ca15e3f42391a1d0c8832dfa70d67708d4773d81db2e789a9a1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP16/face-detection-0202.bin
   - name: FP16-INT8/face-detection-0202.xml
     size: 482719
-    sha384: ad953355f5762581c8fe44aa7d9abec364160df81bda67885b4d43d6a64d3fcf5cb788682909c36f462e92515b4f13ea
+    checksum: ad953355f5762581c8fe44aa7d9abec364160df81bda67885b4d43d6a64d3fcf5cb788682909c36f462e92515b4f13ea
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP16-INT8/face-detection-0202.xml
   - name: FP16-INT8/face-detection-0202.bin
     size: 1921614
-    sha384: ea74f45a5b7baa2319a27f9f33548eeca7da8a87c672fc654775581d36ba983ae2dc843c0e5eeca79bfb654201b61ad7
+    checksum: ea74f45a5b7baa2319a27f9f33548eeca7da8a87c672fc654775581d36ba983ae2dc843c0e5eeca79bfb654201b61ad7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0202/FP16-INT8/face-detection-0202.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0204/model.yml
+++ b/models/intel/face-detection-0204/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0204.xml
     size: 200681
-    sha384: 987937ef2c5a1bc1daadd8f933d4353e47de17f4df926d94c11048f3a3ded74c7fc3a38f09346ca6ce121b933f55c39e
+    checksum: 987937ef2c5a1bc1daadd8f933d4353e47de17f4df926d94c11048f3a3ded74c7fc3a38f09346ca6ce121b933f55c39e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP32/face-detection-0204.xml
   - name: FP32/face-detection-0204.bin
     size: 7269168
-    sha384: 127b95a9b31b39bbd3b270b86317c2aec1658cfcdfbd2a4ddadb2aed97abfb3e43d10280a7f3f5323505ffa5c7b12b7c
+    checksum: 127b95a9b31b39bbd3b270b86317c2aec1658cfcdfbd2a4ddadb2aed97abfb3e43d10280a7f3f5323505ffa5c7b12b7c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP32/face-detection-0204.bin
   - name: FP16/face-detection-0204.xml
     size: 200618
-    sha384: ebf0bad4f1862c41c4bf895edd264308e354669bfc1e53f3b99a3242c3584e03373b0b3264957f4bf9d6edd76f8090e0
+    checksum: ebf0bad4f1862c41c4bf895edd264308e354669bfc1e53f3b99a3242c3584e03373b0b3264957f4bf9d6edd76f8090e0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP16/face-detection-0204.xml
   - name: FP16/face-detection-0204.bin
     size: 3634626
-    sha384: b64bc1c04bfdf6308128c6c351f0f884e55f65d9a88f920bce39c34010291f0664730cdfce378e4dd7680ae3aae9fe8f
+    checksum: b64bc1c04bfdf6308128c6c351f0f884e55f65d9a88f920bce39c34010291f0664730cdfce378e4dd7680ae3aae9fe8f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP16/face-detection-0204.bin
   - name: FP16-INT8/face-detection-0204.xml
     size: 482845
-    sha384: 44db0a902531320d5837b5d03c13e4fe241c79de5f993a659ef14a9584a427506eb6be326943f60ce3f5ed8e6e32fcb9
+    checksum: 44db0a902531320d5837b5d03c13e4fe241c79de5f993a659ef14a9584a427506eb6be326943f60ce3f5ed8e6e32fcb9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP16-INT8/face-detection-0204.xml
   - name: FP16-INT8/face-detection-0204.bin
     size: 1921614
-    sha384: 4c6e712c5a64ca7740add8fb69b9f78508315d6ec6adfafc3e5db7e87d40bf1771c8e080128664ba48a609a7512bbf23
+    checksum: 4c6e712c5a64ca7740add8fb69b9f78508315d6ec6adfafc3e5db7e87d40bf1771c8e080128664ba48a609a7512bbf23
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0204/FP16-INT8/face-detection-0204.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0205/model.yml
+++ b/models/intel/face-detection-0205/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0205.xml
     size: 1014512
-    sha384: d63e119e1f4c0ade7170a7a27d929edc85a19ba64dd5f33f8e4d73516e3fbef2b5ebe3c2934d29f4c022b4116ddd749d
+    checksum: d63e119e1f4c0ade7170a7a27d929edc85a19ba64dd5f33f8e4d73516e3fbef2b5ebe3c2934d29f4c022b4116ddd749d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP32/face-detection-0205.xml
   - name: FP32/face-detection-0205.bin
     size: 8049904
-    sha384: 65b98ab457edc1d16c3771d37e51ea63071c7a6aaf90a34cda21dd3db0907842ca5d12863d1039fb739a4a395190c1e0
+    checksum: 65b98ab457edc1d16c3771d37e51ea63071c7a6aaf90a34cda21dd3db0907842ca5d12863d1039fb739a4a395190c1e0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP32/face-detection-0205.bin
   - name: FP16/face-detection-0205.xml
     size: 1014350
-    sha384: 36de1030a33297a599c22d909b773ab754cca1937cda81aa887fc613d1ad9c0ea3f574410183a654c06798fe273507b2
+    checksum: 36de1030a33297a599c22d909b773ab754cca1937cda81aa887fc613d1ad9c0ea3f574410183a654c06798fe273507b2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP16/face-detection-0205.xml
   - name: FP16/face-detection-0205.bin
     size: 4025142
-    sha384: 835e238dc25f56db0edbc9a980385945aa42102834474ce4fa30c763773e994792ae8816b1099455d0589265ed79fb94
+    checksum: 835e238dc25f56db0edbc9a980385945aa42102834474ce4fa30c763773e994792ae8816b1099455d0589265ed79fb94
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP16/face-detection-0205.bin
   - name: FP16-INT8/face-detection-0205.xml
     size: 1587154
-    sha384: 482286808ef08cdf6a2167f93d57626f835eec069a6a632bbadcb5a4b675dbe213e4a3f2c1943fb27b618e1fc657d80b
+    checksum: 482286808ef08cdf6a2167f93d57626f835eec069a6a632bbadcb5a4b675dbe213e4a3f2c1943fb27b618e1fc657d80b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP16-INT8/face-detection-0205.xml
   - name: FP16-INT8/face-detection-0205.bin
     size: 2115162
-    sha384: ebc0f89e3002249a2c694d1651cc9e3f0b69cead44a084b44c114da304b0c16623305d69588a98be64a017d6ba218fe9
+    checksum: ebc0f89e3002249a2c694d1651cc9e3f0b69cead44a084b44c114da304b0c16623305d69588a98be64a017d6ba218fe9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0205/FP16-INT8/face-detection-0205.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-0206/model.yml
+++ b/models/intel/face-detection-0206/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-0206.xml
     size: 1594752
-    sha384: 83067775530c1267b42373f71ab35a3fd869914fa7caf6fb630cdb1114894dad6c24d01ee4b31888eec856871707a588
+    checksum: 83067775530c1267b42373f71ab35a3fd869914fa7caf6fb630cdb1114894dad6c24d01ee4b31888eec856871707a588
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP32/face-detection-0206.xml
   - name: FP32/face-detection-0206.bin
     size: 254925016
-    sha384: 81df9f2e3c3fd2d847493badc23cb14a4ac942117eb5cc7c75f40837596bec201d8c7e0f14b0e12e2f972995a7c25104
+    checksum: 81df9f2e3c3fd2d847493badc23cb14a4ac942117eb5cc7c75f40837596bec201d8c7e0f14b0e12e2f972995a7c25104
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP32/face-detection-0206.bin
   - name: FP16/face-detection-0206.xml
     size: 1594263
-    sha384: 9db10e1f0dd048015e4fe6f29d7ceb593c73bc6001e3caa5758ba2e2fcdb1fc82cd38c508faf00144cea000a91b146d8
+    checksum: 9db10e1f0dd048015e4fe6f29d7ceb593c73bc6001e3caa5758ba2e2fcdb1fc82cd38c508faf00144cea000a91b146d8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP16/face-detection-0206.xml
   - name: FP16/face-detection-0206.bin
     size: 127462762
-    sha384: 1482a9a716ea59bc7e5012cb69fa2cc7816335824db3bc9c7fbabb4f1c83a2ded6cc949eddd082a434c54673b68a5c42
+    checksum: 1482a9a716ea59bc7e5012cb69fa2cc7816335824db3bc9c7fbabb4f1c83a2ded6cc949eddd082a434c54673b68a5c42
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP16/face-detection-0206.bin
   - name: FP16-INT8/face-detection-0206.xml
     size: 2686695
-    sha384: ad03805146bfa9be98f7e1ebd88c6620909fcb13ddca449f6d77171721b115cbe62cea4acd5e1defecac7487bd2d29cc
+    checksum: ad03805146bfa9be98f7e1ebd88c6620909fcb13ddca449f6d77171721b115cbe62cea4acd5e1defecac7487bd2d29cc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP16-INT8/face-detection-0206.xml
   - name: FP16-INT8/face-detection-0206.bin
     size: 64135662
-    sha384: 750bb017c98230319b1885ebeb93efe23875a71249cc070205066646699849ef9b38f3253159f828a65eed9f816c2842
+    checksum: 750bb017c98230319b1885ebeb93efe23875a71249cc070205066646699849ef9b38f3253159f828a65eed9f816c2842
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-0206/FP16-INT8/face-detection-0206.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-adas-0001/model.yml
+++ b/models/intel/face-detection-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-adas-0001.xml
     size: 237086
-    sha384: 92a8608d18260929ca070a6d27cb0b8c606e22d9b9baff002efad778ff7a65a5996679b6699fe88816d237003e6146bc
+    checksum: 92a8608d18260929ca070a6d27cb0b8c606e22d9b9baff002efad778ff7a65a5996679b6699fe88816d237003e6146bc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP32/face-detection-adas-0001.xml
   - name: FP32/face-detection-adas-0001.bin
     size: 4212072
-    sha384: cfdfcc6163881b3b18dc1c4b5cbcbb4cf3f2f224502972fd8c409f13bb7c6c193bdd8c01fe8fcba92305e4e2c84e39c6
+    checksum: cfdfcc6163881b3b18dc1c4b5cbcbb4cf3f2f224502972fd8c409f13bb7c6c193bdd8c01fe8fcba92305e4e2c84e39c6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP32/face-detection-adas-0001.bin
   - name: FP16/face-detection-adas-0001.xml
     size: 237050
-    sha384: 417a5a690ddf1ced27dbec6e7005ff365ff5ad77f4c92511a17bee20ee9ffef737640e3c3ee267e4c5ab2344c09c8662
+    checksum: 417a5a690ddf1ced27dbec6e7005ff365ff5ad77f4c92511a17bee20ee9ffef737640e3c3ee267e4c5ab2344c09c8662
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP16/face-detection-adas-0001.xml
   - name: FP16/face-detection-adas-0001.bin
     size: 2106088
-    sha384: e5948d9a9df622432eefcc41ed2fb59bf9fcb7067f17857030ae1a542ad7e8cab270e14ab808f943ea9cdb14c2cd8b47
+    checksum: e5948d9a9df622432eefcc41ed2fb59bf9fcb7067f17857030ae1a542ad7e8cab270e14ab808f943ea9cdb14c2cd8b47
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP16/face-detection-adas-0001.bin
   - name: FP16-INT8/face-detection-adas-0001.xml
     size: 510708
-    sha384: 8f8adb032cf4063e9bfc273e3247a2efc4c0c0e62537338eeeccee7314c3e28e93da071172f842a73edcb47d8bfb6094
+    checksum: 8f8adb032cf4063e9bfc273e3247a2efc4c0c0e62537338eeeccee7314c3e28e93da071172f842a73edcb47d8bfb6094
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.xml
   - name: FP16-INT8/face-detection-adas-0001.bin
     size: 1100294
-    sha384: 4ca7ffd713eb41a6c2ec00f35546f0531becde569f00da8ffae322a686a6d7033210b24e8ae364fabc8476c601ed3dc2
+    checksum: 4ca7ffd713eb41a6c2ec00f35546f0531becde569f00da8ffae322a686a6d7033210b24e8ae364fabc8476c601ed3dc2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-adas-0001/FP16-INT8/face-detection-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0004/model.yml
+++ b/models/intel/face-detection-retail-0004/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-retail-0004.xml
     size: 106213
-    sha384: 587b43da22f343a0e8ad1b3d5c33b830634d5aabdeb65963348ea4cb8b0c7f631c396f00c4f0bb439df45b76d56761bd
+    checksum: 587b43da22f343a0e8ad1b3d5c33b830634d5aabdeb65963348ea4cb8b0c7f631c396f00c4f0bb439df45b76d56761bd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP32/face-detection-retail-0004.xml
   - name: FP32/face-detection-retail-0004.bin
     size: 2352984
-    sha384: a2b4fa6dc07a37fb70d3ff11c207e19c167d45b6db5392e7e759b924df8ce16dbcdb8edff682c38820cc2e54bf6fdabf
+    checksum: a2b4fa6dc07a37fb70d3ff11c207e19c167d45b6db5392e7e759b924df8ce16dbcdb8edff682c38820cc2e54bf6fdabf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP32/face-detection-retail-0004.bin
   - name: FP16/face-detection-retail-0004.xml
     size: 106171
-    sha384: 69ad248e0009c95390806353b51d6e38eac28b7c8b199894e35b9d0572444f01682c3023926ff26d9db5e7a253864cf6
+    checksum: 69ad248e0009c95390806353b51d6e38eac28b7c8b199894e35b9d0572444f01682c3023926ff26d9db5e7a253864cf6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP16/face-detection-retail-0004.xml
   - name: FP16/face-detection-retail-0004.bin
     size: 1176544
-    sha384: 6d5482c9b4dbdc2a418c8a410138a8f64421af5c10bc6a52ee5246a2aa4db20b9374f2d50926613179fcd0411ef1b997
+    checksum: 6d5482c9b4dbdc2a418c8a410138a8f64421af5c10bc6a52ee5246a2aa4db20b9374f2d50926613179fcd0411ef1b997
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP16/face-detection-retail-0004.bin
   - name: FP16-INT8/face-detection-retail-0004.xml
     size: 240650
-    sha384: 2c0402ce952bdeed54de08d3e83ab378b9594779ec572df9865fc070ea8507baf3fb093d74686e800796468edcb037ff
+    checksum: 2c0402ce952bdeed54de08d3e83ab378b9594779ec572df9865fc070ea8507baf3fb093d74686e800796468edcb037ff
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.xml
   - name: FP16-INT8/face-detection-retail-0004.bin
     size: 600348
-    sha384: 1d531929c56712651b5b9d5b1c746d610b40200202a6055705487ea64a7a09655f9b243b29486dc5d8088fde84919ac2
+    checksum: 1d531929c56712651b5b9d5b1c746d610b40200202a6055705487ea64a7a09655f9b243b29486dc5d8088fde84919ac2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0004/FP16-INT8/face-detection-retail-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-detection-retail-0005/model.yml
+++ b/models/intel/face-detection-retail-0005/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/face-detection-retail-0005.xml
     size: 170193
-    sha384: 1f8bee41bedba141fdc6a3f4f9baf411a62bfd43ad788182ecc6c9c0ad227822b32df4af64b31e665b3cc399902b9c36
+    checksum: 1f8bee41bedba141fdc6a3f4f9baf411a62bfd43ad788182ecc6c9c0ad227822b32df4af64b31e665b3cc399902b9c36
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP32/face-detection-retail-0005.xml
   - name: FP32/face-detection-retail-0005.bin
     size: 4083112
-    sha384: 3d5721ecb874fe0cad5f743d4619157652c998376bd8761acd59b603ab643e008e2d903ebc348eb011a63bdcf914eb81
+    checksum: 3d5721ecb874fe0cad5f743d4619157652c998376bd8761acd59b603ab643e008e2d903ebc348eb011a63bdcf914eb81
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP32/face-detection-retail-0005.bin
   - name: FP16/face-detection-retail-0005.xml
     size: 170112
-    sha384: a54b36bc02f8038acf6b315acb5d4a1abaf8c5b43d9723c921ea3e94436d056a8d6f152618cc9d80ea0a2270cbfa069e
+    checksum: a54b36bc02f8038acf6b315acb5d4a1abaf8c5b43d9723c921ea3e94436d056a8d6f152618cc9d80ea0a2270cbfa069e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP16/face-detection-retail-0005.xml
   - name: FP16/face-detection-retail-0005.bin
     size: 2041598
-    sha384: da282530f1e8a72352b14cb8dd04a38e3cc160f5f6962fb17856ab62f18951f5a65302355a913cb59e97f71e8070b022
+    checksum: da282530f1e8a72352b14cb8dd04a38e3cc160f5f6962fb17856ab62f18951f5a65302355a913cb59e97f71e8070b022
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP16/face-detection-retail-0005.bin
   - name: FP16-INT8/face-detection-retail-0005.xml
     size: 434088
-    sha384: 99f3278ce19b8aef23b27b3c2be928bef05a1675a13dd1d4822d8bb399d09c2514bf174b3d0da2111bc8158d00a3a990
+    checksum: 99f3278ce19b8aef23b27b3c2be928bef05a1675a13dd1d4822d8bb399d09c2514bf174b3d0da2111bc8158d00a3a990
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.xml
   - name: FP16-INT8/face-detection-retail-0005.bin
     size: 1098786
-    sha384: c27e650835f6f7d65c4479de791e248522439ad8487c1335499de3867b34cda198dd3f3c62ae5a11cad004c5adc0d9a6
+    checksum: c27e650835f6f7d65c4479de791e248522439ad8487c1335499de3867b34cda198dd3f3c62ae5a11cad004c5adc0d9a6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-detection-retail-0005/FP16-INT8/face-detection-retail-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/face-reidentification-retail-0095/model.yml
+++ b/models/intel/face-reidentification-retail-0095/model.yml
@@ -18,27 +18,27 @@ task_type: face_recognition
 files:
   - name: FP32/face-reidentification-retail-0095.xml
     size: 239537
-    sha384: 5fb73d37f374df3a79f1cd97db5eac4defef7c6cbddfd43de75d06cc4b7a74f63625502219056f828b347a9ba8eb5029
+    checksum: 5fb73d37f374df3a79f1cd97db5eac4defef7c6cbddfd43de75d06cc4b7a74f63625502219056f828b347a9ba8eb5029
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.xml
   - name: FP32/face-reidentification-retail-0095.bin
     size: 4427256
-    sha384: b8ddd842ded8f4113e914beab115956ecf8d7970662804a89157437d8cec5a8f2adb11ed290dc914a7da5872312355d9
+    checksum: b8ddd842ded8f4113e914beab115956ecf8d7970662804a89157437d8cec5a8f2adb11ed290dc914a7da5872312355d9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP32/face-reidentification-retail-0095.bin
   - name: FP16/face-reidentification-retail-0095.xml
     size: 239433
-    sha384: 3aca3d2b1b6eaba2918a826694cc9f32bafe9cb90f74b86a6ad3944e5a5fbdb2a18430bd3eeb2131e5c65c4034083e2a
+    checksum: 3aca3d2b1b6eaba2918a826694cc9f32bafe9cb90f74b86a6ad3944e5a5fbdb2a18430bd3eeb2131e5c65c4034083e2a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.xml
   - name: FP16/face-reidentification-retail-0095.bin
     size: 2213724
-    sha384: 5f720826829ec5cea65c2eea89b5a72563c50ac640d28f0d50558799f698d0ce5e64b2d9b24223228178319e695b187f
+    checksum: 5f720826829ec5cea65c2eea89b5a72563c50ac640d28f0d50558799f698d0ce5e64b2d9b24223228178319e695b187f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP16/face-reidentification-retail-0095.bin
   - name: FP16-INT8/face-reidentification-retail-0095.xml
     size: 658847
-    sha384: e14af86f962fdef392ad06a9b93c6d80fa3d875b9526bc2c99702527e78518b463c546039c2f2f6ff73bcd740c704f04
+    checksum: e14af86f962fdef392ad06a9b93c6d80fa3d875b9526bc2c99702527e78518b463c546039c2f2f6ff73bcd740c704f04
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.xml
   - name: FP16-INT8/face-reidentification-retail-0095.bin
     size: 1180982
-    sha384: a30f1859e44ddd77b214fb1152014e2bbe90410475397453d04ba53f2ed7dd40401a715a8ff24b77b3e804728a50d437
+    checksum: a30f1859e44ddd77b214fb1152014e2bbe90410475397453d04ba53f2ed7dd40401a715a8ff24b77b3e804728a50d437
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/face-reidentification-retail-0095/FP16-INT8/face-reidentification-retail-0095.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/facial-landmarks-35-adas-0002/model.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/facial-landmarks-35-adas-0002.xml
     size: 253710
-    sha384: 2623123fbf26e4674edcdf48d5c02408a227743c1e53b20739d227af3267c3de82755cfc22247ea9e7cf0c9dcaa5de65
+    checksum: 2623123fbf26e4674edcdf48d5c02408a227743c1e53b20739d227af3267c3de82755cfc22247ea9e7cf0c9dcaa5de65
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.xml
   - name: FP32/facial-landmarks-35-adas-0002.bin
     size: 18381152
-    sha384: e06715dd84385b0446815afb60cc4bc0dabbcef38deef7ff9cd932c1ca7c39f13d56edeec43ec35c74ca362157101d05
+    checksum: e06715dd84385b0446815afb60cc4bc0dabbcef38deef7ff9cd932c1ca7c39f13d56edeec43ec35c74ca362157101d05
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP32/facial-landmarks-35-adas-0002.bin
   - name: FP16/facial-landmarks-35-adas-0002.xml
     size: 253573
-    sha384: 6a830e86933ec0c2c6f4dad6f617f8ea1471a04aa8eb622c3059cc964c9f5ba17bb6e414ea5db53889ef849555167ffe
+    checksum: 6a830e86933ec0c2c6f4dad6f617f8ea1471a04aa8eb622c3059cc964c9f5ba17bb6e414ea5db53889ef849555167ffe
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.xml
   - name: FP16/facial-landmarks-35-adas-0002.bin
     size: 9190584
-    sha384: 4cca57a4f6ccf8d3b2a7eb6f20ddb14848c21a7e1a264ccae5f17720d29aed3445c8752d00e9bd9a8d8b27979e010727
+    checksum: 4cca57a4f6ccf8d3b2a7eb6f20ddb14848c21a7e1a264ccae5f17720d29aed3445c8752d00e9bd9a8d8b27979e010727
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP16/facial-landmarks-35-adas-0002.bin
   - name: FP16-INT8/facial-landmarks-35-adas-0002.xml
     size: 628613
-    sha384: 12f52a898c0c7614c37205fc67186b8831704945ae28c00174545e42f94048725df2f7cd0c263f92929c869ad89443d7
+    checksum: 12f52a898c0c7614c37205fc67186b8831704945ae28c00174545e42f94048725df2f7cd0c263f92929c869ad89443d7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.xml
   - name: FP16-INT8/facial-landmarks-35-adas-0002.bin
     size: 4634172
-    sha384: 8a8e5e1c97fbeaa4bb635ca549ce82491e1780e5ce92c55762e630f72b816535d5e5ef0139c453da9aa32fdb5881eebc
+    checksum: 8a8e5e1c97fbeaa4bb635ca549ce82491e1780e5ce92c55762e630f72b816535d5e5ef0139c453da9aa32fdb5881eebc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/facial-landmarks-35-adas-0002/FP16-INT8/facial-landmarks-35-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/model.yml
+++ b/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 351050
-    sha384: fa224f29e51134564aab1cb4124db054540efcfba0bcfb4aee5b9aab0534233a893c629a81d1c3bb83d1c4edd0e3ee32
+    checksum: fa224f29e51134564aab1cb4124db054540efcfba0bcfb4aee5b9aab0534233a893c629a81d1c3bb83d1c4edd0e3ee32
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP32/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 211169988
-    sha384: 521b2177e450f204994bb655d454bb9b4dd619080fe6bb3b9207d81443c78a9f2bee613d4ff2811eb18c8eb3be6a5f58
+    checksum: 521b2177e450f204994bb655d454bb9b4dd619080fe6bb3b9207d81443c78a9f2bee613d4ff2811eb18c8eb3be6a5f58
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP32/faster-rcnn-resnet101-coco-sparse-60-0001.bin
   - name: FP16/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 350890
-    sha384: 6e3fe4ae275ffaeb06b05f27c0906b352dcc5adf3cf7704187d7f1206581245b26dce3a18154f2f0ff85f9aa7864c138
+    checksum: 6e3fe4ae275ffaeb06b05f27c0906b352dcc5adf3cf7704187d7f1206581245b26dce3a18154f2f0ff85f9aa7864c138
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP16/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 105585134
-    sha384: ffe322db6d6b094a0d35d1a2b5e1bb702cbf9c7e10bd5db972181031637508283b8e2517883810599d18efd5f648a73e
+    checksum: ffe322db6d6b094a0d35d1a2b5e1bb702cbf9c7e10bd5db972181031637508283b8e2517883810599d18efd5f648a73e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16/faster-rcnn-resnet101-coco-sparse-60-0001.bin
   - name: FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.xml
     size: 871790
-    sha384: 475c8b9827e0372c552f3097e623cd5bcc566d32a44749e276d5f5685986989d93f0f600220d2d53caa8dc7a14564049
+    checksum: 475c8b9827e0372c552f3097e623cd5bcc566d32a44749e276d5f5685986989d93f0f600220d2d53caa8dc7a14564049
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.xml
   - name: FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.bin
     size: 54722851
-    sha384: b03d8f11bc52c87ed33ee41dc1adf20c9629ee9ee5fc4fe6a53176842092d9496f6fdab85dfb3087d6998a68a3b17113
+    checksum: b03d8f11bc52c87ed33ee41dc1adf20c9629ee9ee5fc4fe6a53176842092d9496f6fdab85dfb3087d6998a68a3b17113
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/faster-rcnn-resnet101-coco-sparse-60-0001/FP16-INT8/faster-rcnn-resnet101-coco-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/model.yml
+++ b/models/intel/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/model.yml
@@ -18,19 +18,19 @@ task_type: token_recognition
 files:
   - name: FP32/formula-recognition-medium-scan-0001-im2latex-decoder.xml
     size: 52273
-    sha384: c85fe0474e982d407c5272e1ac3be660210e6b873fc7c35aacd8a600d107d523b29c5a9cbeb543f2d15c1b8554f2c77a
+    checksum: c85fe0474e982d407c5272e1ac3be660210e6b873fc7c35aacd8a600d107d523b29c5a9cbeb543f2d15c1b8554f2c77a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/FP32/formula-recognition-medium-scan-0001-im2latex-decoder.xml
   - name: FP32/formula-recognition-medium-scan-0001-im2latex-decoder.bin
     size: 10252352
-    sha384: 175b85d7a3b59085d64d7c0212450a51506baad1b3e9dc71dd873b1ea419e88fc4936c9b3440a4fa7b2c671ed867ea8b
+    checksum: 175b85d7a3b59085d64d7c0212450a51506baad1b3e9dc71dd873b1ea419e88fc4936c9b3440a4fa7b2c671ed867ea8b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/FP32/formula-recognition-medium-scan-0001-im2latex-decoder.bin
   - name: FP16/formula-recognition-medium-scan-0001-im2latex-decoder.xml
     size: 52265
-    sha384: c88c163d52942c041c9b3ff6296a9c0b0f480a52fd34fcddce5e731fde2552b6a9b3da218f565987bec6a8ecce1021be
+    checksum: c88c163d52942c041c9b3ff6296a9c0b0f480a52fd34fcddce5e731fde2552b6a9b3da218f565987bec6a8ecce1021be
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/FP16/formula-recognition-medium-scan-0001-im2latex-decoder.xml
   - name: FP16/formula-recognition-medium-scan-0001-im2latex-decoder.bin
     size: 5126230
-    sha384: 2dc1387f2418b4319150e7bdc73295f20eaa07639fe6a333fc3c1a918809bdec014ac024ca38cd5ce94c7840dd4677f9
+    checksum: 2dc1387f2418b4319150e7bdc73295f20eaa07639fe6a333fc3c1a918809bdec014ac024ca38cd5ce94c7840dd4677f9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-decoder/FP16/formula-recognition-medium-scan-0001-im2latex-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/model.yml
+++ b/models/intel/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/model.yml
@@ -18,19 +18,19 @@ task_type: feature_extraction
 files:
   - name: FP32/formula-recognition-medium-scan-0001-im2latex-encoder.xml
     size: 146030
-    sha384: f42e07b17dc5f3534a70d5f9de2955a2511555c2224022e22aeb7b377de7f23b3cb23f74077bc38496ab1f9f7e1dd01f
+    checksum: f42e07b17dc5f3534a70d5f9de2955a2511555c2224022e22aeb7b377de7f23b3cb23f74077bc38496ab1f9f7e1dd01f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/FP32/formula-recognition-medium-scan-0001-im2latex-encoder.xml
   - name: FP32/formula-recognition-medium-scan-0001-im2latex-encoder.bin
     size: 12977368
-    sha384: 61dbff7af6f4f2d8531b6b9ff3e73de42d0ee3d1dca9720d4f6f7be250a91a5b558c51651bfedd21c620f8b494a56b89
+    checksum: 61dbff7af6f4f2d8531b6b9ff3e73de42d0ee3d1dca9720d4f6f7be250a91a5b558c51651bfedd21c620f8b494a56b89
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/FP32/formula-recognition-medium-scan-0001-im2latex-encoder.bin
   - name: FP16/formula-recognition-medium-scan-0001-im2latex-encoder.xml
     size: 145988
-    sha384: 7023c8ac8635a330667a41a951cdf918f7b3c9810ce9b3a470659d9c4351e21a1b8dd5d02d4df0f350759aa22dce359f
+    checksum: 7023c8ac8635a330667a41a951cdf918f7b3c9810ce9b3a470659d9c4351e21a1b8dd5d02d4df0f350759aa22dce359f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/FP16/formula-recognition-medium-scan-0001-im2latex-encoder.xml
   - name: FP16/formula-recognition-medium-scan-0001-im2latex-encoder.bin
     size: 6488792
-    sha384: d50979f19c6d08158262feb9cdf5cf9f4998b76024539bb9d38c4dc56e78ec1ad468441539df924f5865cd198dd9c97c
+    checksum: d50979f19c6d08158262feb9cdf5cf9f4998b76024539bb9d38c4dc56e78ec1ad468441539df924f5865cd198dd9c97c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-medium-scan-0001/formula-recognition-medium-scan-0001-im2latex-encoder/FP16/formula-recognition-medium-scan-0001-im2latex-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/model.yml
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/model.yml
@@ -18,19 +18,19 @@ task_type: token_recognition
 files:
   - name: FP32/formula-recognition-polynomials-handwritten-0001-decoder.xml
     size: 52326
-    sha384: d6e022c6da5e904909a5d90e837c8146097e0a5dfaad538e1946c3302b7dedd0ee3f641ec4c6bc0cf0e48b4c5a86fa54
+    checksum: d6e022c6da5e904909a5d90e837c8146097e0a5dfaad538e1946c3302b7dedd0ee3f641ec4c6bc0cf0e48b4c5a86fa54
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/FP32/formula-recognition-polynomials-handwritten-0001-decoder.xml
   - name: FP32/formula-recognition-polynomials-handwritten-0001-decoder.bin
     size: 10179560
-    sha384: 46d3bf27ea023ebfdfe0a72203cd44a7dd309f61be102b432f5a6cca8ec2a3d66dc2475798ccb594a5f1575ef6cbf637
+    checksum: 46d3bf27ea023ebfdfe0a72203cd44a7dd309f61be102b432f5a6cca8ec2a3d66dc2475798ccb594a5f1575ef6cbf637
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/FP32/formula-recognition-polynomials-handwritten-0001-decoder.bin
   - name: FP16/formula-recognition-polynomials-handwritten-0001-decoder.xml
     size: 52317
-    sha384: 9f0b86226cd4c6a96a907f7286b0e7573a59a36c72a4206bea8cc4933c8e17aaa17f98594ee55b960a86384c80cf1b4c
+    checksum: 9f0b86226cd4c6a96a907f7286b0e7573a59a36c72a4206bea8cc4933c8e17aaa17f98594ee55b960a86384c80cf1b4c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/FP16/formula-recognition-polynomials-handwritten-0001-decoder.xml
   - name: FP16/formula-recognition-polynomials-handwritten-0001-decoder.bin
     size: 5089834
-    sha384: 187b5050f693a025aa79e744932b9c195ebedd213e7f3373db08fac15f496d7d2c5a62b7cbc594303e9c43eb3c4ab4bb
+    checksum: 187b5050f693a025aa79e744932b9c195ebedd213e7f3373db08fac15f496d7d2c5a62b7cbc594303e9c43eb3c4ab4bb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-decoder/FP16/formula-recognition-polynomials-handwritten-0001-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/model.yml
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/model.yml
@@ -18,19 +18,19 @@ task_type: feature_extraction
 files:
   - name: FP32/formula-recognition-polynomials-handwritten-0001-encoder.xml
     size: 197976
-    sha384: 94f1499996ab33bd57e571dc7c6d6666a59e073cb7ff9051a7892e0b85545d6c4e412bb3952ae4291ce860ba229e530a
+    checksum: 94f1499996ab33bd57e571dc7c6d6666a59e073cb7ff9051a7892e0b85545d6c4e412bb3952ae4291ce860ba229e530a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/FP32/formula-recognition-polynomials-handwritten-0001-encoder.xml
   - name: FP32/formula-recognition-polynomials-handwritten-0001-encoder.bin
     size: 45208792
-    sha384: fb2d2067fcfb778908551e440191b89270f137d68d81e55f3ddfbb20283cccf0275d58e4314af910abdef8c9b0908e1d
+    checksum: fb2d2067fcfb778908551e440191b89270f137d68d81e55f3ddfbb20283cccf0275d58e4314af910abdef8c9b0908e1d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/FP32/formula-recognition-polynomials-handwritten-0001-encoder.bin
   - name: FP16/formula-recognition-polynomials-handwritten-0001-encoder.xml
     size: 197933
-    sha384: 0bb41c3b1b5ce80c3413621a16a666fbe48f391cbe1a5d0a5e8792689cbe103b1eb1293f92f9cadc26872a01be7c18dc
+    checksum: 0bb41c3b1b5ce80c3413621a16a666fbe48f391cbe1a5d0a5e8792689cbe103b1eb1293f92f9cadc26872a01be7c18dc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/FP16/formula-recognition-polynomials-handwritten-0001-encoder.xml
   - name: FP16/formula-recognition-polynomials-handwritten-0001-encoder.bin
     size: 22604504
-    sha384: a5b085127825f92f9eea55d58b94f89f76b613138c96ac26c2f661970a1e1703a13ac5941dca6ca981f6961e19015293
+    checksum: a5b085127825f92f9eea55d58b94f89f76b613138c96ac26c2f661970a1e1703a13ac5941dca6ca981f6961e19015293
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/formula-recognition-polynomials-handwritten-0001/formula-recognition-polynomials-handwritten-0001-encoder/FP16/formula-recognition-polynomials-handwritten-0001-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/gaze-estimation-adas-0002/model.yml
+++ b/models/intel/gaze-estimation-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/gaze-estimation-adas-0002.xml
     size: 75302
-    sha384: baea08beb304fa7ca5d6ffb58ec0128ec270fdd4de50502c668f030b147dcec21167998419321e03fdf4f69ca8b4caf2
+    checksum: baea08beb304fa7ca5d6ffb58ec0128ec270fdd4de50502c668f030b147dcec21167998419321e03fdf4f69ca8b4caf2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.xml
   - name: FP32/gaze-estimation-adas-0002.bin
     size: 7529480
-    sha384: 377c30aeb2b86a07dc316691f2e730015cd553c012856e1aa898fe5605d62ef96341d3db8bf9c26c51fb67ecc6ed73b2
+    checksum: 377c30aeb2b86a07dc316691f2e730015cd553c012856e1aa898fe5605d62ef96341d3db8bf9c26c51fb67ecc6ed73b2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP32/gaze-estimation-adas-0002.bin
   - name: FP16/gaze-estimation-adas-0002.xml
     size: 75261
-    sha384: d8c4a20143dea665e57d0e70a6856c18cb040094f99ca61ef7c020e479d6d8f203a3e0337b12fe5e2b86c9082889f94c
+    checksum: d8c4a20143dea665e57d0e70a6856c18cb040094f99ca61ef7c020e479d6d8f203a3e0337b12fe5e2b86c9082889f94c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.xml
   - name: FP16/gaze-estimation-adas-0002.bin
     size: 3764842
-    sha384: ebc47d52fc4db9ef59e5f076776ac2660fd95d0df0c4a82babdb482a1b477892aa4916115f25474c6c88ee8785a93d3f
+    checksum: ebc47d52fc4db9ef59e5f076776ac2660fd95d0df0c4a82babdb482a1b477892aa4916115f25474c6c88ee8785a93d3f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP16/gaze-estimation-adas-0002.bin
   - name: FP16-INT8/gaze-estimation-adas-0002.xml
     size: 147906
-    sha384: 0769733d2ddca497f62e8fd18c9276d22723826c4c6b9b18bb030552e8e7633b0f47fb99de839b6c473b071e245a5865
+    checksum: 0769733d2ddca497f62e8fd18c9276d22723826c4c6b9b18bb030552e8e7633b0f47fb99de839b6c473b071e245a5865
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.xml
   - name: FP16-INT8/gaze-estimation-adas-0002.bin
     size: 1893394
-    sha384: 32be63595a71ac0383ad08c3d7a5ebc23954276ea9ebcc50d909b85d18816d5c6091db4095d874400ae08799bfa5322e
+    checksum: 32be63595a71ac0383ad08c3d7a5ebc23954276ea9ebcc50d909b85d18816d5c6091db4095d874400ae08799bfa5322e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/gaze-estimation-adas-0002/FP16-INT8/gaze-estimation-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-japanese-recognition-0001/model.yml
+++ b/models/intel/handwritten-japanese-recognition-0001/model.yml
@@ -18,27 +18,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-japanese-recognition-0001.xml
     size: 44343
-    sha384: 7431457aff6affc7558428298c037c4ee1b447743fa85c1cb8b814ce457dacf943b6fea1b2b1cabcac2c8aefe42e3e2d
+    checksum: 7431457aff6affc7558428298c037c4ee1b447743fa85c1cb8b814ce457dacf943b6fea1b2b1cabcac2c8aefe42e3e2d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.xml
   - name: FP32/handwritten-japanese-recognition-0001.bin
     size: 67969208
-    sha384: 7faad7843dd1cc25a589d2cbec6b73292e1dc2b796d7d3f5e6a404a334b7a7a542370660481e912c335d1a9cce634016
+    checksum: 7faad7843dd1cc25a589d2cbec6b73292e1dc2b796d7d3f5e6a404a334b7a7a542370660481e912c335d1a9cce634016
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP32/handwritten-japanese-recognition-0001.bin
   - name: FP16/handwritten-japanese-recognition-0001.xml
     size: 44331
-    sha384: d579903e5e94d9bd1cf6c6a88839fff107882f3afc0b710c0a2f4a095eea2c0d01d51a30ee0ff0408bae378702b0984e
+    checksum: d579903e5e94d9bd1cf6c6a88839fff107882f3afc0b710c0a2f4a095eea2c0d01d51a30ee0ff0408bae378702b0984e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.xml
   - name: FP16/handwritten-japanese-recognition-0001.bin
     size: 33984640
-    sha384: ee27c871cd38c9c6b2b1a5858b4fcc9083ba8d0eea2ffb35e8542c6d26a9c269e8dbbbf97491adbac3bb2f5dbac3e522
+    checksum: ee27c871cd38c9c6b2b1a5858b4fcc9083ba8d0eea2ffb35e8542c6d26a9c269e8dbbbf97491adbac3bb2f5dbac3e522
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP16/handwritten-japanese-recognition-0001.bin
   - name: FP16-INT8/handwritten-japanese-recognition-0001.xml
     size: 102268
-    sha384: 0e617bf3a2893396ff50e21aa8c8dca998c111508af680d528c87a8fbe37e15599da51df2ce24deaa74fa48a4f8ea1fb
+    checksum: 0e617bf3a2893396ff50e21aa8c8dca998c111508af680d528c87a8fbe37e15599da51df2ce24deaa74fa48a4f8ea1fb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.xml
   - name: FP16-INT8/handwritten-japanese-recognition-0001.bin
     size: 17012014
-    sha384: 76ea9ed13eab6a704fdc15f258aa19326adb59c143d45271dca385f197d4261f6aaab8ac64a8fa52770ad3abd00fa971
+    checksum: 76ea9ed13eab6a704fdc15f258aa19326adb59c143d45271dca385f197d4261f6aaab8ac64a8fa52770ad3abd00fa971
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-japanese-recognition-0001/FP16-INT8/handwritten-japanese-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-score-recognition-0003/model.yml
+++ b/models/intel/handwritten-score-recognition-0003/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-score-recognition-0003.xml
     size: 92625
-    sha384: 7a589299fcc92b4fd81136b2736f7b21797d28baebc80e2b196ef2a55c91cdb97a2135877f42548ffb1d7b860c6e4950
+    checksum: 7a589299fcc92b4fd81136b2736f7b21797d28baebc80e2b196ef2a55c91cdb97a2135877f42548ffb1d7b860c6e4950
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.xml
   - name: FP32/handwritten-score-recognition-0003.bin
     size: 41121956
-    sha384: 1e1d50337a76ce7e5e0b535250ee51e4cce4151461e6dac71276972d6b5e3e5e14e88fb397f77bc070830cd5ccb710e7
+    checksum: 1e1d50337a76ce7e5e0b535250ee51e4cce4151461e6dac71276972d6b5e3e5e14e88fb397f77bc070830cd5ccb710e7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP32/handwritten-score-recognition-0003.bin
   - name: FP16/handwritten-score-recognition-0003.xml
     size: 92600
-    sha384: 862cf6873379e4a3f28bac4e48523635fe8c51ed4e74770eb03613cae68f6f55f2f4a6f07add5329622a960b4d2f10ed
+    checksum: 862cf6873379e4a3f28bac4e48523635fe8c51ed4e74770eb03613cae68f6f55f2f4a6f07add5329622a960b4d2f10ed
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.xml
   - name: FP16/handwritten-score-recognition-0003.bin
     size: 20561030
-    sha384: ef63427055bcbe34bd616df0fa5fe133bc2690e0188103e3cee39ceda820e1ecc06c68e86637ecc8a971004613164fd7
+    checksum: ef63427055bcbe34bd616df0fa5fe133bc2690e0188103e3cee39ceda820e1ecc06c68e86637ecc8a971004613164fd7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP16/handwritten-score-recognition-0003.bin
   - name: FP16-INT8/handwritten-score-recognition-0003.xml
     size: 128496
-    sha384: f773af0aa8970422ef99e28b7238c6fe41b76a769a8a91152b2cfa95e3d2d542ace77be5e512a663fcd0ae0dd970b35c
+    checksum: f773af0aa8970422ef99e28b7238c6fe41b76a769a8a91152b2cfa95e3d2d542ace77be5e512a663fcd0ae0dd970b35c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.xml
   - name: FP16-INT8/handwritten-score-recognition-0003.bin
     size: 15030168
-    sha384: 67e965d52290e15dedda40265493a09ef3d3d44e0ca3d1dfdf1321c231a2687db0036400e56e05e7ada609fcbf49f329
+    checksum: 67e965d52290e15dedda40265493a09ef3d3d44e0ca3d1dfdf1321c231a2687db0036400e56e05e7ada609fcbf49f329
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-score-recognition-0003/FP16-INT8/handwritten-score-recognition-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/handwritten-simplified-chinese-recognition-0001/model.yml
+++ b/models/intel/handwritten-simplified-chinese-recognition-0001/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/handwritten-simplified-chinese-recognition-0001.xml
     size: 119599
-    sha384: 7a2361a9987fbe314a9b89b68243f707a94d96834a137f2c03260501af8aa7dbd9e0e5bbbd3e93505c3cdf4f40877e80
+    checksum: 7a2361a9987fbe314a9b89b68243f707a94d96834a137f2c03260501af8aa7dbd9e0e5bbbd3e93505c3cdf4f40877e80
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP32/handwritten-simplified-chinese-recognition-0001.xml
   - name: FP32/handwritten-simplified-chinese-recognition-0001.bin
     size: 69071580
-    sha384: 45c6e0ecc24730069e423402791f71b83f0e9d3d71bc58a6d8a8a2811d1e034a927fc10dd0de0bcb77c81c1af6a88726
+    checksum: 45c6e0ecc24730069e423402791f71b83f0e9d3d71bc58a6d8a8a2811d1e034a927fc10dd0de0bcb77c81c1af6a88726
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP32/handwritten-simplified-chinese-recognition-0001.bin
   - name: FP16/handwritten-simplified-chinese-recognition-0001.xml
     size: 119523
-    sha384: ebd52fc51fd94df9ea927e8dd5120392e7ef09da158754cb4e3179ced187d2cfa1f0d5cebc64aa2ddaf98e0ae0cad4b6
+    checksum: ebd52fc51fd94df9ea927e8dd5120392e7ef09da158754cb4e3179ced187d2cfa1f0d5cebc64aa2ddaf98e0ae0cad4b6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP16/handwritten-simplified-chinese-recognition-0001.xml
   - name: FP16/handwritten-simplified-chinese-recognition-0001.bin
     size: 34535842
-    sha384: b572b3097d4fcb172660527d314973a17b4e1fa8176dbcb25e82706363ba3e6f03a7cfc85891a1ca3afbae56594a1da8
+    checksum: b572b3097d4fcb172660527d314973a17b4e1fa8176dbcb25e82706363ba3e6f03a7cfc85891a1ca3afbae56594a1da8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP16/handwritten-simplified-chinese-recognition-0001.bin
   - name: FP16-INT8/handwritten-simplified-chinese-recognition-0001.xml
     size: 240459
-    sha384: 5d9409003a20badb3152b6644c10dd0cb29e7969e1e5fc32a2d7b45b796d0737ceb7ed8f85d6039d182c5a13fad98b77
+    checksum: 5d9409003a20badb3152b6644c10dd0cb29e7969e1e5fc32a2d7b45b796d0737ceb7ed8f85d6039d182c5a13fad98b77
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP16-INT8/handwritten-simplified-chinese-recognition-0001.xml
   - name: FP16-INT8/handwritten-simplified-chinese-recognition-0001.bin
     size: 17320954
-    sha384: 91444adddff42c68d10aff669202f0072131df34500a1e4d33159de43de5ef9bdc9edf13a9dc81ce80c31906fa59fe2f
+    checksum: 91444adddff42c68d10aff669202f0072131df34500a1e4d33159de43de5ef9bdc9edf13a9dc81ce80c31906fa59fe2f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/handwritten-simplified-chinese-recognition-0001/FP16-INT8/handwritten-simplified-chinese-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/head-pose-estimation-adas-0001/model.yml
+++ b/models/intel/head-pose-estimation-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: head_pose_estimation
 files:
   - name: FP32/head-pose-estimation-adas-0001.xml
     size: 53353
-    sha384: 9a8214bc938fe964306b5b9c106de7dde3bab2752edab58eb35d4725ac8c8059c49221e673a27d7c080c0b115ae24247
+    checksum: 9a8214bc938fe964306b5b9c106de7dde3bab2752edab58eb35d4725ac8c8059c49221e673a27d7c080c0b115ae24247
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.xml
   - name: FP32/head-pose-estimation-adas-0001.bin
     size: 7647604
-    sha384: 26899d66b5c594d1f10d18b3e454462d5cd2d80d2addb9199fc81c5383d75fc0419d0d4045bc1404457245886c5dc90f
+    checksum: 26899d66b5c594d1f10d18b3e454462d5cd2d80d2addb9199fc81c5383d75fc0419d0d4045bc1404457245886c5dc90f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP32/head-pose-estimation-adas-0001.bin
   - name: FP16/head-pose-estimation-adas-0001.xml
     size: 53344
-    sha384: ca7d81259b071d0eca12be8c235e9943ea16d60a1756ff5994dd464391a0cd1d7a8c39fb23bedb4c0faa7a56f796a9d8
+    checksum: ca7d81259b071d0eca12be8c235e9943ea16d60a1756ff5994dd464391a0cd1d7a8c39fb23bedb4c0faa7a56f796a9d8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.xml
   - name: FP16/head-pose-estimation-adas-0001.bin
     size: 3823810
-    sha384: 99ff8940eef5c1b1423c0ff6f50e8666072ccb71ba5737f908dc9b572535c0aebdaae714e07bb619a2ee9e5651d19ecc
+    checksum: 99ff8940eef5c1b1423c0ff6f50e8666072ccb71ba5737f908dc9b572535c0aebdaae714e07bb619a2ee9e5651d19ecc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP16/head-pose-estimation-adas-0001.bin
   - name: FP16-INT8/head-pose-estimation-adas-0001.xml
     size: 89782
-    sha384: d529730c242e3f08e6f8dca9eecaefe65088b96a992b0d68ce9d07754fd182b6f99034b43289f21663ce3c11b4af4197
+    checksum: d529730c242e3f08e6f8dca9eecaefe65088b96a992b0d68ce9d07754fd182b6f99034b43289f21663ce3c11b4af4197
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.xml
   - name: FP16-INT8/head-pose-estimation-adas-0001.bin
     size: 2074366
-    sha384: 73ff9374b63fce5d62c8417dd58489a481d814a700da5ce12fac968c79dd8a7f7f5448c1bece2acb2afd94d50e49eaa8
+    checksum: 73ff9374b63fce5d62c8417dd58489a481d814a700da5ce12fac968c79dd8a7f7f5448c1bece2acb2afd94d50e49eaa8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/head-pose-estimation-adas-0001/FP16-INT8/head-pose-estimation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/horizontal-text-detection-0001/model.yml
+++ b/models/intel/horizontal-text-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/horizontal-text-detection-0001.xml
     size: 883052
-    sha384: 2459c5a7cad0faf125fb066d9b200b992b7b6c4256c91cdf8de6925314410d8f5d12bb9b1bf84955a15fc0c765cf7b8b
+    checksum: 2459c5a7cad0faf125fb066d9b200b992b7b6c4256c91cdf8de6925314410d8f5d12bb9b1bf84955a15fc0c765cf7b8b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP32/horizontal-text-detection-0001.xml
   - name: FP32/horizontal-text-detection-0001.bin
     size: 7753404
-    sha384: a592ba2c86fb67552467165768a53d2a34d253f2def73b7a5aa888429275d0724a326e59e01df72a312057c8a7e4d175
+    checksum: a592ba2c86fb67552467165768a53d2a34d253f2def73b7a5aa888429275d0724a326e59e01df72a312057c8a7e4d175
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP32/horizontal-text-detection-0001.bin
   - name: FP16/horizontal-text-detection-0001.xml
     size: 882890
-    sha384: 96f0f3c92d6d26136723e28a165ef92f5b089376ebd5100be7ac7f2cdad7b1aeecdf14f993dc9f2a5ec5ed85267eb2f8
+    checksum: 96f0f3c92d6d26136723e28a165ef92f5b089376ebd5100be7ac7f2cdad7b1aeecdf14f993dc9f2a5ec5ed85267eb2f8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP16/horizontal-text-detection-0001.xml
   - name: FP16/horizontal-text-detection-0001.bin
     size: 3876864
-    sha384: cfbf81a8a48155b6918d00784effd398e3750fdbcd4672aab10c2fddf9994c23f4773c202be6572c88488ebb5d27be10
+    checksum: cfbf81a8a48155b6918d00784effd398e3750fdbcd4672aab10c2fddf9994c23f4773c202be6572c88488ebb5d27be10
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP16/horizontal-text-detection-0001.bin
   - name: FP16-INT8/horizontal-text-detection-0001.xml
     size: 1457277
-    sha384: c4ed8f18ded06d82926bd472fa0335d6586e0d9e1063530f2e6897b035a013a5a7a800f3338076b77a683acef8100e4e
+    checksum: c4ed8f18ded06d82926bd472fa0335d6586e0d9e1063530f2e6897b035a013a5a7a800f3338076b77a683acef8100e4e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP16-INT8/horizontal-text-detection-0001.xml
   - name: FP16-INT8/horizontal-text-detection-0001.bin
     size: 2038038
-    sha384: 66a7473dcb875c065241036823f45de5711cc66f73f86c08b58bfb01bb5a73f8fffffaf1686e495cb3b59ccd8e4a9317
+    checksum: 66a7473dcb875c065241036823f45de5711cc66f73f86c08b58bfb01bb5a73f8fffffaf1686e495cb3b59ccd8e4a9317
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/horizontal-text-detection-0001/FP16-INT8/horizontal-text-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0001/model.yml
+++ b/models/intel/human-pose-estimation-0001/model.yml
@@ -18,27 +18,27 @@ task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0001.xml
     size: 153774
-    sha384: 2769141a37b1b8ac562f23944ccde0ae10083ca356ed53d8e4b999d9573380df2ab64f90ee7432415ef3ac38af8c1cd0
+    checksum: 2769141a37b1b8ac562f23944ccde0ae10083ca356ed53d8e4b999d9573380df2ab64f90ee7432415ef3ac38af8c1cd0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP32/human-pose-estimation-0001.xml
   - name: FP32/human-pose-estimation-0001.bin
     size: 16394712
-    sha384: 25a546e55a683a0a548193cb43360a8cef09846aaba5f130192f93846563ec1a749a4270ff614d98952982f5c45d13f8
+    checksum: 25a546e55a683a0a548193cb43360a8cef09846aaba5f130192f93846563ec1a749a4270ff614d98952982f5c45d13f8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin
   - name: FP16/human-pose-estimation-0001.xml
     size: 153702
-    sha384: 24f853c4ed0456e988c58cbb134e15f6b0db151ef89e8ca3413fa5961488553557c572e7ff9a0021d8929cbc2f650e76
+    checksum: 24f853c4ed0456e988c58cbb134e15f6b0db151ef89e8ca3413fa5961488553557c572e7ff9a0021d8929cbc2f650e76
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml
   - name: FP16/human-pose-estimation-0001.bin
     size: 8197356
-    sha384: 329c69990da8eeccca7215e124bf4feb48d43c2c9013114da703b25a69fe38a15a32af589ef2903e0cdbc96658953d6f
+    checksum: 329c69990da8eeccca7215e124bf4feb48d43c2c9013114da703b25a69fe38a15a32af589ef2903e0cdbc96658953d6f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP16/human-pose-estimation-0001.bin
   - name: FP16-INT8/human-pose-estimation-0001.xml
     size: 426156
-    sha384: f2c890b36f3fd45c81b6a8c7bc952977b1b60748c036a1e48eed7bf0fcae9d8372a6d897ba65ebde27529fe1ab56ce3d
+    checksum: f2c890b36f3fd45c81b6a8c7bc952977b1b60748c036a1e48eed7bf0fcae9d8372a6d897ba65ebde27529fe1ab56ce3d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.xml
   - name: FP16-INT8/human-pose-estimation-0001.bin
     size: 4170034
-    sha384: c8fd0eea004648dc2e52805757c4e5ba26c5900096c71e46571ac6578e22f88f4e12c8cf07cf5f08810421821a19f6f1
+    checksum: c8fd0eea004648dc2e52805757c4e5ba26c5900096c71e46571ac6578e22f88f4e12c8cf07cf5f08810421821a19f6f1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0001/FP16-INT8/human-pose-estimation-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0005/model.yml
+++ b/models/intel/human-pose-estimation-0005/model.yml
@@ -18,19 +18,19 @@ task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0005.xml
     size: 1082819
-    sha384: e0346c4508053a0df64828e18635ac608941a0685f0895ad68c42f8c9f96a12758150be505f3b94e1f412fcc55f1514d
+    checksum: e0346c4508053a0df64828e18635ac608941a0685f0895ad68c42f8c9f96a12758150be505f3b94e1f412fcc55f1514d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0005/FP32/human-pose-estimation-0005.xml
   - name: FP32/human-pose-estimation-0005.bin
     size: 32601740
-    sha384: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
+    checksum: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0005/FP32/human-pose-estimation-0005.bin
   - name: FP16/human-pose-estimation-0005.xml
     size: 1082562
-    sha384: 4250714caf2f65bb7f4f8e9cba97f28a0cc582abdfb351f42e460aeaed249d0e406a233a4ac1687d15a247e2ba05770d
+    checksum: 4250714caf2f65bb7f4f8e9cba97f28a0cc582abdfb351f42e460aeaed249d0e406a233a4ac1687d15a247e2ba05770d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0005/FP16/human-pose-estimation-0005.xml
   - name: FP16/human-pose-estimation-0005.bin
     size: 16300908
-    sha384: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
+    checksum: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0005/FP16/human-pose-estimation-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0006/model.yml
+++ b/models/intel/human-pose-estimation-0006/model.yml
@@ -18,19 +18,19 @@ task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0006.xml
     size: 1083375
-    sha384: 6bf410d96326a52869aba792eb1e02fb51d6858b0e23686f0e07565ad2c62c712a23472c204949fee5f93b76c21f294e
+    checksum: 6bf410d96326a52869aba792eb1e02fb51d6858b0e23686f0e07565ad2c62c712a23472c204949fee5f93b76c21f294e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0006/FP32/human-pose-estimation-0006.xml
   - name: FP32/human-pose-estimation-0006.bin
     size: 32601740
-    sha384: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
+    checksum: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0006/FP32/human-pose-estimation-0006.bin
   - name: FP16/human-pose-estimation-0006.xml
     size: 1083118
-    sha384: 434434c5c7f263ea9dd380349c16dd04495a737740c283955f88390c0e8629bb7b66768d4e02e45c8d230505e0e130db
+    checksum: 434434c5c7f263ea9dd380349c16dd04495a737740c283955f88390c0e8629bb7b66768d4e02e45c8d230505e0e130db
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0006/FP16/human-pose-estimation-0006.xml
   - name: FP16/human-pose-estimation-0006.bin
     size: 16300908
-    sha384: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
+    checksum: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0006/FP16/human-pose-estimation-0006.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/human-pose-estimation-0007/model.yml
+++ b/models/intel/human-pose-estimation-0007/model.yml
@@ -18,19 +18,19 @@ task_type: human_pose_estimation
 files:
   - name: FP32/human-pose-estimation-0007.xml
     size: 1084057
-    sha384: d27b276d3e04488e21dc1149f89df6680db1ba418550c7342ecfa21c069ee1587f838d5f1e4ea98b82d8680804de65e6
+    checksum: d27b276d3e04488e21dc1149f89df6680db1ba418550c7342ecfa21c069ee1587f838d5f1e4ea98b82d8680804de65e6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0007/FP32/human-pose-estimation-0007.xml
   - name: FP32/human-pose-estimation-0007.bin
     size: 32601740
-    sha384: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
+    checksum: 5e5d7e1c1c456d1c6a40b723524f0c1171a2510680a3cdd724cda61f1ffadfc8b0a22635139ea8781ad9ccfdb26d0189
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0007/FP32/human-pose-estimation-0007.bin
   - name: FP16/human-pose-estimation-0007.xml
     size: 1083800
-    sha384: 8f45396367bb48d4e071e729849bd62f39bb4fa08c1e3f9d7a9e1ca43f6aada9f56976703ea0e97478dd7e3ae827de4e
+    checksum: 8f45396367bb48d4e071e729849bd62f39bb4fa08c1e3f9d7a9e1ca43f6aada9f56976703ea0e97478dd7e3ae827de4e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0007/FP16/human-pose-estimation-0007.xml
   - name: FP16/human-pose-estimation-0007.bin
     size: 16300908
-    sha384: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
+    checksum: da51ed5b8f5ce38155523ede9907ca8231b3b23cba0669304c7895a5f5e94c8de9f1b19568e8ce21698739bc89633451
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/human-pose-estimation-0007/FP16/human-pose-estimation-0007.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-0001.xml
     size: 422351
-    sha384: 83703a022a1be193a83b929ab81b19c88fd2fcf3f3e7dad54c21cf38cc99c52fe6ba20ff22c383b534fb7177b5d30d9f
+    checksum: 83703a022a1be193a83b929ab81b19c88fd2fcf3f3e7dad54c21cf38cc99c52fe6ba20ff22c383b534fb7177b5d30d9f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.xml
   - name: FP32/icnet-camvid-ava-0001.bin
     size: 106816968
-    sha384: f1e7bc55b0e26656265d769cc05816cf0944a22bfbe1472ea90d3f300572533b77d15624edfb558752955af78f3d7290
+    checksum: f1e7bc55b0e26656265d769cc05816cf0944a22bfbe1472ea90d3f300572533b77d15624edfb558752955af78f3d7290
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP32/icnet-camvid-ava-0001.bin
   - name: FP16/icnet-camvid-ava-0001.xml
     size: 422254
-    sha384: 1b203b3e343bca49d3e862c3a58347a2cb5f98ea600e4690617cf9d3bca8f490629a077e4822c94657d11c472413c915
+    checksum: 1b203b3e343bca49d3e862c3a58347a2cb5f98ea600e4690617cf9d3bca8f490629a077e4822c94657d11c472413c915
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.xml
   - name: FP16/icnet-camvid-ava-0001.bin
     size: 53408674
-    sha384: f7efcaf04ed08b31963ec8b8b1f6cce64de1962d7aa2e5e64d4ed07c250e34df0d645f2454651f93c94124be1d5d623a
+    checksum: f7efcaf04ed08b31963ec8b8b1f6cce64de1962d7aa2e5e64d4ed07c250e34df0d645f2454651f93c94124be1d5d623a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP16/icnet-camvid-ava-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-0001.xml
     size: 778002
-    sha384: 66fc6317ad7bdc877739664045f5b46b4e75a524ff28d5ca4afd0dc19b9c5fd1518b25680db6d3003d1b899b73d53ba8
+    checksum: 66fc6317ad7bdc877739664045f5b46b4e75a524ff28d5ca4afd0dc19b9c5fd1518b25680db6d3003d1b899b73d53ba8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-0001.bin
     size: 26847556
-    sha384: a24998e9d2617d1723756337b8323668d188996051feddcfa78d447136f804d7e0a73adf17ec8b24a5c6473f2cf94022
+    checksum: a24998e9d2617d1723756337b8323668d188996051feddcfa78d447136f804d7e0a73adf17ec8b24a5c6473f2cf94022
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-0001/FP16-INT8/icnet-camvid-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-sparse-30-0001.xml
     size: 422371
-    sha384: 660bb11dece37800d3d5133664706d8e734ab38032843a0ce0e0f57a777be8c4b0426ac1b06183be38084ba4a96100e2
+    checksum: 660bb11dece37800d3d5133664706d8e734ab38032843a0ce0e0f57a777be8c4b0426ac1b06183be38084ba4a96100e2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP32/icnet-camvid-ava-sparse-30-0001.bin
     size: 106816968
-    sha384: edb67a6114a807e0ff65b250be4549514b6cb340871f4b79aa19bd20a7ee2eb5d51c233cd5a70232c939954a0ccb6479
+    checksum: edb67a6114a807e0ff65b250be4549514b6cb340871f4b79aa19bd20a7ee2eb5d51c233cd5a70232c939954a0ccb6479
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP32/icnet-camvid-ava-sparse-30-0001.bin
   - name: FP16/icnet-camvid-ava-sparse-30-0001.xml
     size: 422274
-    sha384: 2afae8506b27e5df469ae08f1ff2ece1a48843b76f279f7538764fbd37276fe0487eddab826956c8490aec16b2ce7fdb
+    checksum: 2afae8506b27e5df469ae08f1ff2ece1a48843b76f279f7538764fbd37276fe0487eddab826956c8490aec16b2ce7fdb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP16/icnet-camvid-ava-sparse-30-0001.bin
     size: 53408674
-    sha384: 0c5a3af0cb09569ef8f46c8a8c5bcf89dcbdeece782dfb1aa16e381db35e6544dbefad6a660ebe71b18f1e8df3de1681
+    checksum: 0c5a3af0cb09569ef8f46c8a8c5bcf89dcbdeece782dfb1aa16e381db35e6544dbefad6a660ebe71b18f1e8df3de1681
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16/icnet-camvid-ava-sparse-30-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-sparse-30-0001.xml
     size: 778010
-    sha384: 3badfcff679f36dddce100558d0edddad67547c0bb00f508d6d3f709e2912e01e114f548af3e7e1af7be23865a7c5977
+    checksum: 3badfcff679f36dddce100558d0edddad67547c0bb00f508d6d3f709e2912e01e114f548af3e7e1af7be23865a7c5977
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-sparse-30-0001.bin
     size: 26847550
-    sha384: 11148315fc814f03d50917f5e7e0dce5df61d5463b17e4a619fd9a396fc73e35b4ad2e636552382a2b1eb06ee3b34d12
+    checksum: 11148315fc814f03d50917f5e7e0dce5df61d5463b17e4a619fd9a396fc73e35b4ad2e636552382a2b1eb06ee3b34d12
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-30-0001/FP16-INT8/icnet-camvid-ava-sparse-30-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/model.yml
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/icnet-camvid-ava-sparse-60-0001.xml
     size: 422371
-    sha384: 4f463fbc62602f70fd05e8c65b53c1fa3dde483469b400e0466b7ebcb7d73b91eb6e8c46d410a4299caf408bfb73858c
+    checksum: 4f463fbc62602f70fd05e8c65b53c1fa3dde483469b400e0466b7ebcb7d73b91eb6e8c46d410a4299caf408bfb73858c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP32/icnet-camvid-ava-sparse-60-0001.bin
     size: 106816968
-    sha384: ef83e9f039d9b403c423929404c7f4cfe92af59db72bd238cc8ef911cc3d719579b1e537805f7e8093a1a57810b97cb0
+    checksum: ef83e9f039d9b403c423929404c7f4cfe92af59db72bd238cc8ef911cc3d719579b1e537805f7e8093a1a57810b97cb0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP32/icnet-camvid-ava-sparse-60-0001.bin
   - name: FP16/icnet-camvid-ava-sparse-60-0001.xml
     size: 422274
-    sha384: 8efbb588decb8dd953979d71cae4675f0a51126bb29421c5d1e077a7476d5d522e8e47f0470b6f0374297c5a69072bcb
+    checksum: 8efbb588decb8dd953979d71cae4675f0a51126bb29421c5d1e077a7476d5d522e8e47f0470b6f0374297c5a69072bcb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP16/icnet-camvid-ava-sparse-60-0001.bin
     size: 53408674
-    sha384: 16358230bded0a798c894cfdb0fad2e492989496954f102c29e114c9db6722fef3f476b33e99b0d51fa495402f6ffde8
+    checksum: 16358230bded0a798c894cfdb0fad2e492989496954f102c29e114c9db6722fef3f476b33e99b0d51fa495402f6ffde8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16/icnet-camvid-ava-sparse-60-0001.bin
   - name: FP16-INT8/icnet-camvid-ava-sparse-60-0001.xml
     size: 778036
-    sha384: a85c5e967347ef287177897dbdc3db71286401c82dc2d0652117906af21d697e90e6928ad751ba85b73da8ef929dab49
+    checksum: a85c5e967347ef287177897dbdc3db71286401c82dc2d0652117906af21d697e90e6928ad751ba85b73da8ef929dab49
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.xml
   - name: FP16-INT8/icnet-camvid-ava-sparse-60-0001.bin
     size: 26847552
-    sha384: d0218b90d30bf062842685ef3de67ddd4959321d7e4df30fb26e2fa6a41388de613d5d399028d2bed2e467c3b0298d4e
+    checksum: d0218b90d30bf062842685ef3de67ddd4959321d7e4df30fb26e2fa6a41388de613d5d399028d2bed2e467c3b0298d4e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/icnet-camvid-ava-sparse-60-0001/FP16-INT8/icnet-camvid-ava-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/image-retrieval-0001/model.yml
+++ b/models/intel/image-retrieval-0001/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/image-retrieval-0001.xml
     size: 166236
-    sha384: d2aa7e79b8be3a807445d1b8b7faf9a945623791ba170fc4c13e0e2a6c5764e8b47515da0446604dccf26ff20f0e972e
+    checksum: d2aa7e79b8be3a807445d1b8b7faf9a945623791ba170fc4c13e0e2a6c5764e8b47515da0446604dccf26ff20f0e972e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP32/image-retrieval-0001.xml
   - name: FP32/image-retrieval-0001.bin
     size: 10139232
-    sha384: 5cb8486aaeecb2a5dd22976c6019ea9952640ed14091d384e40c0bd4474c41b3cf5df8801fc39c6f0a6afa7a6e980f92
+    checksum: 5cb8486aaeecb2a5dd22976c6019ea9952640ed14091d384e40c0bd4474c41b3cf5df8801fc39c6f0a6afa7a6e980f92
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP32/image-retrieval-0001.bin
   - name: FP16/image-retrieval-0001.xml
     size: 166167
-    sha384: 10fde5b572c9e12568046556fcaf5e75e6ca2c60de0753670d0b9ad936be2f4c56b3b3b0fa3a51eb3a6fcf69b32dd94f
+    checksum: 10fde5b572c9e12568046556fcaf5e75e6ca2c60de0753670d0b9ad936be2f4c56b3b3b0fa3a51eb3a6fcf69b32dd94f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP16/image-retrieval-0001.xml
   - name: FP16/image-retrieval-0001.bin
     size: 5069716
-    sha384: f1b04cd98494d9d0a9e1ee9c3cc15f67283bfeca284e5ecc6de3aed83dc30922cc4fe409fce2c5a4edb91f8840024483
+    checksum: f1b04cd98494d9d0a9e1ee9c3cc15f67283bfeca284e5ecc6de3aed83dc30922cc4fe409fce2c5a4edb91f8840024483
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP16/image-retrieval-0001.bin
   - name: FP16-INT8/image-retrieval-0001.xml
     size: 434759
-    sha384: daff4bb3de370d6c00b8488d6716bf4210fbb1c5e3600e45824bd043f562a12f14f9603ad8ec019ac8667c088510b3a6
+    checksum: daff4bb3de370d6c00b8488d6716bf4210fbb1c5e3600e45824bd043f562a12f14f9603ad8ec019ac8667c088510b3a6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP16-INT8/image-retrieval-0001.xml
   - name: FP16-INT8/image-retrieval-0001.bin
     size: 2640981
-    sha384: 79a4feea583ce4faa1a7b51b822c3eadfb6e7ca52d32204b85fd921b23255c8efddf60cd3ec4ed444454f3e374b965f2
+    checksum: 79a4feea583ce4faa1a7b51b822c3eadfb6e7ca52d32204b85fd921b23255c8efddf60cd3ec4ed444454f3e374b965f2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/image-retrieval-0001/FP16-INT8/image-retrieval-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0002/model.yml
+++ b/models/intel/instance-segmentation-security-0002/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0002.xml
     size: 840711
-    sha384: 78135fb7adbbbea5cf0b80cab259ec498d59be1c8669a12f2ff58fc0b834e3edbef015e24018d835385b000d8bc60d03
+    checksum: 78135fb7adbbbea5cf0b80cab259ec498d59be1c8669a12f2ff58fc0b834e3edbef015e24018d835385b000d8bc60d03
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP32/instance-segmentation-security-0002.xml
   - name: FP32/instance-segmentation-security-0002.bin
     size: 177479928
-    sha384: 3e8c8715efa85469141f972512ceaba68917beae9f688ef0ba046fd5c2a7eb1af1de00c3936f5c022886df91e304e498
+    checksum: 3e8c8715efa85469141f972512ceaba68917beae9f688ef0ba046fd5c2a7eb1af1de00c3936f5c022886df91e304e498
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP32/instance-segmentation-security-0002.bin
   - name: FP16/instance-segmentation-security-0002.xml
     size: 840311
-    sha384: b65acf4637a3dd0e15147fc3b29d122ef7dc8826d59b16135b2a0cf7c451c6d4491396a1b1455bc21d6d78309ae497fe
+    checksum: b65acf4637a3dd0e15147fc3b29d122ef7dc8826d59b16135b2a0cf7c451c6d4491396a1b1455bc21d6d78309ae497fe
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP16/instance-segmentation-security-0002.xml
   - name: FP16/instance-segmentation-security-0002.bin
     size: 88740226
-    sha384: b395fa2d5136ccfb5e2dc7e7c8bd84ad90733e4043ba22ec38e7474249eb4d1bd01d64d9eede3aed99dc91388f39973b
+    checksum: b395fa2d5136ccfb5e2dc7e7c8bd84ad90733e4043ba22ec38e7474249eb4d1bd01d64d9eede3aed99dc91388f39973b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP16/instance-segmentation-security-0002.bin
   - name: FP16-INT8/instance-segmentation-security-0002.xml
     size: 1186837
-    sha384: e6cbd0888f572a75df83c354597d495da33e9d4117701d9e9b72d2466cbd4a81da8b836f7615ccc7999cf2633aef89be
+    checksum: e6cbd0888f572a75df83c354597d495da33e9d4117701d9e9b72d2466cbd4a81da8b836f7615ccc7999cf2633aef89be
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP16-INT8/instance-segmentation-security-0002.xml
   - name: FP16-INT8/instance-segmentation-security-0002.bin
     size: 70485480
-    sha384: 5695805c2b031cc7bedf7a8010c3d39088c7a2f0948da40ba50e8875c4a0e8046b8cb4f7703f60ed54ce1d34930a7145
+    checksum: 5695805c2b031cc7bedf7a8010c3d39088c7a2f0948da40ba50e8875c4a0e8046b8cb4f7703f60ed54ce1d34930a7145
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0002/FP16-INT8/instance-segmentation-security-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0091/model.yml
+++ b/models/intel/instance-segmentation-security-0091/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0091.xml
     size: 1381647
-    sha384: 00dfe3ae4e41aa2088447577affe8a6c1cdcb5de90f4f64f4ee3c0428ae09e1eda9a1e57b9974855dd77a4e47d51f47e
+    checksum: 00dfe3ae4e41aa2088447577affe8a6c1cdcb5de90f4f64f4ee3c0428ae09e1eda9a1e57b9974855dd77a4e47d51f47e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP32/instance-segmentation-security-0091.xml
   - name: FP32/instance-segmentation-security-0091.bin
     size: 390233536
-    sha384: 554f90c40dd9601cadfb60c6132d68b418fc513308a4bdd53e4869850fe6f70b3016929b87ebbe395fba357210ec695d
+    checksum: 554f90c40dd9601cadfb60c6132d68b418fc513308a4bdd53e4869850fe6f70b3016929b87ebbe395fba357210ec695d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP32/instance-segmentation-security-0091.bin
   - name: FP16/instance-segmentation-security-0091.xml
     size: 1380558
-    sha384: 0957ca26070417375eb3dbc354f499c2e34ee6ee5b96b33932ab1393a09bf948eb7969517db6ed8359f21ff7036649cd
+    checksum: 0957ca26070417375eb3dbc354f499c2e34ee6ee5b96b33932ab1393a09bf948eb7969517db6ed8359f21ff7036649cd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP16/instance-segmentation-security-0091.xml
   - name: FP16/instance-segmentation-security-0091.bin
     size: 195117022
-    sha384: b3c9813e9fc34e719bc4d928ecd28891493ab42d956d683625ea705518080083933fa25cf5e2ee9100d6253a52f1f1a8
+    checksum: b3c9813e9fc34e719bc4d928ecd28891493ab42d956d683625ea705518080083933fa25cf5e2ee9100d6253a52f1f1a8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP16/instance-segmentation-security-0091.bin
   - name: FP16-INT8/instance-segmentation-security-0091.xml
     size: 2082233
-    sha384: aef66830c7f100735b67e83d9a12c7a3261fc6f6499f8780e07a006a515f846e0515575be5e7e2e96498471e273c70c9
+    checksum: aef66830c7f100735b67e83d9a12c7a3261fc6f6499f8780e07a006a515f846e0515575be5e7e2e96498471e273c70c9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP16-INT8/instance-segmentation-security-0091.xml
   - name: FP16-INT8/instance-segmentation-security-0091.bin
     size: 196951642
-    sha384: ac5fd8b40f946ac3cce8f51e07e9bcbd47f7cb0f6334977b758755af097f1278cac3465879246140b5c07b190636ee4f
+    checksum: ac5fd8b40f946ac3cce8f51e07e9bcbd47f7cb0f6334977b758755af097f1278cac3465879246140b5c07b190636ee4f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0091/FP16-INT8/instance-segmentation-security-0091.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-0228/model.yml
+++ b/models/intel/instance-segmentation-security-0228/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-0228.xml
     size: 985819
-    sha384: 72e727da368775f3da151c8fc32d4b0f69851655e1cad34f4776a646b7fdb4195f5ab0ddfae798701907b7e41ca41cf7
+    checksum: 72e727da368775f3da151c8fc32d4b0f69851655e1cad34f4776a646b7fdb4195f5ab0ddfae798701907b7e41ca41cf7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP32/instance-segmentation-security-0228.xml
   - name: FP32/instance-segmentation-security-0228.bin
     size: 192104184
-    sha384: 258a8e8ebe64e399e0bdee1889dff206d9abb9501a0dfd16cb5714df33cf613cda23b943a654697578ffad247d38fd7c
+    checksum: 258a8e8ebe64e399e0bdee1889dff206d9abb9501a0dfd16cb5714df33cf613cda23b943a654697578ffad247d38fd7c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP32/instance-segmentation-security-0228.bin
   - name: FP16/instance-segmentation-security-0228.xml
     size: 985032
-    sha384: 22d4adea9138bdd0982bfc3774e9b896849c22f216977e09451fe896c33431b8c88c1451e4382dbd6cdc27d2fd292f56
+    checksum: 22d4adea9138bdd0982bfc3774e9b896849c22f216977e09451fe896c33431b8c88c1451e4382dbd6cdc27d2fd292f56
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP16/instance-segmentation-security-0228.xml
   - name: FP16/instance-segmentation-security-0228.bin
     size: 96052354
-    sha384: 5b40943fd559e7655a98e0a21c7596565db66bfc169bc5d06f7a0e8689d0db242814263389439594ca328e4abf2811cc
+    checksum: 5b40943fd559e7655a98e0a21c7596565db66bfc169bc5d06f7a0e8689d0db242814263389439594ca328e4abf2811cc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP16/instance-segmentation-security-0228.bin
   - name: FP16-INT8/instance-segmentation-security-0228.xml
     size: 1568012
-    sha384: 54a88b1353fe80d0c9bb53d69fbf4ecc5e489cadd4e081dbbb0eb261645bd1d65cfbbfa356743723b8c26c3c9bdb462f
+    checksum: 54a88b1353fe80d0c9bb53d69fbf4ecc5e489cadd4e081dbbb0eb261645bd1d65cfbbfa356743723b8c26c3c9bdb462f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP16-INT8/instance-segmentation-security-0228.xml
   - name: FP16-INT8/instance-segmentation-security-0228.bin
     size: 54794552
-    sha384: 43badd3b8f208c2be7fc893cca203fe4d456157a829fc699ad6b3dee796948fce5fa645d4d36110f479373e8a90c2333
+    checksum: 43badd3b8f208c2be7fc893cca203fe4d456157a829fc699ad6b3dee796948fce5fa645d4d36110f479373e8a90c2333
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-0228/FP16-INT8/instance-segmentation-security-0228.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-1039/model.yml
+++ b/models/intel/instance-segmentation-security-1039/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-1039.xml
     size: 980470
-    sha384: 98a60dda52535cae06698a508d14cce0f5eb199b7293b5090cb5a2a46e85e3c4e50a5c81b81c8194e5081b0f9fab424e
+    checksum: 98a60dda52535cae06698a508d14cce0f5eb199b7293b5090cb5a2a46e85e3c4e50a5c81b81c8194e5081b0f9fab424e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP32/instance-segmentation-security-1039.xml
   - name: FP32/instance-segmentation-security-1039.bin
     size: 40970632
-    sha384: 640db0ffb7a76818187328362f888e59051bb93278b9678c99cf9f457108251bb1d3407994b326d0973c964a54b4959f
+    checksum: 640db0ffb7a76818187328362f888e59051bb93278b9678c99cf9f457108251bb1d3407994b326d0973c964a54b4959f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP32/instance-segmentation-security-1039.bin
   - name: FP16/instance-segmentation-security-1039.xml
     size: 980390
-    sha384: 673b571d6aee434ac9ad810bb6c43489908865d2ad991cca791ec1b750f5d1f6c4ec6b7f48b49d5aba9a18abfbc76118
+    checksum: 673b571d6aee434ac9ad810bb6c43489908865d2ad991cca791ec1b750f5d1f6c4ec6b7f48b49d5aba9a18abfbc76118
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP16/instance-segmentation-security-1039.xml
   - name: FP16/instance-segmentation-security-1039.bin
     size: 20485598
-    sha384: 295dbbebe66800303b54ba4d8d353843fc96331cdd86f7d3ef9c66aa1822df98de10a2de18ef8f3a3c300aff912c6fe3
+    checksum: 295dbbebe66800303b54ba4d8d353843fc96331cdd86f7d3ef9c66aa1822df98de10a2de18ef8f3a3c300aff912c6fe3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP16/instance-segmentation-security-1039.bin
   - name: FP16-INT8/instance-segmentation-security-1039.xml
     size: 1688277
-    sha384: 5e83f2bee4f295a2d06a6e33f538ae006b3627e8aac6c56276c0091cb8db6f6edee470d0bf9f9962d95a65246a861a93
+    checksum: 5e83f2bee4f295a2d06a6e33f538ae006b3627e8aac6c56276c0091cb8db6f6edee470d0bf9f9962d95a65246a861a93
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP16-INT8/instance-segmentation-security-1039.xml
   - name: FP16-INT8/instance-segmentation-security-1039.bin
     size: 14595052
-    sha384: bb669e5ed556e4473bbcc5efb19960fc91bf7d5a1e71b1a33b0d261fd994b08f5357ab257bb034836c6c46bc3b56a81e
+    checksum: bb669e5ed556e4473bbcc5efb19960fc91bf7d5a1e71b1a33b0d261fd994b08f5357ab257bb034836c6c46bc3b56a81e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1039/FP16-INT8/instance-segmentation-security-1039.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/instance-segmentation-security-1040/model.yml
+++ b/models/intel/instance-segmentation-security-1040/model.yml
@@ -19,27 +19,27 @@ task_type: instance_segmentation
 files:
   - name: FP32/instance-segmentation-security-1040.xml
     size: 980908
-    sha384: 8ded927b8542d6645e095a7570dbd92e004d21e917b900092f6ab5014c3b0a37ba3cf06f486974b0dd3f6b8f7873f5ca
+    checksum: 8ded927b8542d6645e095a7570dbd92e004d21e917b900092f6ab5014c3b0a37ba3cf06f486974b0dd3f6b8f7873f5ca
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP32/instance-segmentation-security-1040.xml
   - name: FP32/instance-segmentation-security-1040.bin
     size: 52969864
-    sha384: 7dd555c9daef256a216299cfd47c5cc45b521d3349c1c4d86c63b7210256a5f5f24afc48dc7b1858098cd86377080819
+    checksum: 7dd555c9daef256a216299cfd47c5cc45b521d3349c1c4d86c63b7210256a5f5f24afc48dc7b1858098cd86377080819
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP32/instance-segmentation-security-1040.bin
   - name: FP16/instance-segmentation-security-1040.xml
     size: 980828
-    sha384: d7f89dd9b100462247dcceaa2137ee355fabea8aed9777dbd13fc318049cd16de475e2bef2b97659c512810ad6879668
+    checksum: d7f89dd9b100462247dcceaa2137ee355fabea8aed9777dbd13fc318049cd16de475e2bef2b97659c512810ad6879668
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP16/instance-segmentation-security-1040.xml
   - name: FP16/instance-segmentation-security-1040.bin
     size: 26485214
-    sha384: 1538332959f447535620f64c29a40d085784d7941c7a205961627e27b5be02e4ddc44041299cb78377e80ca632450270
+    checksum: 1538332959f447535620f64c29a40d085784d7941c7a205961627e27b5be02e4ddc44041299cb78377e80ca632450270
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP16/instance-segmentation-security-1040.bin
   - name: FP16-INT8/instance-segmentation-security-1040.xml
     size: 1688757
-    sha384: 292773a3f3f094dce7cc71e92554912eb9dd8f7de6624e42dd23fe2523fe604968364b1a45623b18600943f3fef74ed0
+    checksum: 292773a3f3f094dce7cc71e92554912eb9dd8f7de6624e42dd23fe2523fe604968364b1a45623b18600943f3fef74ed0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP16-INT8/instance-segmentation-security-1040.xml
   - name: FP16-INT8/instance-segmentation-security-1040.bin
     size: 21614048
-    sha384: 02b3a87dabd2e767cac215b27b4387c6f37f28c3e5cafba1cbbd590e47cd6d09aea00f45b48ee7bdac3f2d8aa3d38c36
+    checksum: 02b3a87dabd2e767cac215b27b4387c6f37f28c3e5cafba1cbbd590e47cd6d09aea00f45b48ee7bdac3f2d8aa3d38c36
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/instance-segmentation-security-1040/FP16-INT8/instance-segmentation-security-1040.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/landmarks-regression-retail-0009/model.yml
+++ b/models/intel/landmarks-regression-retail-0009/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/landmarks-regression-retail-0009.xml
     size: 44890
-    sha384: 84e5fd89c411c1128863c884818c7779184c9f551cb4e6d7f507c19f1ee0ec1fb8e76be5ed97fd006b66752e282bf651
+    checksum: 84e5fd89c411c1128863c884818c7779184c9f551cb4e6d7f507c19f1ee0ec1fb8e76be5ed97fd006b66752e282bf651
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.xml
   - name: FP32/landmarks-regression-retail-0009.bin
     size: 762464
-    sha384: 1eaf75784c7383cd39e38032dfaf29609083d2d6796ccad38e9fff4721dee847bb83d13e7e2aee25db909c692b60a3ce
+    checksum: 1eaf75784c7383cd39e38032dfaf29609083d2d6796ccad38e9fff4721dee847bb83d13e7e2aee25db909c692b60a3ce
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP32/landmarks-regression-retail-0009.bin
   - name: FP16/landmarks-regression-retail-0009.xml
     size: 44871
-    sha384: 1400847442a9b67be5c63ebca1f17e3f2b7a2e0a876519bc3700262031cf3001e312036d170764a98ee02b6b64c92db3
+    checksum: 1400847442a9b67be5c63ebca1f17e3f2b7a2e0a876519bc3700262031cf3001e312036d170764a98ee02b6b64c92db3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.xml
   - name: FP16/landmarks-regression-retail-0009.bin
     size: 381248
-    sha384: 18c5d0b980d3ca27b9a2bd1a551a69ed2d86f3fb81211a1f66b6e336fcf2c4070235ec9698673a6ac6d815229f1f144e
+    checksum: 18c5d0b980d3ca27b9a2bd1a551a69ed2d86f3fb81211a1f66b6e336fcf2c4070235ec9698673a6ac6d815229f1f144e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP16/landmarks-regression-retail-0009.bin
   - name: FP16-INT8/landmarks-regression-retail-0009.xml
     size: 88757
-    sha384: 0333f00bcda3cf638b2643e568eb02c930e1a7d0825bf01460d8e04fe659d91a4e1b3652cd1352702d6907325709e314
+    checksum: 0333f00bcda3cf638b2643e568eb02c930e1a7d0825bf01460d8e04fe659d91a4e1b3652cd1352702d6907325709e314
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.xml
   - name: FP16-INT8/landmarks-regression-retail-0009.bin
     size: 196426
-    sha384: 5275de63086681c874f56e6818510ce4c1482fe729d46e1f0842b8d57b01c04c29a04b430ae05f0f84410318d7829822
+    checksum: 5275de63086681c874f56e6818510ce4c1482fe729d46e1f0842b8d57b01c04c29a04b430ae05f0f84410318d7829822
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/landmarks-regression-retail-0009/FP16-INT8/landmarks-regression-retail-0009.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/license-plate-recognition-barrier-0001/model.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/model.yml
@@ -18,27 +18,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/license-plate-recognition-barrier-0001.xml
     size: 51681
-    sha384: c3c36fbec5559bbd3c0aa195253e2dd1c55ff28c4e1a675a6068e5af6299c03ebec97f0317297466b7c446de079790ce
+    checksum: c3c36fbec5559bbd3c0aa195253e2dd1c55ff28c4e1a675a6068e5af6299c03ebec97f0317297466b7c446de079790ce
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.xml
   - name: FP32/license-plate-recognition-barrier-0001.bin
     size: 4871940
-    sha384: 4ec3d6adc5e470cb8faed53c5866e45a89e745b0ee0bd81d5be7d80481c49a2fccd694435e68c1470c365eb77c7ad30d
+    checksum: 4ec3d6adc5e470cb8faed53c5866e45a89e745b0ee0bd81d5be7d80481c49a2fccd694435e68c1470c365eb77c7ad30d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP32/license-plate-recognition-barrier-0001.bin
   - name: FP16/license-plate-recognition-barrier-0001.xml
     size: 51662
-    sha384: 6bd38237b1b90507f341021724c05b93060458205bc4f5b1e268695496b49b9be551c617c00aaa7365a66c4b8ee09dfd
+    checksum: 6bd38237b1b90507f341021724c05b93060458205bc4f5b1e268695496b49b9be551c617c00aaa7365a66c4b8ee09dfd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.xml
   - name: FP16/license-plate-recognition-barrier-0001.bin
     size: 2436038
-    sha384: f3db84570810f4476c6cab374a7b875dc10d2b29c0a1e38ab8d4e55cf39f5d63a34b82a79417c5788681e27265390d8c
+    checksum: f3db84570810f4476c6cab374a7b875dc10d2b29c0a1e38ab8d4e55cf39f5d63a34b82a79417c5788681e27265390d8c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP16/license-plate-recognition-barrier-0001.bin
   - name: FP16-INT8/license-plate-recognition-barrier-0001.xml
     size: 116073
-    sha384: 9f1cb692d8ac5eba5f07e21da2319996adc39c73e6202787cb613489769e21acbccc7b94322e5b69009f70c79ddee8f5
+    checksum: 9f1cb692d8ac5eba5f07e21da2319996adc39c73e6202787cb613489769e21acbccc7b94322e5b69009f70c79ddee8f5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.xml
   - name: FP16-INT8/license-plate-recognition-barrier-0001.bin
     size: 2041028
-    sha384: 008b22ce6b4cb5298dd6cd0aa770335b6482e0388337e692721b6dbda8eb865701974d2af38f13e0fbec3cf8bb6b1466
+    checksum: 008b22ce6b4cb5298dd6cd0aa770335b6482e0388337e692721b6dbda8eb865701974d2af38f13e0fbec3cf8bb6b1466
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/license-plate-recognition-barrier-0001/FP16-INT8/license-plate-recognition-barrier-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/machine-translation-nar-de-en-0002/model.yml
+++ b/models/intel/machine-translation-nar-de-en-0002/model.yml
@@ -19,19 +19,19 @@ task_type: machine_translation
 files:
   - name: FP32/machine-translation-nar-de-en-0002.xml
     size: 912660
-    sha384: ccc6c83cf9b982052719040dbbdb391f5f67d795703492d315d107de4b4846fe9abd156f21d33a5801f7437b21b3a571
+    checksum: ccc6c83cf9b982052719040dbbdb391f5f67d795703492d315d107de4b4846fe9abd156f21d33a5801f7437b21b3a571
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-de-en-0002/FP32/machine-translation-nar-de-en-0002.xml
   - name: FP32/machine-translation-nar-de-en-0002.bin
     size: 284547188
-    sha384: 5c909dba9177196f5a8b459d488b08977cdc2bdfea6ba3d07f0e1f0a762652db7ef7a006c9127a444fcd6ad658308085
+    checksum: 5c909dba9177196f5a8b459d488b08977cdc2bdfea6ba3d07f0e1f0a762652db7ef7a006c9127a444fcd6ad658308085
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-de-en-0002/FP32/machine-translation-nar-de-en-0002.bin
   - name: FP16/machine-translation-nar-de-en-0002.xml
     size: 912717
-    sha384: 8e1873ea32ba4d9161fe30512820be45c8f7f11707cf5b0771477b783df12c308bdf05567f8c240b4a6a71e3e4ce52a5
+    checksum: 8e1873ea32ba4d9161fe30512820be45c8f7f11707cf5b0771477b783df12c308bdf05567f8c240b4a6a71e3e4ce52a5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-de-en-0002/FP16/machine-translation-nar-de-en-0002.xml
   - name: FP16/machine-translation-nar-de-en-0002.bin
     size: 142274522
-    sha384: 1a2f1ffd9d9fac6b78ba4d0d6b69522934be1fd488fb92584f2cf83c12919954feaa15688d8aedf6e4d8fbdbf96c2305
+    checksum: 1a2f1ffd9d9fac6b78ba4d0d6b69522934be1fd488fb92584f2cf83c12919954feaa15688d8aedf6e4d8fbdbf96c2305
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-de-en-0002/FP16/machine-translation-nar-de-en-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/machine-translation-nar-en-de-0002/model.yml
+++ b/models/intel/machine-translation-nar-en-de-0002/model.yml
@@ -19,19 +19,19 @@ task_type: machine_translation
 files:
   - name: FP32/machine-translation-nar-en-de-0002.xml
     size: 912660
-    sha384: be85eaecee672829462e7edb18f36edbfe3edd8550b93a21a3b7042047fd5046957e59e73682add53f9ee31d77516681
+    checksum: be85eaecee672829462e7edb18f36edbfe3edd8550b93a21a3b7042047fd5046957e59e73682add53f9ee31d77516681
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-de-0002/FP32/machine-translation-nar-en-de-0002.xml
   - name: FP32/machine-translation-nar-en-de-0002.bin
     size: 284547188
-    sha384: 83f91dbbd894f3379f156682c59a64a903e7571d481c61805115f6ac26755388215328b93bece260a49989fa0963e1c7
+    checksum: 83f91dbbd894f3379f156682c59a64a903e7571d481c61805115f6ac26755388215328b93bece260a49989fa0963e1c7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-de-0002/FP32/machine-translation-nar-en-de-0002.bin
   - name: FP16/machine-translation-nar-en-de-0002.xml
     size: 912717
-    sha384: 15bdea70ebc32a539a76a7567cf65e37d56c09c137550e62c682ab9265d4fb5459b634a46e0ffd501aff31910aa78758
+    checksum: 15bdea70ebc32a539a76a7567cf65e37d56c09c137550e62c682ab9265d4fb5459b634a46e0ffd501aff31910aa78758
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-de-0002/FP16/machine-translation-nar-en-de-0002.xml
   - name: FP16/machine-translation-nar-en-de-0002.bin
     size: 142274522
-    sha384: 30485018446f624f3236a1c64d0faf3e7c8c6b4d985343f08941c24f2416a6a71df3d3cc65e21441b3df4ecb0f11ca15
+    checksum: 30485018446f624f3236a1c64d0faf3e7c8c6b4d985343f08941c24f2416a6a71df3d3cc65e21441b3df4ecb0f11ca15
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-de-0002/FP16/machine-translation-nar-en-de-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/machine-translation-nar-en-ru-0001/model.yml
+++ b/models/intel/machine-translation-nar-en-ru-0001/model.yml
@@ -19,19 +19,19 @@ task_type: machine_translation
 files:
   - name: FP32/machine-translation-nar-en-ru-0001.xml
     size: 918531
-    sha384: 8c049d1dd1e38345c8a01bb9110b1a2745acf92adf73a52c2f096010ba2cee546bb4483e0d5bf0c89c51b67a26c08715
+    checksum: 8c049d1dd1e38345c8a01bb9110b1a2745acf92adf73a52c2f096010ba2cee546bb4483e0d5bf0c89c51b67a26c08715
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-ru-0001/FP32/machine-translation-nar-en-ru-0001.xml
   - name: FP32/machine-translation-nar-en-ru-0001.bin
     size: 251814396
-    sha384: 8cc0315c4ecc84c5de1f89c2eacb883ef78f100b2d4995e69ffab9eab2c88adddf72e4862beea7c23324198230c3eb6d
+    checksum: 8cc0315c4ecc84c5de1f89c2eacb883ef78f100b2d4995e69ffab9eab2c88adddf72e4862beea7c23324198230c3eb6d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-ru-0001/FP32/machine-translation-nar-en-ru-0001.bin
   - name: FP16/machine-translation-nar-en-ru-0001.xml
     size: 918582
-    sha384: 2735ef50722c6807f0ef258c31b7abd8ec5c4e5e850005d7efdbcf43716abd9de22f51c8acf4fe035da689c9a2bc71c3
+    checksum: 2735ef50722c6807f0ef258c31b7abd8ec5c4e5e850005d7efdbcf43716abd9de22f51c8acf4fe035da689c9a2bc71c3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-ru-0001/FP16/machine-translation-nar-en-ru-0001.xml
   - name: FP16/machine-translation-nar-en-ru-0001.bin
     size: 125907314
-    sha384: ddc5e03ecd2deb149c51aed28065574a5843a6c5153231d6d4b87e4c9444020a59bf10b23859b547c519ee101b89b56e
+    checksum: ddc5e03ecd2deb149c51aed28065574a5843a6c5153231d6d4b87e4c9444020a59bf10b23859b547c519ee101b89b56e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-en-ru-0001/FP16/machine-translation-nar-en-ru-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/machine-translation-nar-ru-en-0001/model.yml
+++ b/models/intel/machine-translation-nar-ru-en-0001/model.yml
@@ -19,19 +19,19 @@ task_type: machine_translation
 files:
   - name: FP32/machine-translation-nar-ru-en-0001.xml
     size: 918531
-    sha384: 8ed34651a2c227bc7fe85a25bef8b74303fea0cf5555d4410600754f811d4685c641c960d7e384190118284a16ecc123
+    checksum: 8ed34651a2c227bc7fe85a25bef8b74303fea0cf5555d4410600754f811d4685c641c960d7e384190118284a16ecc123
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-ru-en-0001/FP32/machine-translation-nar-ru-en-0001.xml
   - name: FP32/machine-translation-nar-ru-en-0001.bin
     size: 251814396
-    sha384: 23c1bad7d1608ca1715a5e77e9598fdc3ddd4f88b3860855bc5c53251ba4b85df58cfc49b478753836f9c3a63d324c39
+    checksum: 23c1bad7d1608ca1715a5e77e9598fdc3ddd4f88b3860855bc5c53251ba4b85df58cfc49b478753836f9c3a63d324c39
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-ru-en-0001/FP32/machine-translation-nar-ru-en-0001.bin
   - name: FP16/machine-translation-nar-ru-en-0001.xml
     size: 918582
-    sha384: 1091343da67f5fdbaae952424f3f517de92c37a28c05617f6e0d2937a269466850378481c5f117079a4e4a501abf4049
+    checksum: 1091343da67f5fdbaae952424f3f517de92c37a28c05617f6e0d2937a269466850378481c5f117079a4e4a501abf4049
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-ru-en-0001/FP16/machine-translation-nar-ru-en-0001.xml
   - name: FP16/machine-translation-nar-ru-en-0001.bin
     size: 125907314
-    sha384: 74c3ac24911c5b1abc52114036255217b2829670cb453664594973d8f2045e40ed7c712ff18a6004c060bd8a46b5013e
+    checksum: 74c3ac24911c5b1abc52114036255217b2829670cb453664594973d8f2045e40ed7c712ff18a6004c060bd8a46b5013e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/machine-translation-nar-ru-en-0001/FP16/machine-translation-nar-ru-en-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/noise-suppression-poconetlike-0001/model.yml
+++ b/models/intel/noise-suppression-poconetlike-0001/model.yml
@@ -19,19 +19,19 @@ task_type: noise_suppression
 files:
   - name: FP32/noise-suppression-poconetlike-0001.xml
     size: 1496368
-    sha384: a178d77627473c743f1913deb79bad3ea0722cc33ced12dfc885264a793e80b1e8fedf0790c292d51fa83eccd214cda4
+    checksum: a178d77627473c743f1913deb79bad3ea0722cc33ced12dfc885264a793e80b1e8fedf0790c292d51fa83eccd214cda4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/4/noise-suppression-poconetlike-0001/FP32/noise-suppression-poconetlike-0001.xml
   - name: FP32/noise-suppression-poconetlike-0001.bin
     size: 29589616
-    sha384: a4fac74c9d2ca9a217464dc1e1ae8f4c8cec1187d9ec961043f6d49a11213cc1b11529d0b7d79a746cd1e05ad5af0809
+    checksum: a4fac74c9d2ca9a217464dc1e1ae8f4c8cec1187d9ec961043f6d49a11213cc1b11529d0b7d79a746cd1e05ad5af0809
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/4/noise-suppression-poconetlike-0001/FP32/noise-suppression-poconetlike-0001.bin
   - name: FP16/noise-suppression-poconetlike-0001.xml
     size: 1496238
-    sha384: 3eb339ee2cc336d1cee65dfa7ad104186e57a9216b9b4a679a2384848e21e8412fabc5e98595c67c6abe4a19c9d63d5c
+    checksum: 3eb339ee2cc336d1cee65dfa7ad104186e57a9216b9b4a679a2384848e21e8412fabc5e98595c67c6abe4a19c9d63d5c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/4/noise-suppression-poconetlike-0001/FP16/noise-suppression-poconetlike-0001.xml
   - name: FP16/noise-suppression-poconetlike-0001.bin
     size: 14795124
-    sha384: a7079744ba378094b2285c28eb7f79454ca9ff778f86a28fb46ac3ec93c049632b4c5a0712f9067a166290bdf36e50a7
+    checksum: a7079744ba378094b2285c28eb7f79454ca9ff778f86a28fb46ac3ec93c049632b4c5a0712f9067a166290bdf36e50a7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/4/noise-suppression-poconetlike-0001/FP16/noise-suppression-poconetlike-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 245221
-    sha384: c0a4141e351ea8daec0e2ec471c9246d155c97475d3a03e27e00c1255136c775928171747b7a6a16108dff2b1ceaf584
+    checksum: c0a4141e351ea8daec0e2ec471c9246d155c97475d3a03e27e00c1255136c775928171747b7a6a16108dff2b1ceaf584
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP32/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 6598568
-    sha384: 2c2b8c66780d5eaac5443bf42398d5bc61e326850c4db4ff5105f663180fc2db5afdd60ba2d7f0d6c909af4ce5777010
+    checksum: 2c2b8c66780d5eaac5443bf42398d5bc61e326850c4db4ff5105f663180fc2db5afdd60ba2d7f0d6c909af4ce5777010
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 245175
-    sha384: 390f3ba92d8d7c3cd7d9e94e78fc16b1473236e9db2140490bb4be1a639233b4db8b62ef255f5f8de3f1324c8e6eaf8b
+    checksum: 390f3ba92d8d7c3cd7d9e94e78fc16b1473236e9db2140490bb4be1a639233b4db8b62ef255f5f8de3f1324c8e6eaf8b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 3299336
-    sha384: 584f152c038fe3168dfbc7865a92e094e28265185ac1f13b48e623aa95e7493f718c70305842cbf286155c49747f64e5
+    checksum: 584f152c038fe3168dfbc7865a92e094e28265185ac1f13b48e623aa95e7493f718c70305842cbf286155c49747f64e5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16/pedestrian-and-vehicle-detector-adas-0001.bin
   - name: FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
     size: 478621
-    sha384: 9ec31e25161c225cd287fd74d9b13a448f6469da80071a6df76fffbd48f87667cb256b1d3771d9851fc52e253672b833
+    checksum: 9ec31e25161c225cd287fd74d9b13a448f6469da80071a6df76fffbd48f87667cb256b1d3771d9851fc52e253672b833
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.xml
   - name: FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
     size: 1705674
-    sha384: c062842bd776897622eadf7578e8a210e38eea57e24aff5f933cc63ad3819a5b6cf43da29f787c211a9f267977ee9b6f
+    checksum: c062842bd776897622eadf7578e8a210e38eea57e24aff5f933cc63ad3819a5b6cf43da29f787c211a9f267977ee9b6f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-and-vehicle-detector-adas-0001/FP16-INT8/pedestrian-and-vehicle-detector-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/pedestrian-detection-adas-0002/model.yml
+++ b/models/intel/pedestrian-detection-adas-0002/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/pedestrian-detection-adas-0002.xml
     size: 245104
-    sha384: 677956f4ed5d8321d10d728eb907c6a872bb1d623e5eacbae6054f8fb0458db4639983efa5bee6a1753610f77e35ef9b
+    checksum: 677956f4ed5d8321d10d728eb907c6a872bb1d623e5eacbae6054f8fb0458db4639983efa5bee6a1753610f77e35ef9b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.xml
   - name: FP32/pedestrian-detection-adas-0002.bin
     size: 4660248
-    sha384: 73ae5a4a75e2ab2492d0bac7bd55ac55935f31c25566ebfa121248647f53e9e30f3201d7b959fbda5b002834cdff0711
+    checksum: 73ae5a4a75e2ab2492d0bac7bd55ac55935f31c25566ebfa121248647f53e9e30f3201d7b959fbda5b002834cdff0711
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP32/pedestrian-detection-adas-0002.bin
   - name: FP16/pedestrian-detection-adas-0002.xml
     size: 245055
-    sha384: 8f3666672c95527709675596fe1a8ce4f6cb0450ddb3ee9a41d46d6dc134c552b2ab35bed5b53bc89d855284ff1c091f
+    checksum: 8f3666672c95527709675596fe1a8ce4f6cb0450ddb3ee9a41d46d6dc134c552b2ab35bed5b53bc89d855284ff1c091f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.xml
   - name: FP16/pedestrian-detection-adas-0002.bin
     size: 2330176
-    sha384: 6d13534345ed4d740eb4569c2b819ecc2e985c2740ec18914e659c9e94b29c35528b5c96162b12d5eb19109a67f9a96f
+    checksum: 6d13534345ed4d740eb4569c2b819ecc2e985c2740ec18914e659c9e94b29c35528b5c96162b12d5eb19109a67f9a96f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP16/pedestrian-detection-adas-0002.bin
   - name: FP16-INT8/pedestrian-detection-adas-0002.xml
     size: 478256
-    sha384: f263e7110ffcd392b2c86e6da3c65233928c402a4277b8de935c391c84d2bd8641e7efe45a0cdb4c3d5436226fbaf8a3
+    checksum: f263e7110ffcd392b2c86e6da3c65233928c402a4277b8de935c391c84d2bd8641e7efe45a0cdb4c3d5436226fbaf8a3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.xml
   - name: FP16-INT8/pedestrian-detection-adas-0002.bin
     size: 1212524
-    sha384: be05116c6ef364c585a6fbf33e2d9fc2caf9f3fe4219296074e73a5488541bb3b519ce24a5896fea1b994be0318c27ba
+    checksum: be05116c6ef364c585a6fbf33e2d9fc2caf9f3fe4219296074e73a5488541bb3b519ce24a5896fea1b994be0318c27ba
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/pedestrian-detection-adas-0002/FP16-INT8/pedestrian-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0230/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/model.yml
@@ -19,27 +19,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0230.xml
     size: 190069
-    sha384: d76a47b0266b2db8e8c094314b89e19396d42bbdca75552fc5798555b4abc33c5e129a5b3a9e5684f18ad4b8fedc4e00
+    checksum: d76a47b0266b2db8e8c094314b89e19396d42bbdca75552fc5798555b4abc33c5e129a5b3a9e5684f18ad4b8fedc4e00
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.xml
   - name: FP32/person-attributes-recognition-crossroad-0230.bin
     size: 2939240
-    sha384: 7aba696e9770272269e7f43dc3642975e0359abec20ec8e48baca6a588a8974e361a233f35fb8a4a7ac208afc1ed6c66
+    checksum: 7aba696e9770272269e7f43dc3642975e0359abec20ec8e48baca6a588a8974e361a233f35fb8a4a7ac208afc1ed6c66
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP32/person-attributes-recognition-crossroad-0230.bin
   - name: FP16/person-attributes-recognition-crossroad-0230.xml
     size: 189984
-    sha384: 674fb2f9cb12cd01fdeb705be73b242bad6386fe9e130678f6a5cb51280444fa50a7efe1d1f1dc5dd4cdf63ecded2d6c
+    checksum: 674fb2f9cb12cd01fdeb705be73b242bad6386fe9e130678f6a5cb51280444fa50a7efe1d1f1dc5dd4cdf63ecded2d6c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.xml
   - name: FP16/person-attributes-recognition-crossroad-0230.bin
     size: 1469632
-    sha384: a61c55f76ba12feb7e47ca84634fc9e1b3c99c53687f8b0152416f96006130ed24ae2726b24f788ebf4f15530f61f4fe
+    checksum: a61c55f76ba12feb7e47ca84634fc9e1b3c99c53687f8b0152416f96006130ed24ae2726b24f788ebf4f15530f61f4fe
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP16/person-attributes-recognition-crossroad-0230.bin
   - name: FP16-INT8/person-attributes-recognition-crossroad-0230.xml
     size: 491305
-    sha384: d09f548bb031643ff5fde2a09cc23c9219f2e9d7cb7e11529f2635aaf3fe2e26dfb1fffc51f0c83dbc417bea2b05e384
+    checksum: d09f548bb031643ff5fde2a09cc23c9219f2e9d7cb7e11529f2635aaf3fe2e26dfb1fffc51f0c83dbc417bea2b05e384
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.xml
   - name: FP16-INT8/person-attributes-recognition-crossroad-0230.bin
     size: 753574
-    sha384: 124d1d7d8cfb0ab470c43a48201792eecce60f5a7770f9d51701ca3976b8b712016a968396ad2d12b9d21e1dd8abfba4
+    checksum: 124d1d7d8cfb0ab470c43a48201792eecce60f5a7770f9d51701ca3976b8b712016a968396ad2d12b9d21e1dd8abfba4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0230/FP16-INT8/person-attributes-recognition-crossroad-0230.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0234/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0234/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0234.xml
     size: 192956
-    sha384: 1b1974cc36a2e6cc86510b48d682f75bd1424aedbe2d210068fa2314d23793df4bd2d9fe37eb41d3c0ae11c9fa6d22fd
+    checksum: 1b1974cc36a2e6cc86510b48d682f75bd1424aedbe2d210068fa2314d23793df4bd2d9fe37eb41d3c0ae11c9fa6d22fd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP32/person-attributes-recognition-crossroad-0234.xml
   - name: FP32/person-attributes-recognition-crossroad-0234.bin
     size: 94040716
-    sha384: e08ac2acf8b06f15417ac44e2ed6d40faaddb9ff147ef6c5c64692b10b1aa00e807e3c52769abc7bb37beb661615c5d2
+    checksum: e08ac2acf8b06f15417ac44e2ed6d40faaddb9ff147ef6c5c64692b10b1aa00e807e3c52769abc7bb37beb661615c5d2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP32/person-attributes-recognition-crossroad-0234.bin
   - name: FP16/person-attributes-recognition-crossroad-0234.xml
     size: 192896
-    sha384: 0eee7f11f4445d438aec71a281121f5f3a5d22a8e638eb4d00dfcd767294b9ea2bf7d3a51e5b352081ee284218bbba85
+    checksum: 0eee7f11f4445d438aec71a281121f5f3a5d22a8e638eb4d00dfcd767294b9ea2bf7d3a51e5b352081ee284218bbba85
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP16/person-attributes-recognition-crossroad-0234.xml
   - name: FP16/person-attributes-recognition-crossroad-0234.bin
     size: 47020388
-    sha384: ad1bd24fbedd058d72d4a7e77d374b7e1c8532b89330a61ffada0ab2dacc4ff9d2cff22e128d0e0571b35eb67daa78c7
+    checksum: ad1bd24fbedd058d72d4a7e77d374b7e1c8532b89330a61ffada0ab2dacc4ff9d2cff22e128d0e0571b35eb67daa78c7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP16/person-attributes-recognition-crossroad-0234.bin
   - name: FP16-INT8/person-attributes-recognition-crossroad-0234.xml
     size: 449259
-    sha384: ece2e9b754f0f5d080232ff22329eaa8632762d5b34b3cdf842071a1eb2713fcd972bbd3dcc0349f5fe3ad212379a4a7
+    checksum: ece2e9b754f0f5d080232ff22329eaa8632762d5b34b3cdf842071a1eb2713fcd972bbd3dcc0349f5fe3ad212379a4a7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP16-INT8/person-attributes-recognition-crossroad-0234.xml
   - name: FP16-INT8/person-attributes-recognition-crossroad-0234.bin
     size: 23651452
-    sha384: 694dda90a769bdd56beb76844882699f7fb262fcd33a8d20a7bd86bc30f52c0cf5775e6d6a8787591788e947526a095e
+    checksum: 694dda90a769bdd56beb76844882699f7fb262fcd33a8d20a7bd86bc30f52c0cf5775e6d6a8787591788e947526a095e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0234/FP16-INT8/person-attributes-recognition-crossroad-0234.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-attributes-recognition-crossroad-0238/model.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0238/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-attributes-recognition-crossroad-0238.xml
     size: 327332
-    sha384: dfb1cd96adf0509cc8b0086b017b321cbcf5f6fa3c4b0267e0f0a03d7a310fe9ddc0f9062b8fe59383a07d8638ca0ec6
+    checksum: dfb1cd96adf0509cc8b0086b017b321cbcf5f6fa3c4b0267e0f0a03d7a310fe9ddc0f9062b8fe59383a07d8638ca0ec6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP32/person-attributes-recognition-crossroad-0238.xml
   - name: FP32/person-attributes-recognition-crossroad-0238.bin
     size: 87188272
-    sha384: 84b00db26f24e15cdc2fec6dbdccf4a66192ceb29c0b28b8643b0a04404a25b9ff538c65dbaf264610882f1e4307837e
+    checksum: 84b00db26f24e15cdc2fec6dbdccf4a66192ceb29c0b28b8643b0a04404a25b9ff538c65dbaf264610882f1e4307837e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP32/person-attributes-recognition-crossroad-0238.bin
   - name: FP16/person-attributes-recognition-crossroad-0238.xml
     size: 327199
-    sha384: a851346bf3edf0741a5aa93912de3b8fca786e07cfb924e0f43ec59a38bb0fb8570c2e530b0eb0fdceeda8141de5ef9a
+    checksum: a851346bf3edf0741a5aa93912de3b8fca786e07cfb924e0f43ec59a38bb0fb8570c2e530b0eb0fdceeda8141de5ef9a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP16/person-attributes-recognition-crossroad-0238.xml
   - name: FP16/person-attributes-recognition-crossroad-0238.bin
     size: 43594182
-    sha384: 5f994148685dcf0e0710264ab37ebad6bb404e642966ddfc8d10f34dcf42e606cc148a1b55f9dabd1f2b8af61698c9e4
+    checksum: 5f994148685dcf0e0710264ab37ebad6bb404e642966ddfc8d10f34dcf42e606cc148a1b55f9dabd1f2b8af61698c9e4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP16/person-attributes-recognition-crossroad-0238.bin
   - name: FP16-INT8/person-attributes-recognition-crossroad-0238.xml
     size: 734570
-    sha384: e8dce714b9906b949530b767245d1c0f701580a090bc7e35485d816a3374cd45120be8f896294bf239ff8651c1c2c8e6
+    checksum: e8dce714b9906b949530b767245d1c0f701580a090bc7e35485d816a3374cd45120be8f896294bf239ff8651c1c2c8e6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP16-INT8/person-attributes-recognition-crossroad-0238.xml
   - name: FP16-INT8/person-attributes-recognition-crossroad-0238.bin
     size: 21891668
-    sha384: cc86f6c064718bba7d596f812ed730849bff2ff1f760797a8f90ccb092bd2d8be5e79a0a89745c363b759cc5960e7604
+    checksum: cc86f6c064718bba7d596f812ed730849bff2ff1f760797a8f90ccb092bd2d8be5e79a0a89745c363b759cc5960e7604
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-attributes-recognition-crossroad-0238/FP16-INT8/person-attributes-recognition-crossroad-0238.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0106/model.yml
+++ b/models/intel/person-detection-0106/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0106.xml
     size: 1450390
-    sha384: bb24738ed7a90527287d34fdd3af932eeacec6ff6701e5bcb5d07730ad086fad8977c2b8e81a3330f1f47a205e7fcc95
+    checksum: bb24738ed7a90527287d34fdd3af932eeacec6ff6701e5bcb5d07730ad086fad8977c2b8e81a3330f1f47a205e7fcc95
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP32/person-detection-0106.xml
   - name: FP32/person-detection-0106.bin
     size: 276501900
-    sha384: 20ef3b23d0a1315f3edb32b771bdae537f227fb3c10b359e4b2b272e8189dcb15ebdd2584653d83e606afe1a03b4bc7a
+    checksum: 20ef3b23d0a1315f3edb32b771bdae537f227fb3c10b359e4b2b272e8189dcb15ebdd2584653d83e606afe1a03b4bc7a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP32/person-detection-0106.bin
   - name: FP16/person-detection-0106.xml
     size: 1449678
-    sha384: 0f8930b39fc52a71bf13481c4a08686844b8e279352a9b47c1a0beb3d18835e2b203be4574b5b28823862f91616fdd0b
+    checksum: 0f8930b39fc52a71bf13481c4a08686844b8e279352a9b47c1a0beb3d18835e2b203be4574b5b28823862f91616fdd0b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP16/person-detection-0106.xml
   - name: FP16/person-detection-0106.bin
     size: 138251164
-    sha384: 608070aabee27cbc105935e63708c2b85f35f66981c0bc25e45667e602b279ea1feaf725a3b95681167e9f2783c2bfaf
+    checksum: 608070aabee27cbc105935e63708c2b85f35f66981c0bc25e45667e602b279ea1feaf725a3b95681167e9f2783c2bfaf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP16/person-detection-0106.bin
   - name: FP16-INT8/person-detection-0106.xml
     size: 1781713
-    sha384: 766d2f5cf1d390bf10ee65714fd90c039a6b8a4e32fa32d9e2fa5466b3d8a58eda3f9fed015c7df76cc373ec09af3010
+    checksum: 766d2f5cf1d390bf10ee65714fd90c039a6b8a4e32fa32d9e2fa5466b3d8a58eda3f9fed015c7df76cc373ec09af3010
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP16-INT8/person-detection-0106.xml
   - name: FP16-INT8/person-detection-0106.bin
     size: 146371996
-    sha384: ab8e8ae498a7ba8ff88b7c3100607dab8f406a01e533fa4ac24f349c333b8c20cdf5d67545f91aff12e5c52e2d10a2f0
+    checksum: ab8e8ae498a7ba8ff88b7c3100607dab8f406a01e533fa4ac24f349c333b8c20cdf5d67545f91aff12e5c52e2d10a2f0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0106/FP16-INT8/person-detection-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0200/model.yml
+++ b/models/intel/person-detection-0200/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0200.xml
     size: 200423
-    sha384: f44db5a2975a8058c015e7bcac356c8084f6bf79518885e706a2b92dfe551ab4a124d70800001845ef5bc4d92bc342ca
+    checksum: f44db5a2975a8058c015e7bcac356c8084f6bf79518885e706a2b92dfe551ab4a124d70800001845ef5bc4d92bc342ca
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP32/person-detection-0200.xml
   - name: FP32/person-detection-0200.bin
     size: 7269168
-    sha384: d5a49a7a9821600ee8724860e2dcd6c22a1b14b03b238e09eb9f01ebfe34beff422cf2b15eb7d3583cbb3d4bec01aade
+    checksum: d5a49a7a9821600ee8724860e2dcd6c22a1b14b03b238e09eb9f01ebfe34beff422cf2b15eb7d3583cbb3d4bec01aade
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP32/person-detection-0200.bin
   - name: FP16/person-detection-0200.xml
     size: 200360
-    sha384: a1ca2881d623f4c111095a6931dd0c060b66feddd38634dc8e5ed2c92f666aec2f76bfc0d0b9f7e97cf19be20a1e31f3
+    checksum: a1ca2881d623f4c111095a6931dd0c060b66feddd38634dc8e5ed2c92f666aec2f76bfc0d0b9f7e97cf19be20a1e31f3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP16/person-detection-0200.xml
   - name: FP16/person-detection-0200.bin
     size: 3634626
-    sha384: 3edb6efbcd59d0606d39ae0d7ea25ca93d83ec7ffc16af97186d32e278a738f731f8f347607a388240c9a3fec28a26bd
+    checksum: 3edb6efbcd59d0606d39ae0d7ea25ca93d83ec7ffc16af97186d32e278a738f731f8f347607a388240c9a3fec28a26bd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP16/person-detection-0200.bin
   - name: FP16-INT8/person-detection-0200.xml
     size: 482309
-    sha384: ab0f4131ea0a5dd4a9f83b7125be323793d3f6431b4a821ab482f2220dfbfe2c97f765119a24e72ae36f50b9317b2a76
+    checksum: ab0f4131ea0a5dd4a9f83b7125be323793d3f6431b4a821ab482f2220dfbfe2c97f765119a24e72ae36f50b9317b2a76
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP16-INT8/person-detection-0200.xml
   - name: FP16-INT8/person-detection-0200.bin
     size: 1921618
-    sha384: a937724b169567f0ee3cb91c0cd00ce39b1b700cc05ada14833113587442463f63ee840de5b4430284389e15e6558a7f
+    checksum: a937724b169567f0ee3cb91c0cd00ce39b1b700cc05ada14833113587442463f63ee840de5b4430284389e15e6558a7f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0200/FP16-INT8/person-detection-0200.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0201/model.yml
+++ b/models/intel/person-detection-0201/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0201.xml
     size: 200612
-    sha384: 432dc5cb62264a1686a43632a28adde1d9cd0385cf1aec402b9b85488a8e6a4b0c767f0c577df5edf01bb49ff59c8d44
+    checksum: 432dc5cb62264a1686a43632a28adde1d9cd0385cf1aec402b9b85488a8e6a4b0c767f0c577df5edf01bb49ff59c8d44
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP32/person-detection-0201.xml
   - name: FP32/person-detection-0201.bin
     size: 7269168
-    sha384: fc215ad9d88f2fd4af97b06b4b3025565bcd04c4f981f50631ef213328f8da880be5c784a80f3b94180bbf7db176fa84
+    checksum: fc215ad9d88f2fd4af97b06b4b3025565bcd04c4f981f50631ef213328f8da880be5c784a80f3b94180bbf7db176fa84
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP32/person-detection-0201.bin
   - name: FP16/person-detection-0201.xml
     size: 200549
-    sha384: a459efd8fa31a3a9419743d385cba9ce328a0df1781eb49a58ada070fb0e1e04e31f370bbf7cd287d08f7759c47d0d54
+    checksum: a459efd8fa31a3a9419743d385cba9ce328a0df1781eb49a58ada070fb0e1e04e31f370bbf7cd287d08f7759c47d0d54
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP16/person-detection-0201.xml
   - name: FP16/person-detection-0201.bin
     size: 3634626
-    sha384: 5ee11d3d5cfd360e47e146ab158a1235f88c0d03d203c442b7e49e004eecb629dd7275d30c4017aee08e6136267a8054
+    checksum: 5ee11d3d5cfd360e47e146ab158a1235f88c0d03d203c442b7e49e004eecb629dd7275d30c4017aee08e6136267a8054
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP16/person-detection-0201.bin
   - name: FP16-INT8/person-detection-0201.xml
     size: 482538
-    sha384: 58aa31e979e601609e05586b9cb63dfc0a9561fa8a1babcea1d13fbc246c1fc59d0efc95d3c398677d20dd8e2106397a
+    checksum: 58aa31e979e601609e05586b9cb63dfc0a9561fa8a1babcea1d13fbc246c1fc59d0efc95d3c398677d20dd8e2106397a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP16-INT8/person-detection-0201.xml
   - name: FP16-INT8/person-detection-0201.bin
     size: 1921614
-    sha384: 4e8b3bb3d1805e1b935f085511a68be9c9f48e309d37a008990aa0315df5833c5662f85e72d221d790655ac683a4abad
+    checksum: 4e8b3bb3d1805e1b935f085511a68be9c9f48e309d37a008990aa0315df5833c5662f85e72d221d790655ac683a4abad
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0201/FP16-INT8/person-detection-0201.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0202/model.yml
+++ b/models/intel/person-detection-0202/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0202.xml
     size: 200694
-    sha384: 847ae840e8c780ac1fe4557ae93041e11cf752eaec3c9efb0e5172b8b7eb82a13cc8ff284308abb04d4b52cbc56574c1
+    checksum: 847ae840e8c780ac1fe4557ae93041e11cf752eaec3c9efb0e5172b8b7eb82a13cc8ff284308abb04d4b52cbc56574c1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP32/person-detection-0202.xml
   - name: FP32/person-detection-0202.bin
     size: 7269168
-    sha384: 02f39b83f9cbdc5f4bb8e44d5570e6e1f4148cfac4355e114c68d6f83b929dbca027e44cf7063da487942ddbe3bafce8
+    checksum: 02f39b83f9cbdc5f4bb8e44d5570e6e1f4148cfac4355e114c68d6f83b929dbca027e44cf7063da487942ddbe3bafce8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP32/person-detection-0202.bin
   - name: FP16/person-detection-0202.xml
     size: 200631
-    sha384: 6f1f379fad8256d6743fae2890fafcfeb26d61cf7300deace3a0c12fbafe439c0bd0e68a28018427dbe28450ed6b8508
+    checksum: 6f1f379fad8256d6743fae2890fafcfeb26d61cf7300deace3a0c12fbafe439c0bd0e68a28018427dbe28450ed6b8508
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP16/person-detection-0202.xml
   - name: FP16/person-detection-0202.bin
     size: 3634626
-    sha384: 1f3033bf448786aa7239f49b5eecca69f08787e04d7ba8e37ce9413450178a4aaf8b5f090c8a9155b629319167de0c5d
+    checksum: 1f3033bf448786aa7239f49b5eecca69f08787e04d7ba8e37ce9413450178a4aaf8b5f090c8a9155b629319167de0c5d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP16/person-detection-0202.bin
   - name: FP16-INT8/person-detection-0202.xml
     size: 479635
-    sha384: a9e8fe34b58f4391fec7489323bb75f441d63c9e0a81ab1095b81409e561ce051927c5bac3ec4fbd99c2389281754ac9
+    checksum: a9e8fe34b58f4391fec7489323bb75f441d63c9e0a81ab1095b81409e561ce051927c5bac3ec4fbd99c2389281754ac9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP16-INT8/person-detection-0202.xml
   - name: FP16-INT8/person-detection-0202.bin
     size: 1587028
-    sha384: 0743b95413c17b159e65640aeab841dbf52b86b250dde8562e5b8676e1f289ebffc3ef65f95414738ba0f5fced3f3210
+    checksum: 0743b95413c17b159e65640aeab841dbf52b86b250dde8562e5b8676e1f289ebffc3ef65f95414738ba0f5fced3f3210
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0202/FP16-INT8/person-detection-0202.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-0203/model.yml
+++ b/models/intel/person-detection-0203/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-0203.xml
     size: 1270918
-    sha384: a9d557c6fa3e552895a0433e85a72a66cf774d0da4a1f7450d93a72ad69c7c447b7b8458e9d1010b9e3373ce9f616374
+    checksum: a9d557c6fa3e552895a0433e85a72a66cf774d0da4a1f7450d93a72ad69c7c447b7b8458e9d1010b9e3373ce9f616374
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP32/person-detection-0203.xml
   - name: FP32/person-detection-0203.bin
     size: 7804628
-    sha384: 46845765fb29bd214d0e6c5b5024915652b095e0e2833e061c97d0ad65ec5f27d682c78731f1a50584e1bf55cfa57e6c
+    checksum: 46845765fb29bd214d0e6c5b5024915652b095e0e2833e061c97d0ad65ec5f27d682c78731f1a50584e1bf55cfa57e6c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP32/person-detection-0203.bin
   - name: FP16/person-detection-0203.xml
     size: 1270746
-    sha384: b87d29b4f9be012ca5264e9f18c31fb497e594ce18c3baa6f1ad635cbae586dc27b6754d76f175808bfc0dda8337dd94
+    checksum: b87d29b4f9be012ca5264e9f18c31fb497e594ce18c3baa6f1ad635cbae586dc27b6754d76f175808bfc0dda8337dd94
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP16/person-detection-0203.xml
   - name: FP16/person-detection-0203.bin
     size: 3902536
-    sha384: ab8f7f800e701e616838db164fb521ec3d8db5f4148569d0925458b5353866e5c213e09c4e6e5d5d947725be2b98f46e
+    checksum: ab8f7f800e701e616838db164fb521ec3d8db5f4148569d0925458b5353866e5c213e09c4e6e5d5d947725be2b98f46e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP16/person-detection-0203.bin
   - name: FP16-INT8/person-detection-0203.xml
     size: 1827991
-    sha384: ccddba6bbdf513d66b5ee1b78e7a4331184b29fcb5125d0e81836ca9d52f4e46bc79c1a0a385f21127ad473e22174db7
+    checksum: ccddba6bbdf513d66b5ee1b78e7a4331184b29fcb5125d0e81836ca9d52f4e46bc79c1a0a385f21127ad473e22174db7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP16-INT8/person-detection-0203.xml
   - name: FP16-INT8/person-detection-0203.bin
     size: 2053626
-    sha384: 0ae93e7db22ba3068047fb20c75876cb6c34716b6ca28aefd21dd38e28d6528357e22603cfab0670beb31a7c9a9a61b1
+    checksum: 0ae93e7db22ba3068047fb20c75876cb6c34716b6ca28aefd21dd38e28d6528357e22603cfab0670beb31a7c9a9a61b1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-0203/FP16-INT8/person-detection-0203.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0005/model.yml
+++ b/models/intel/person-detection-action-recognition-0005/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0005.xml
     size: 707400
-    sha384: e5540277fc08d7bba03dd652cb49d549c39871159635110b4e0e5a5bc261b8bb66d5fe9c6e347951fb0c73ab0002e00c
+    checksum: e5540277fc08d7bba03dd652cb49d549c39871159635110b4e0e5a5bc261b8bb66d5fe9c6e347951fb0c73ab0002e00c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.xml
   - name: FP32/person-detection-action-recognition-0005.bin
     size: 7800360
-    sha384: 36aa2b7f15b3a5960bd7369e6981bb2256507fed9a42ce1ca9a53d03ae9a48ba72bf0219ea76a91c309e9feef8688043
+    checksum: 36aa2b7f15b3a5960bd7369e6981bb2256507fed9a42ce1ca9a53d03ae9a48ba72bf0219ea76a91c309e9feef8688043
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP32/person-detection-action-recognition-0005.bin
   - name: FP16/person-detection-action-recognition-0005.xml
     size: 707156
-    sha384: 323ddb0bb97cdc354b25ad82517f673f6e1c335d7cb2fb424ac24734c78533654c0e15e15a3ff7477fa6bc39efd34289
+    checksum: 323ddb0bb97cdc354b25ad82517f673f6e1c335d7cb2fb424ac24734c78533654c0e15e15a3ff7477fa6bc39efd34289
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.xml
   - name: FP16/person-detection-action-recognition-0005.bin
     size: 3900234
-    sha384: d74f201413724f289205d7a623492ef2f591c6a0df08307ade843f8e7aef43ff8736868e59e384c20055c51dea40144e
+    checksum: d74f201413724f289205d7a623492ef2f591c6a0df08307ade843f8e7aef43ff8736868e59e384c20055c51dea40144e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP16/person-detection-action-recognition-0005.bin
   - name: FP16-INT8/person-detection-action-recognition-0005.xml
     size: 1949791
-    sha384: e63ce32bc01ce38b73b4150765cf5a6c73127b9ed2263e239b85d7984da8d7e1bed8c557940224d58fb882af79cff30f
+    checksum: e63ce32bc01ce38b73b4150765cf5a6c73127b9ed2263e239b85d7984da8d7e1bed8c557940224d58fb882af79cff30f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.xml
   - name: FP16-INT8/person-detection-action-recognition-0005.bin
     size: 2055112
-    sha384: 9a9505db6a7f8314ea64d248a19a5577c78fc49d27d7632adaaee2cf39fb9b560df1d9d12e5db03efef5100467f2d29a
+    checksum: 9a9505db6a7f8314ea64d248a19a5577c78fc49d27d7632adaaee2cf39fb9b560df1d9d12e5db03efef5100467f2d29a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0005/FP16-INT8/person-detection-action-recognition-0005.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-0006/model.yml
+++ b/models/intel/person-detection-action-recognition-0006/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-0006.xml
     size: 862995
-    sha384: e31d4931c74172a527bb769d949b4fb0e2de831ba7147dd45e9dba48d8a4be6c6f7c2cec93bd0bee9475a3de95f55991
+    checksum: e31d4931c74172a527bb769d949b4fb0e2de831ba7147dd45e9dba48d8a4be6c6f7c2cec93bd0bee9475a3de95f55991
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.xml
   - name: FP32/person-detection-action-recognition-0006.bin
     size: 7458348
-    sha384: 80aae816b96ec8fe06c0c7ab5b5bc3d5806f61a5d094800b6eb021740ee0931c34c7f180eea2bf3538d676c58d59b0c8
+    checksum: 80aae816b96ec8fe06c0c7ab5b5bc3d5806f61a5d094800b6eb021740ee0931c34c7f180eea2bf3538d676c58d59b0c8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP32/person-detection-action-recognition-0006.bin
   - name: FP16/person-detection-action-recognition-0006.xml
     size: 862754
-    sha384: 7e2b2ada7a2275507f6eb34fc983c9ce31e5c35eb5c888dda705d42103564d98017a6b89e7783faed60d0845b2b69651
+    checksum: 7e2b2ada7a2275507f6eb34fc983c9ce31e5c35eb5c888dda705d42103564d98017a6b89e7783faed60d0845b2b69651
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.xml
   - name: FP16/person-detection-action-recognition-0006.bin
     size: 3729220
-    sha384: b81ddbbe914cbb0815428c362d3c664401ff58a648e43f4a9caafcc8b147d2d86ca9bedf32c2d46d4e415a8e59e5c8ae
+    checksum: b81ddbbe914cbb0815428c362d3c664401ff58a648e43f4a9caafcc8b147d2d86ca9bedf32c2d46d4e415a8e59e5c8ae
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP16/person-detection-action-recognition-0006.bin
   - name: FP16-INT8/person-detection-action-recognition-0006.xml
     size: 2219124
-    sha384: 2bc91f497d159968bbd12d043f54ac32375e0ab39f7d86210654f7f46768d29c40009dccf0413dc88c16cc85e28b71ac
+    checksum: 2bc91f497d159968bbd12d043f54ac32375e0ab39f7d86210654f7f46768d29c40009dccf0413dc88c16cc85e28b71ac
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.xml
   - name: FP16-INT8/person-detection-action-recognition-0006.bin
     size: 1982770
-    sha384: aa8dec743a1116483738fed5fec190fbf6aafc265dd0c775ce2c83ef53d0c2b35a22349173d996a6d4013cfdd018d9b3
+    checksum: aa8dec743a1116483738fed5fec190fbf6aafc265dd0c775ce2c83ef53d0c2b35a22349173d996a6d4013cfdd018d9b3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-0006/FP16-INT8/person-detection-action-recognition-0006.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-action-recognition-teacher-0002/model.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-action-recognition-teacher-0002.xml
     size: 707408
-    sha384: 3b91813d9e2f9f485b9d9763a5adea5e7d0e064ada191fa8086972e8bdbb71bd035b3327442266d09139a214579d21d0
+    checksum: 3b91813d9e2f9f485b9d9763a5adea5e7d0e064ada191fa8086972e8bdbb71bd035b3327442266d09139a214579d21d0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.xml
   - name: FP32/person-detection-action-recognition-teacher-0002.bin
     size: 7800360
-    sha384: 71ebd437ed9e4d2b91dd49bcada2cc58b8772f7f4f911c69746d0f209e36d7e14fad450e4d6a944c3577312cf648e4ba
+    checksum: 71ebd437ed9e4d2b91dd49bcada2cc58b8772f7f4f911c69746d0f209e36d7e14fad450e4d6a944c3577312cf648e4ba
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP32/person-detection-action-recognition-teacher-0002.bin
   - name: FP16/person-detection-action-recognition-teacher-0002.xml
     size: 707164
-    sha384: 1fee57b9c17389400fb1a03f64cf07143799a2560717b855917f46a03680a149a47d7e992dc5bdf52e44ae27d8a4df2e
+    checksum: 1fee57b9c17389400fb1a03f64cf07143799a2560717b855917f46a03680a149a47d7e992dc5bdf52e44ae27d8a4df2e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.xml
   - name: FP16/person-detection-action-recognition-teacher-0002.bin
     size: 3900234
-    sha384: 54af2b0962fe3152160c07af8590a6fd5fac80e40ef1576a7668433988a14ffcca2cbf06993632fc777da7354dec6820
+    checksum: 54af2b0962fe3152160c07af8590a6fd5fac80e40ef1576a7668433988a14ffcca2cbf06993632fc777da7354dec6820
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP16/person-detection-action-recognition-teacher-0002.bin
   - name: FP16-INT8/person-detection-action-recognition-teacher-0002.xml
     size: 1949822
-    sha384: 93896c4dd2a7759a7e5eb37d1778aff4d712acb230cf1d5a904787659007fe6adeac878c9f263ca2394ad3044380119f
+    checksum: 93896c4dd2a7759a7e5eb37d1778aff4d712acb230cf1d5a904787659007fe6adeac878c9f263ca2394ad3044380119f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.xml
   - name: FP16-INT8/person-detection-action-recognition-teacher-0002.bin
     size: 2055068
-    sha384: 2f822911f38d56f7001a6ebb8377eba035c73e51163b3c7b381e8cee48b6a6d038624ff1eb463cd6eec9a18f286593cb
+    checksum: 2f822911f38d56f7001a6ebb8377eba035c73e51163b3c7b381e8cee48b6a6d038624ff1eb463cd6eec9a18f286593cb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-action-recognition-teacher-0002/FP16-INT8/person-detection-action-recognition-teacher-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-asl-0001/model.yml
+++ b/models/intel/person-detection-asl-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-asl-0001.xml
     size: 1016377
-    sha384: 7161073f6a5d7d7a9c85118cd10abf5a2d466fdf717b1c37635b66f4dd3ae7fb8e78835a9793a44ad14026bac8ba383e
+    checksum: 7161073f6a5d7d7a9c85118cd10abf5a2d466fdf717b1c37635b66f4dd3ae7fb8e78835a9793a44ad14026bac8ba383e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP32/person-detection-asl-0001.xml
   - name: FP32/person-detection-asl-0001.bin
     size: 4026304
-    sha384: 93a88e414311757538e0bf0652c3cdc1013137cc7cc5f4e2b954494e11176bb905ae62f818ff0fb4f64ade58c3a3366a
+    checksum: 93a88e414311757538e0bf0652c3cdc1013137cc7cc5f4e2b954494e11176bb905ae62f818ff0fb4f64ade58c3a3366a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP32/person-detection-asl-0001.bin
   - name: FP16/person-detection-asl-0001.xml
     size: 1016222
-    sha384: 6e6c8e63a68d3761102b597c2e0184ae8f657cfabeae626706f5728bee1f26199b49eae6fa8c62ecd9da3b31aeeca5a7
+    checksum: 6e6c8e63a68d3761102b597c2e0184ae8f657cfabeae626706f5728bee1f26199b49eae6fa8c62ecd9da3b31aeeca5a7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP16/person-detection-asl-0001.xml
   - name: FP16/person-detection-asl-0001.bin
     size: 2013336
-    sha384: c3daaca936d19e7282f0aa949ca8e42efb80ec7cb90cfb46f1473cd2cea7ea7f48f2841ce8331512a1427d98a2594c4f
+    checksum: c3daaca936d19e7282f0aa949ca8e42efb80ec7cb90cfb46f1473cd2cea7ea7f48f2841ce8331512a1427d98a2594c4f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP16/person-detection-asl-0001.bin
   - name: FP16-INT8/person-detection-asl-0001.xml
     size: 1581814
-    sha384: 6eb03c5b82c1fcf0d771c4303fb9df00a512c2f32f8fb0e4fd5d7c2fc9235f2f3285ae2590f826c85a4472fcfc7921e3
+    checksum: 6eb03c5b82c1fcf0d771c4303fb9df00a512c2f32f8fb0e4fd5d7c2fc9235f2f3285ae2590f826c85a4472fcfc7921e3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.xml
   - name: FP16-INT8/person-detection-asl-0001.bin
     size: 1055666
-    sha384: fe1f63b73aa2eca383c66f1abfedb5e072b66c4e8b78266f81cd3dd63d2b49106a73c8ba01154aeb9fc1a53a4e67f072
+    checksum: fe1f63b73aa2eca383c66f1abfedb5e072b66c4e8b78266f81cd3dd63d2b49106a73c8ba01154aeb9fc1a53a4e67f072
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-asl-0001/FP16-INT8/person-detection-asl-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-raisinghand-recognition-0001/model.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-raisinghand-recognition-0001.xml
     size: 707405
-    sha384: 92f25cf7f8531a4cdb8e56a5a1f11ef3a2f9e09c4f2619bcc9e7e3021f2d694f9c6253d14388a04fa8136e77acc33d5f
+    checksum: 92f25cf7f8531a4cdb8e56a5a1f11ef3a2f9e09c4f2619bcc9e7e3021f2d694f9c6253d14388a04fa8136e77acc33d5f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.xml
   - name: FP32/person-detection-raisinghand-recognition-0001.bin
     size: 7799848
-    sha384: dd7106ca149b42b8a995842fac18d7c3ca89bce8bb1de0235f2a1c3c306858cdf92571f8d726c24f3c792edd93763538
+    checksum: dd7106ca149b42b8a995842fac18d7c3ca89bce8bb1de0235f2a1c3c306858cdf92571f8d726c24f3c792edd93763538
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP32/person-detection-raisinghand-recognition-0001.bin
   - name: FP16/person-detection-raisinghand-recognition-0001.xml
     size: 707161
-    sha384: f74cf09d0335231c454fd3aeee6124542b6cf60c79816ef0a42f58c97e37e881301f1378bec2623008dac271573cd1b7
+    checksum: f74cf09d0335231c454fd3aeee6124542b6cf60c79816ef0a42f58c97e37e881301f1378bec2623008dac271573cd1b7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.xml
   - name: FP16/person-detection-raisinghand-recognition-0001.bin
     size: 3899978
-    sha384: 0527ecac1b503953ff7655cde7428a164a44c961c44cb769cfb28229b411282302e4e834904092205ab56ee64a7ff0a7
+    checksum: 0527ecac1b503953ff7655cde7428a164a44c961c44cb769cfb28229b411282302e4e834904092205ab56ee64a7ff0a7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP16/person-detection-raisinghand-recognition-0001.bin
   - name: FP16-INT8/person-detection-raisinghand-recognition-0001.xml
     size: 1797554
-    sha384: 54d0ce6f85f08e41d98abe51c866813116d81bbce1d0f4108080ec072ce2a4cf48bacc2f24689cbe11e263ec86fc1eaa
+    checksum: 54d0ce6f85f08e41d98abe51c866813116d81bbce1d0f4108080ec072ce2a4cf48bacc2f24689cbe11e263ec86fc1eaa
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.xml
   - name: FP16-INT8/person-detection-raisinghand-recognition-0001.bin
     size: 2054944
-    sha384: 9ecb0eada22d8738b1eb359d2983c2cbc0851bfcd8f359fd79fedc0584580a75137c2bafa54d66e7757953b9b14591c8
+    checksum: 9ecb0eada22d8738b1eb359d2983c2cbc0851bfcd8f359fd79fedc0584580a75137c2bafa54d66e7757953b9b14591c8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-raisinghand-recognition-0001/FP16-INT8/person-detection-raisinghand-recognition-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0002/model.yml
+++ b/models/intel/person-detection-retail-0002/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-retail-0002.xml
     size: 285234
-    sha384: a8c4c8ee9ad2e94e70b9e6978afbcd64d228811db23502eccb6dc82dfe226bb65d3dc049063bd2253bffea772359325e
+    checksum: a8c4c8ee9ad2e94e70b9e6978afbcd64d228811db23502eccb6dc82dfe226bb65d3dc049063bd2253bffea772359325e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP32/person-detection-retail-0002.xml
   - name: FP32/person-detection-retail-0002.bin
     size: 12976100
-    sha384: 1caf321bbb4f4e8ac2f6ecbd1e184938a3fa4fe8d2a04ae8930e4467590a14fc6e6c79942903ae729a6c647f842d4758
+    checksum: 1caf321bbb4f4e8ac2f6ecbd1e184938a3fa4fe8d2a04ae8930e4467590a14fc6e6c79942903ae729a6c647f842d4758
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP32/person-detection-retail-0002.bin
   - name: FP16/person-detection-retail-0002.xml
     size: 285111
-    sha384: 100e0f0b41c5e31ac0b8313841030d0bd7c03b0260882a458a46dafdd0900d061b512c82c658e7a1e048c58a41bced74
+    checksum: 100e0f0b41c5e31ac0b8313841030d0bd7c03b0260882a458a46dafdd0900d061b512c82c658e7a1e048c58a41bced74
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP16/person-detection-retail-0002.xml
   - name: FP16/person-detection-retail-0002.bin
     size: 6488130
-    sha384: 3db936c591df3125df3a541b0d2d94ac2b63564d7680851c095dd6aceea92af7638d4af965dd9a04a00e5b8f55c06d19
+    checksum: 3db936c591df3125df3a541b0d2d94ac2b63564d7680851c095dd6aceea92af7638d4af965dd9a04a00e5b8f55c06d19
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP16/person-detection-retail-0002.bin
   - name: FP16-INT8/person-detection-retail-0002.xml
     size: 720318
-    sha384: 68eb2b0941cffdd993b19c012785ac0bdfc66c17a78c7b60d6bf6fe0c3cb02d4359be59d5717dfdc0cbcc9047d2e6449
+    checksum: 68eb2b0941cffdd993b19c012785ac0bdfc66c17a78c7b60d6bf6fe0c3cb02d4359be59d5717dfdc0cbcc9047d2e6449
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.xml
   - name: FP16-INT8/person-detection-retail-0002.bin
     size: 3298354
-    sha384: 8f737b7d7741c10deab8f78cac69589775c1ca2a70fc6de319a2e87c9e5009f387238d779988eeb47d63f6c4a6c52c73
+    checksum: 8f737b7d7741c10deab8f78cac69589775c1ca2a70fc6de319a2e87c9e5009f387238d779988eeb47d63f6c4a6c52c73
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0002/FP16-INT8/person-detection-retail-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-detection-retail-0013/model.yml
+++ b/models/intel/person-detection-retail-0013/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-detection-retail-0013.xml
     size: 382996
-    sha384: cf011606b06e5f293ab572715225d6f536077c32c35296c54d8d0bcb9f6a92695a7960a6cd8deb15b89641ef71045406
+    checksum: cf011606b06e5f293ab572715225d6f536077c32c35296c54d8d0bcb9f6a92695a7960a6cd8deb15b89641ef71045406
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP32/person-detection-retail-0013.xml
   - name: FP32/person-detection-retail-0013.bin
     size: 2891364
-    sha384: e26fbd0ec879ea7de5338e7cb4b3607128a4b9c690e07c17c9ee89d3a5c686e0e9d1d05b8654f08ff227435d8c6e8169
+    checksum: e26fbd0ec879ea7de5338e7cb4b3607128a4b9c690e07c17c9ee89d3a5c686e0e9d1d05b8654f08ff227435d8c6e8169
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP32/person-detection-retail-0013.bin
   - name: FP16/person-detection-retail-0013.xml
     size: 382841
-    sha384: ac4e5f267cd91b7254487d7e7effde4bbbc56f69bd66fabd017c55fe8a7675009255bae12315caef61e0e33cc78fbb29
+    checksum: ac4e5f267cd91b7254487d7e7effde4bbbc56f69bd66fabd017c55fe8a7675009255bae12315caef61e0e33cc78fbb29
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP16/person-detection-retail-0013.xml
   - name: FP16/person-detection-retail-0013.bin
     size: 1445736
-    sha384: c6c66dcb8e24b5d87c553477ecd006dc679ece3ec03137b079e0fe3084b4acda2fc570330d6dbc6844dbbc03f289106e
+    checksum: c6c66dcb8e24b5d87c553477ecd006dc679ece3ec03137b079e0fe3084b4acda2fc570330d6dbc6844dbbc03f289106e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP16/person-detection-retail-0013.bin
   - name: FP16-INT8/person-detection-retail-0013.xml
     size: 971255
-    sha384: 1f05b6971a5e742e39beacc1dd5a51fe68c6675cf26c2204351e3346a014f16b0b42c6540082b7da2cc49c7458e5c03d
+    checksum: 1f05b6971a5e742e39beacc1dd5a51fe68c6675cf26c2204351e3346a014f16b0b42c6540082b7da2cc49c7458e5c03d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.xml
   - name: FP16-INT8/person-detection-retail-0013.bin
     size: 770360
-    sha384: d022f70657a423618edc9998b48c77f4fb88d85dc2c1d0ec6ac88ec17af738217076549286fe424afdf1af81e1e4c767
+    checksum: d022f70657a423618edc9998b48c77f4fb88d85dc2c1d0ec6ac88ec17af738217076549286fe424afdf1af81e1e4c767
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-detection-retail-0013/FP16-INT8/person-detection-retail-0013.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0277/model.yml
+++ b/models/intel/person-reidentification-retail-0277/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0277.xml
     size: 573033
-    sha384: 1e41950f7dc353ea131a29ffd3586e40933984b9b5bab67b64ce1f4a4cf140469f353f96b64a6fcf03085fdce25cf488
+    checksum: 1e41950f7dc353ea131a29ffd3586e40933984b9b5bab67b64ce1f4a4cf140469f353f96b64a6fcf03085fdce25cf488
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP32/person-reidentification-retail-0277.xml
   - name: FP32/person-reidentification-retail-0277.bin
     size: 8357560
-    sha384: 72f904eb6d7a93c258937c42f840390c40375053c0a0c9462db8e72ae285529fcb3af0b7ff0bd1cec7a749ab835e41a2
+    checksum: 72f904eb6d7a93c258937c42f840390c40375053c0a0c9462db8e72ae285529fcb3af0b7ff0bd1cec7a749ab835e41a2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP32/person-reidentification-retail-0277.bin
   - name: FP16/person-reidentification-retail-0277.xml
     size: 572915
-    sha384: 7d57fc4e211b739316164d9417e6bd0dd254e3af14e1864086142ccb7c75f06e1a355f5416816ecb1786138e26b4a88e
+    checksum: 7d57fc4e211b739316164d9417e6bd0dd254e3af14e1864086142ccb7c75f06e1a355f5416816ecb1786138e26b4a88e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP16/person-reidentification-retail-0277.xml
   - name: FP16/person-reidentification-retail-0277.bin
     size: 4178812
-    sha384: 05aa0bc7be2f7121f38e8c26105797b6dae966cf5d44eed89cd16af3d81937447cd9dfe8e07f149f09f4b64982a079d9
+    checksum: 05aa0bc7be2f7121f38e8c26105797b6dae966cf5d44eed89cd16af3d81937447cd9dfe8e07f149f09f4b64982a079d9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP16/person-reidentification-retail-0277.bin
   - name: FP16-INT8/person-reidentification-retail-0277.xml
     size: 1449896
-    sha384: 917d7b5c128c7ed4f0f63633c5654a39350dfeb183adf1a7883e49ff7cf421ac422ca807f9704cbd843da912fcdcaf19
+    checksum: 917d7b5c128c7ed4f0f63633c5654a39350dfeb183adf1a7883e49ff7cf421ac422ca807f9704cbd843da912fcdcaf19
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP16-INT8/person-reidentification-retail-0277.xml
   - name: FP16-INT8/person-reidentification-retail-0277.bin
     size: 2201582
-    sha384: 1ca76d99f894ebc7347951c128008a9a2c0313dda9938554a56107c9c1160ba052a3a6963c0245efcdc22b98274fc054
+    checksum: 1ca76d99f894ebc7347951c128008a9a2c0313dda9938554a56107c9c1160ba052a3a6963c0245efcdc22b98274fc054
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0277/FP16-INT8/person-reidentification-retail-0277.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0286/model.yml
+++ b/models/intel/person-reidentification-retail-0286/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0286.xml
     size: 572273
-    sha384: 22f4ed1319d8dc3fc17683794e1d3ec024401e2f194bc4591c3313ccb89bc41cc997b3c66a9b1a415307f69fbdeb5911
+    checksum: 22f4ed1319d8dc3fc17683794e1d3ec024401e2f194bc4591c3313ccb89bc41cc997b3c66a9b1a415307f69fbdeb5911
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.xml
   - name: FP32/person-reidentification-retail-0286.bin
     size: 4905116
-    sha384: 13e4ad7def9e200af035c655846609aaa311cc540af86d4a6073f917abcfafa93feb170fdcdf0bb889c780faa60aa8f2
+    checksum: 13e4ad7def9e200af035c655846609aaa311cc540af86d4a6073f917abcfafa93feb170fdcdf0bb889c780faa60aa8f2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.bin
   - name: FP16/person-reidentification-retail-0286.xml
     size: 572088
-    sha384: a2d7ae21b62ff75f8164310e6688cd74adf20b2a033b9ceb7b0841b34ba8464b5915e7f7d939255b2222f35e8df683d2
+    checksum: a2d7ae21b62ff75f8164310e6688cd74adf20b2a033b9ceb7b0841b34ba8464b5915e7f7d939255b2222f35e8df683d2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP16/person-reidentification-retail-0286.xml
   - name: FP16/person-reidentification-retail-0286.bin
     size: 2452594
-    sha384: 0e24cbbd346ade3957373a63b61d500f33aa30f831c16aa8a09b483d95db66828a33be30e48845b90f976677bc6a9602
+    checksum: 0e24cbbd346ade3957373a63b61d500f33aa30f831c16aa8a09b483d95db66828a33be30e48845b90f976677bc6a9602
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP16/person-reidentification-retail-0286.bin
   - name: FP16-INT8/person-reidentification-retail-0286.xml
     size: 1447924
-    sha384: 2bae2f8ca8e33b2c1d843b2945ef038d7ad1e32ab766d7b97c3a6d8db3f06748e1517a5e9e4ea07ee8e594556f9a469a
+    checksum: 2bae2f8ca8e33b2c1d843b2945ef038d7ad1e32ab766d7b97c3a6d8db3f06748e1517a5e9e4ea07ee8e594556f9a469a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.xml
   - name: FP16-INT8/person-reidentification-retail-0286.bin
     size: 1311266
-    sha384: f4844b2415bea1e62289fce565248f3d44f481cde0b1bd4ec0323642d7e106d3c2fb4effe9597837b70ef66f36d48b69
+    checksum: f4844b2415bea1e62289fce565248f3d44f481cde0b1bd4ec0323642d7e106d3c2fb4effe9597837b70ef66f36d48b69
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0287/model.yml
+++ b/models/intel/person-reidentification-retail-0287/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0287.xml
     size: 572188
-    sha384: e6406234a4b60873a64fd8040bbf88c5bd34ddaa288ffb35187e5847a7bd6a9fecfca48e047822f431f02ec97809252a
+    checksum: e6406234a4b60873a64fd8040bbf88c5bd34ddaa288ffb35187e5847a7bd6a9fecfca48e047822f431f02ec97809252a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP32/person-reidentification-retail-0287.xml
   - name: FP32/person-reidentification-retail-0287.bin
     size: 2362196
-    sha384: 9b69111320fea37b8da122f259354425fc86694854c14721d2e4bf9bc2c2c69d983f9acf0e22f46b9793ac356270b8b3
+    checksum: 9b69111320fea37b8da122f259354425fc86694854c14721d2e4bf9bc2c2c69d983f9acf0e22f46b9793ac356270b8b3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP32/person-reidentification-retail-0287.bin
   - name: FP16/person-reidentification-retail-0287.xml
     size: 571871
-    sha384: 8d3b6b361bee42ce668859986638c657abb75b99ef4a52bcbd41d32b069d68590ce1b6a1a5479f1af31307f965e7441f
+    checksum: 8d3b6b361bee42ce668859986638c657abb75b99ef4a52bcbd41d32b069d68590ce1b6a1a5479f1af31307f965e7441f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP16/person-reidentification-retail-0287.xml
   - name: FP16/person-reidentification-retail-0287.bin
     size: 1181130
-    sha384: 0fa762c24000263aa867cfbee7651d68d32e8020a5d89f7889d0a766ed756b7cf21cfc0419fdc1183b1f1deeba3f0fe3
+    checksum: 0fa762c24000263aa867cfbee7651d68d32e8020a5d89f7889d0a766ed756b7cf21cfc0419fdc1183b1f1deeba3f0fe3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP16/person-reidentification-retail-0287.bin
   - name: FP16-INT8/person-reidentification-retail-0287.xml
     size: 1447358
-    sha384: 41e634d28e693cd66cfbae0f8609bfd4600b45e7279bba52d58c61e0495d5a4cb1d1515df5848928ecc5cc8d6b7c3f82
+    checksum: 41e634d28e693cd66cfbae0f8609bfd4600b45e7279bba52d58c61e0495d5a4cb1d1515df5848928ecc5cc8d6b7c3f82
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP16-INT8/person-reidentification-retail-0287.xml
   - name: FP16-INT8/person-reidentification-retail-0287.bin
     size: 647530
-    sha384: 623c1d2d3e2cd6a882dc7bc4204f5e77143d81635e729c114099e884183718d59677fd957713e05490aeb6d535ded3ce
+    checksum: 623c1d2d3e2cd6a882dc7bc4204f5e77143d81635e729c114099e884183718d59677fd957713e05490aeb6d535ded3ce
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0287/FP16-INT8/person-reidentification-retail-0287.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-reidentification-retail-0288/model.yml
+++ b/models/intel/person-reidentification-retail-0288/model.yml
@@ -18,19 +18,19 @@ task_type: object_attributes
 files:
   - name: FP32/person-reidentification-retail-0288.xml
     size: 571633
-    sha384: c37bb53b5c535d516719c6f90157b3b88cdb9103957f2a25fff82e41b7c1393d7b56e43b71120f83e8bb7e9e1a3b6efb
+    checksum: c37bb53b5c535d516719c6f90157b3b88cdb9103957f2a25fff82e41b7c1393d7b56e43b71120f83e8bb7e9e1a3b6efb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0288/FP32/person-reidentification-retail-0288.xml
   - name: FP32/person-reidentification-retail-0288.bin
     size: 728120
-    sha384: 58b3715a3138c5ff16cb3027ae09ac26041857b127292783da37ba598f6b37602895335b687e4e406930bc8d4dbd2b26
+    checksum: 58b3715a3138c5ff16cb3027ae09ac26041857b127292783da37ba598f6b37602895335b687e4e406930bc8d4dbd2b26
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0288/FP32/person-reidentification-retail-0288.bin
   - name: FP16/person-reidentification-retail-0288.xml
     size: 571438
-    sha384: d84071e53e92c3672076d98f5260b6619aefd4e7bcde8c4283f79bed3f78ab02ad9fa39f0bc74a14913c9447ecd60f8c
+    checksum: d84071e53e92c3672076d98f5260b6619aefd4e7bcde8c4283f79bed3f78ab02ad9fa39f0bc74a14913c9447ecd60f8c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0288/FP16/person-reidentification-retail-0288.xml
   - name: FP16/person-reidentification-retail-0288.bin
     size: 364104
-    sha384: 3473e599658614cef8e37713e86dd02f9f1c54f2ff52e09e99a0c950a3442e38c548c0d827a1450565507bdaf08e953d
+    checksum: 3473e599658614cef8e37713e86dd02f9f1c54f2ff52e09e99a0c950a3442e38c548c0d827a1450565507bdaf08e953d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-reidentification-retail-0288/FP16/person-reidentification-retail-0288.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-2000/model.yml
+++ b/models/intel/person-vehicle-bike-detection-2000/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-2000.xml
     size: 200461
-    sha384: 999e6dd3faff4da201103371f25013a57cd04076f49e64bdc247e2a277126a40353879d86fbada1e0e84f1d8abdf3d7a
+    checksum: 999e6dd3faff4da201103371f25013a57cd04076f49e64bdc247e2a277126a40353879d86fbada1e0e84f1d8abdf3d7a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP32/person-vehicle-bike-detection-2000.xml
   - name: FP32/person-vehicle-bike-detection-2000.bin
     size: 7285112
-    sha384: 48e38d99835259df617ce55e4a0eeba8e19b7bfe7ae2752cc228926336222e459d0a4da4629eea0ec6e8361e21dff224
+    checksum: 48e38d99835259df617ce55e4a0eeba8e19b7bfe7ae2752cc228926336222e459d0a4da4629eea0ec6e8361e21dff224
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP32/person-vehicle-bike-detection-2000.bin
   - name: FP16/person-vehicle-bike-detection-2000.xml
     size: 200399
-    sha384: 8595565dfa30e2493ca85c72a4131ae7a754286c12bdcb4e7437e0ce1da23e161b6023e5c1466c3f966b31d70d39e259
+    checksum: 8595565dfa30e2493ca85c72a4131ae7a754286c12bdcb4e7437e0ce1da23e161b6023e5c1466c3f966b31d70d39e259
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP16/person-vehicle-bike-detection-2000.xml
   - name: FP16/person-vehicle-bike-detection-2000.bin
     size: 3642598
-    sha384: a0e3f342b6877781e8700ebc5217cc1a772a32b0f16227d8f6c5834a32bfc3dee22f34720c03e9cf4554a7c9d9005e1b
+    checksum: a0e3f342b6877781e8700ebc5217cc1a772a32b0f16227d8f6c5834a32bfc3dee22f34720c03e9cf4554a7c9d9005e1b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP16/person-vehicle-bike-detection-2000.bin
   - name: FP16-INT8/person-vehicle-bike-detection-2000.xml
     size: 454058
-    sha384: 0594fe4cb3142b6ebd73f83895840670319d6f37fc1f8f42fbdbe760e0a15924481a0bab02188aae8a487345d59eb0e6
+    checksum: 0594fe4cb3142b6ebd73f83895840670319d6f37fc1f8f42fbdbe760e0a15924481a0bab02188aae8a487345d59eb0e6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP16-INT8/person-vehicle-bike-detection-2000.xml
   - name: FP16-INT8/person-vehicle-bike-detection-2000.bin
     size: 1932488
-    sha384: 2e2208aeebbcf1b0ccff4c09ea5954e572771270d5ae4358424eae9b3d582951bff2309e2c39511962799c6f1f217331
+    checksum: 2e2208aeebbcf1b0ccff4c09ea5954e572771270d5ae4358424eae9b3d582951bff2309e2c39511962799c6f1f217331
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2000/FP16-INT8/person-vehicle-bike-detection-2000.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-2001/model.yml
+++ b/models/intel/person-vehicle-bike-detection-2001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-2001.xml
     size: 200654
-    sha384: b00452bf0c3bd927a182f924e8ec48c22ca0810d0810c2dba1447957468864b8a708b608bbb25895a039b918aceb0401
+    checksum: b00452bf0c3bd927a182f924e8ec48c22ca0810d0810c2dba1447957468864b8a708b608bbb25895a039b918aceb0401
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP32/person-vehicle-bike-detection-2001.xml
   - name: FP32/person-vehicle-bike-detection-2001.bin
     size: 7285112
-    sha384: 194b3585d3f24e4aeba9c0873d3b16c7a39945f63810add14bfd91ced537bcf7afc0548f1be159fc388024fa37c37702
+    checksum: 194b3585d3f24e4aeba9c0873d3b16c7a39945f63810add14bfd91ced537bcf7afc0548f1be159fc388024fa37c37702
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP32/person-vehicle-bike-detection-2001.bin
   - name: FP16/person-vehicle-bike-detection-2001.xml
     size: 200592
-    sha384: 60deb4599d89d301c9fe59086d4fe9c97d191cb422f5688e80d34f9c3119e947b2bf5984a3b9726eafbf6414b2d90c11
+    checksum: 60deb4599d89d301c9fe59086d4fe9c97d191cb422f5688e80d34f9c3119e947b2bf5984a3b9726eafbf6414b2d90c11
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP16/person-vehicle-bike-detection-2001.xml
   - name: FP16/person-vehicle-bike-detection-2001.bin
     size: 3642598
-    sha384: a2f845c675e9bd75410114abcad1f89d7e7f72d7457d28a22f1c764ec879e9672d2be68fb0d51fb02284206c93a76985
+    checksum: a2f845c675e9bd75410114abcad1f89d7e7f72d7457d28a22f1c764ec879e9672d2be68fb0d51fb02284206c93a76985
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP16/person-vehicle-bike-detection-2001.bin
   - name: FP16-INT8/person-vehicle-bike-detection-2001.xml
     size: 396681
-    sha384: 687f6e9dbf460278fa449db942abfe4359a4106b01c8e8d595fd91642ca3a76586e39bea2f47a05416876d05d0cf6f5f
+    checksum: 687f6e9dbf460278fa449db942abfe4359a4106b01c8e8d595fd91642ca3a76586e39bea2f47a05416876d05d0cf6f5f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP16-INT8/person-vehicle-bike-detection-2001.xml
   - name: FP16-INT8/person-vehicle-bike-detection-2001.bin
     size: 2097373
-    sha384: 89cd6d08fe2573a05174a10ef2629199af7f3261cc9843eee4ea8562590230fe9ee65033d9de886f6fe28a47d9aeac86
+    checksum: 89cd6d08fe2573a05174a10ef2629199af7f3261cc9843eee4ea8562590230fe9ee65033d9de886f6fe28a47d9aeac86
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2001/FP16-INT8/person-vehicle-bike-detection-2001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-2002/model.yml
+++ b/models/intel/person-vehicle-bike-detection-2002/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-2002.xml
     size: 200730
-    sha384: f6ab86e3993261df6743f9ea485cbb0dd29fa9db039e32111d82658fa9be5d604a4d8d46b9c301336d820b689fa4c83a
+    checksum: f6ab86e3993261df6743f9ea485cbb0dd29fa9db039e32111d82658fa9be5d604a4d8d46b9c301336d820b689fa4c83a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP32/person-vehicle-bike-detection-2002.xml
   - name: FP32/person-vehicle-bike-detection-2002.bin
     size: 7285112
-    sha384: d248f123c0904b526d185b8baa5106367e9cf4cd8c84f668749a2b9175231a99e309074e3deedc85d08f8d0e7e103e2f
+    checksum: d248f123c0904b526d185b8baa5106367e9cf4cd8c84f668749a2b9175231a99e309074e3deedc85d08f8d0e7e103e2f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP32/person-vehicle-bike-detection-2002.bin
   - name: FP16/person-vehicle-bike-detection-2002.xml
     size: 200668
-    sha384: eb9cd13a29d1c964fd1ca75940899b62dd77fac35f9e87685283ed324bc5da57ff2cb54b6cebaf9dbcb09247c95c920a
+    checksum: eb9cd13a29d1c964fd1ca75940899b62dd77fac35f9e87685283ed324bc5da57ff2cb54b6cebaf9dbcb09247c95c920a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP16/person-vehicle-bike-detection-2002.xml
   - name: FP16/person-vehicle-bike-detection-2002.bin
     size: 3642598
-    sha384: ff9d4dd213693b56d324ea4e67f0d386b177550b2bf9bcc112424991df19a90f75998866c57b0dedec324cbe325da6fe
+    checksum: ff9d4dd213693b56d324ea4e67f0d386b177550b2bf9bcc112424991df19a90f75998866c57b0dedec324cbe325da6fe
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP16/person-vehicle-bike-detection-2002.bin
   - name: FP16-INT8/person-vehicle-bike-detection-2002.xml
     size: 479369
-    sha384: bb743db60229aee72fd892115ac7184382d42b15ee0b83ed83449c347edae26701310f0dfd76cb0c0d1b4b7b782cb6dc
+    checksum: bb743db60229aee72fd892115ac7184382d42b15ee0b83ed83449c347edae26701310f0dfd76cb0c0d1b4b7b782cb6dc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP16-INT8/person-vehicle-bike-detection-2002.xml
   - name: FP16-INT8/person-vehicle-bike-detection-2002.bin
     size: 1290337
-    sha384: 3a20877c5871d1b0c2efe4604cc9eae8af8f98cce5ff39f0d65ea2ebcdc99bd1d0b908417f8a10859239ff409655772d
+    checksum: 3a20877c5871d1b0c2efe4604cc9eae8af8f98cce5ff39f0d65ea2ebcdc99bd1d0b908417f8a10859239ff409655772d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2002/FP16-INT8/person-vehicle-bike-detection-2002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-2003/model.yml
+++ b/models/intel/person-vehicle-bike-detection-2003/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-2003.xml
     size: 1298136
-    sha384: d3445634db157b0222a31408b2ab969b8ab48087570a40d5b956e6f5b46f3e5b05de93406f650b530a8d4a917df23a78
+    checksum: d3445634db157b0222a31408b2ab969b8ab48087570a40d5b956e6f5b46f3e5b05de93406f650b530a8d4a917df23a78
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP32/person-vehicle-bike-detection-2003.xml
   - name: FP32/person-vehicle-bike-detection-2003.bin
     size: 7811564
-    sha384: d70950d55be7eae22d9f989f5388119ab7b8521cc190da20eadcb8e47fc74271e45fdbcc18a517cf17fb321162683c80
+    checksum: d70950d55be7eae22d9f989f5388119ab7b8521cc190da20eadcb8e47fc74271e45fdbcc18a517cf17fb321162683c80
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP32/person-vehicle-bike-detection-2003.bin
   - name: FP16/person-vehicle-bike-detection-2003.xml
     size: 1297964
-    sha384: f9ab6d097b4098af9cb642acbc90d2b182f3d38c8cc4ea76f22bf4d645f3e283bc89b679c012f04c0ff8723915ce81e8
+    checksum: f9ab6d097b4098af9cb642acbc90d2b182f3d38c8cc4ea76f22bf4d645f3e283bc89b679c012f04c0ff8723915ce81e8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP16/person-vehicle-bike-detection-2003.xml
   - name: FP16/person-vehicle-bike-detection-2003.bin
     size: 3906004
-    sha384: e92caeb7a2996f5ef974138b4fa10055ec0baf651f743f5fbffac95257ac5fd2e92fadd1d3cb02e23fa54d22bfbd62a7
+    checksum: e92caeb7a2996f5ef974138b4fa10055ec0baf651f743f5fbffac95257ac5fd2e92fadd1d3cb02e23fa54d22bfbd62a7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP16/person-vehicle-bike-detection-2003.bin
   - name: FP16-INT8/person-vehicle-bike-detection-2003.xml
     size: 1859739
-    sha384: f44983fd513055aa1026c92daa1ad16c81926080a3da73fb873223936911c773b0906c3300e9e6f6fff9b997a36e9388
+    checksum: f44983fd513055aa1026c92daa1ad16c81926080a3da73fb873223936911c773b0906c3300e9e6f6fff9b997a36e9388
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP16-INT8/person-vehicle-bike-detection-2003.xml
   - name: FP16-INT8/person-vehicle-bike-detection-2003.bin
     size: 2055446
-    sha384: 22fd1a174a704c4742fea07ba72df33753927719df81e6ca80a804343975c286014392975807790c4b9a3152a1c3061f
+    checksum: 22fd1a174a704c4742fea07ba72df33753927719df81e6ca80a804343975c286014392975807790c4b9a3152a1c3061f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2003/FP16-INT8/person-vehicle-bike-detection-2003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-2004/model.yml
+++ b/models/intel/person-vehicle-bike-detection-2004/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-2004.xml
     size: 1296909
-    sha384: 4068510f2d5bce04b440d4a576062a861d364163bdd7b6a72c3d66ac31db5eb69bf541a2ac0ec7e81221d831a55a6f32
+    checksum: 4068510f2d5bce04b440d4a576062a861d364163bdd7b6a72c3d66ac31db5eb69bf541a2ac0ec7e81221d831a55a6f32
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP32/person-vehicle-bike-detection-2004.xml
   - name: FP32/person-vehicle-bike-detection-2004.bin
     size: 7811564
-    sha384: 2256a40e90f9c0778dae01187ebc5abaf9eb6ebc4c88352bb12ce7b0212b943f8a299061139ca1586bc1e45266824f43
+    checksum: 2256a40e90f9c0778dae01187ebc5abaf9eb6ebc4c88352bb12ce7b0212b943f8a299061139ca1586bc1e45266824f43
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP32/person-vehicle-bike-detection-2004.bin
   - name: FP16/person-vehicle-bike-detection-2004.xml
     size: 1296737
-    sha384: 8c61102021677d0e02e185356e494bf9552ece535d2a80cd2d76f65e695518627462009cccc245dc1b0a3842b455d1a0
+    checksum: 8c61102021677d0e02e185356e494bf9552ece535d2a80cd2d76f65e695518627462009cccc245dc1b0a3842b455d1a0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP16/person-vehicle-bike-detection-2004.xml
   - name: FP16/person-vehicle-bike-detection-2004.bin
     size: 3906004
-    sha384: 4b7fe5676e3593411b259c26c6384682b1ead9bde50acc935cd00294442bee61dcc4ef38140c19c5c4d00d56630b9109
+    checksum: 4b7fe5676e3593411b259c26c6384682b1ead9bde50acc935cd00294442bee61dcc4ef38140c19c5c4d00d56630b9109
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP16/person-vehicle-bike-detection-2004.bin
   - name: FP16-INT8/person-vehicle-bike-detection-2004.xml
     size: 1858288
-    sha384: 63a0c6a797455fb5ed505fd723b26e6936b3d8e85f33412dc2432b8962165e216e20cdf3b8c59b56c3b4edae792c8e45
+    checksum: 63a0c6a797455fb5ed505fd723b26e6936b3d8e85f33412dc2432b8962165e216e20cdf3b8c59b56c3b4edae792c8e45
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP16-INT8/person-vehicle-bike-detection-2004.xml
   - name: FP16-INT8/person-vehicle-bike-detection-2004.bin
     size: 2055438
-    sha384: fd28f40790051abf63b7ddff5bb22a974988c6452d7b56f46b623868f1be944e8fb47fdc60ef63cf1b57bc9dd89e67f8
+    checksum: fd28f40790051abf63b7ddff5bb22a974988c6452d7b56f46b623868f1be944e8fb47fdc60ef63cf1b57bc9dd89e67f8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-2004/FP16-INT8/person-vehicle-bike-detection-2004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/model.yml
@@ -20,27 +20,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.xml
     size: 381374
-    sha384: 70b10a6fe7a5c7c791aaffde5998e3e0f8a4d6c6c56a327e9e115dd3fcbc86ee0e144001918a9700a52cea85a11c48fd
+    checksum: 70b10a6fe7a5c7c791aaffde5998e3e0f8a4d6c6c56a327e9e115dd3fcbc86ee0e144001918a9700a52cea85a11c48fd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-0078.bin
     size: 4713980
-    sha384: f0c205b70420030d701583631f21d8edfd1a611b9806d7440c231f8b9a0358a31a194f0da3e6355eced4b31af68c8ad8
+    checksum: f0c205b70420030d701583631f21d8edfd1a611b9806d7440c231f8b9a0358a31a194f0da3e6355eced4b31af68c8ad8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP32/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.xml
     size: 381204
-    sha384: 6e2db79fa89019cbf922afb7be6573cfae1d32013df4660a32f375a34dd2f06e76aab4b3fd6c1796f3cf14e11f735c20
+    checksum: 6e2db79fa89019cbf922afb7be6573cfae1d32013df4660a32f375a34dd2f06e76aab4b3fd6c1796f3cf14e11f735c20
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-0078.bin
     size: 2357042
-    sha384: 2a88f518fcf75987ad065fd35d95e30af824b9168d9aba4b1b9a0eb0f97eb6a4ec1995fc5c603c5ca23afe2f5510dbab
+    checksum: 2a88f518fcf75987ad065fd35d95e30af824b9168d9aba4b1b9a0eb0f97eb6a4ec1995fc5c603c5ca23afe2f5510dbab
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16/person-vehicle-bike-detection-crossroad-0078.bin
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-0078.xml
     size: 1082089
-    sha384: 563dbeb9c8d4d38c5cf6fc5fde137978e8d1262fca2a6cbd97003e58625c5e464edf3a08485c869c102590ff2b1faa5f
+    checksum: 563dbeb9c8d4d38c5cf6fc5fde137978e8d1262fca2a6cbd97003e58625c5e464edf3a08485c869c102590ff2b1faa5f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.xml
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-0078.bin
     size: 1228693
-    sha384: 1f5d5d3663455e1134e7840b731e74844aaed8ebd87af2789574d578207d91262e89e73dd116d29979eb65fafca1bcf0
+    checksum: 1f5d5d3663455e1134e7840b731e74844aaed8ebd87af2789574d578207d91262e89e73dd116d29979eb65fafca1bcf0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-0078/FP16-INT8/person-vehicle-bike-detection-crossroad-0078.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.xml
     size: 226808
-    sha384: a4aa57c8baa6a68b939fdae300ac919c10e5709ee70bda1d7749bb21a858b6aa29a17482f5d443b21315216c21189c0a
+    checksum: a4aa57c8baa6a68b939fdae300ac919c10e5709ee70bda1d7749bb21a858b6aa29a17482f5d443b21315216c21189c0a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-1016.bin
     size: 11547984
-    sha384: eaf13dd5e4dc4e9dd62a906436cda443603d76c123f7aba9cb6a2d6a4064500dc2ea054584c3df9eb487bec59ace4af3
+    checksum: eaf13dd5e4dc4e9dd62a906436cda443603d76c123f7aba9cb6a2d6a4064500dc2ea054584c3df9eb487bec59ace4af3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP32/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.xml
     size: 226695
-    sha384: 1fb40d030bc9a836fe29042c5064ec7d8c06a1a3e0a4426dc41a7c656f504b4e21c248f256c616256cdf8a4b3223aa5e
+    checksum: 1fb40d030bc9a836fe29042c5064ec7d8c06a1a3e0a4426dc41a7c656f504b4e21c248f256c616256cdf8a4b3223aa5e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-1016.bin
     size: 5774034
-    sha384: 86d74775d2dbb5de2aadd3ac1fd896f6c9bccf62e1aa96993e6c1f05d1e9343b0401957f0ecf5a4246eb0bb5f4a51f6b
+    checksum: 86d74775d2dbb5de2aadd3ac1fd896f6c9bccf62e1aa96993e6c1f05d1e9343b0401957f0ecf5a4246eb0bb5f4a51f6b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16/person-vehicle-bike-detection-crossroad-1016.bin
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-1016.xml
     size: 539155
-    sha384: 9d690bc61b2020cb9353e83d72b3698f6abc31a9d8323ab0934a6b40d5a77645fa441c7ec269f26b392623410dc20a7a
+    checksum: 9d690bc61b2020cb9353e83d72b3698f6abc31a9d8323ab0934a6b40d5a77645fa441c7ec269f26b392623410dc20a7a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.xml
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-1016.bin
     size: 3024898
-    sha384: ccf8800fdb4d24ae2ccbdf90b1675eccc0dfcbf36d34372d4135d7a082348efa7d1e59b4638d8e1c5d13782dbd40d9dd
+    checksum: ccf8800fdb4d24ae2ccbdf90b1675eccc0dfcbf36d34372d4135d7a082348efa7d1e59b4638d8e1c5d13782dbd40d9dd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-1016/FP16-INT8/person-vehicle-bike-detection-crossroad-1016.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/model.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
     size: 281150
-    sha384: a16cddc7a11e27ed68bceeb203b9379181fd1729bf1a39f896862b11ec52f6ad453577b8312e8c1fa3df8699955c0429
+    checksum: a16cddc7a11e27ed68bceeb203b9379181fd1729bf1a39f896862b11ec52f6ad453577b8312e8c1fa3df8699955c0429
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP32/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
   - name: FP32/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
     size: 247688456
-    sha384: 71f72f63da3e52256c8429f70b488f5a33efd2d331ebed5d3b0ba54508cae85d0cd3b045bd7c1347f2a315062663826c
+    checksum: 71f72f63da3e52256c8429f70b488f5a33efd2d331ebed5d3b0ba54508cae85d0cd3b045bd7c1347f2a315062663826c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP32/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
   - name: FP16/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
     size: 281055
-    sha384: 3ae82536813f60c23076513d5b11fb493e87e50350232112ec759952ad51276a42629a1751c552c4e4db7682d1b7d284
+    checksum: 3ae82536813f60c23076513d5b11fb493e87e50350232112ec759952ad51276a42629a1751c552c4e4db7682d1b7d284
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP16/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
   - name: FP16/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
     size: 123844294
-    sha384: 336707edfb3e1e592571a508ea003ed0d749d99d0b91c0967157ab70af14859591d8246171f53912a019950f8ccd1990
+    checksum: 336707edfb3e1e592571a508ea003ed0d749d99d0b91c0967157ab70af14859591d8246171f53912a019950f8ccd1990
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP16/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
     size: 630267
-    sha384: 7d1a223146f3a2d4b1144965c9de320bf71f30e0666be14ae4d8cd3de40d559aa77c39f5b5ad690c9f0b5600c44d5582
+    checksum: 7d1a223146f3a2d4b1144965c9de320bf71f30e0666be14ae4d8cd3de40d559aa77c39f5b5ad690c9f0b5600c44d5582
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP16-INT8/person-vehicle-bike-detection-crossroad-yolov3-1020.xml
   - name: FP16-INT8/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
     size: 62057678
-    sha384: 87a5464d3d3cefaf52a03ae92d3d5409a791b7ddc5bb688634865afb396014ce379ef14c06d12c71f48b15a088e0863d
+    checksum: 87a5464d3d3cefaf52a03ae92d3d5409a791b7ddc5bb688634865afb396014ce379ef14c06d12c71f48b15a088e0863d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/person-vehicle-bike-detection-crossroad-yolov3-1020/FP16-INT8/person-vehicle-bike-detection-crossroad-yolov3-1020.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/product-detection-0001/model.yml
+++ b/models/intel/product-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/product-detection-0001.xml
     size: 323305
-    sha384: 731c73f3cef19694238ae8a0c7ce6c1e60cc7c6ebe78d5ff8cb01e1fe65da2f767be75e5643e2c8b087f71f69debee99
+    checksum: 731c73f3cef19694238ae8a0c7ce6c1e60cc7c6ebe78d5ff8cb01e1fe65da2f767be75e5643e2c8b087f71f69debee99
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP32/product-detection-0001.xml
   - name: FP32/product-detection-0001.bin
     size: 12850024
-    sha384: dc3e6fa2805627a6b96a4734a899bee296e6e7feed419764b7264deb4d686a29cc25730fbc1309456ccc1f77957bad49
+    checksum: dc3e6fa2805627a6b96a4734a899bee296e6e7feed419764b7264deb4d686a29cc25730fbc1309456ccc1f77957bad49
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP32/product-detection-0001.bin
   - name: FP16/product-detection-0001.xml
     size: 323127
-    sha384: 525bd3f072620785415bcbe5649564f75e3fc3db6525592fffc1fd29e4f131873d1e0f350f67220fc4f59ec146f2b58d
+    checksum: 525bd3f072620785415bcbe5649564f75e3fc3db6525592fffc1fd29e4f131873d1e0f350f67220fc4f59ec146f2b58d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP16/product-detection-0001.xml
   - name: FP16/product-detection-0001.bin
     size: 6425058
-    sha384: 5e1c57999d4dc26c6a097b97af3a698f38664ecf96455253683536444853843f9e9615f17f7ec8885894136a59070fd8
+    checksum: 5e1c57999d4dc26c6a097b97af3a698f38664ecf96455253683536444853843f9e9615f17f7ec8885894136a59070fd8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP16/product-detection-0001.bin
   - name: FP16-INT8/product-detection-0001.xml
     size: 716994
-    sha384: 2dd5695452d68bf0fc5c7836ac281f8266fb42525b2bc45f3ae884ff7be801c01c20d5bf008e1583055f75659e632fcc
+    checksum: 2dd5695452d68bf0fc5c7836ac281f8266fb42525b2bc45f3ae884ff7be801c01c20d5bf008e1583055f75659e632fcc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP16-INT8/product-detection-0001.xml
   - name: FP16-INT8/product-detection-0001.bin
     size: 3364170
-    sha384: 44dabe31d4e9907f3506556a0baf61bee1e1167fe1f1ff2ff81571368e2ca73bdb1b74667e6b9d814c6b06ada0299096
+    checksum: 44dabe31d4e9907f3506556a0baf61bee1e1167fe1f1ff2ff81571368e2ca73bdb1b74667e6b9d814c6b06ada0299096
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/product-detection-0001/FP16-INT8/product-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 103162
-    sha384: 0f81610cfff20a91e8a4f7caacc9ab90a2b786ad0ef7c8bb876c68a9e00c04d23cf3a7042c10e921ac70e5fc8a305bdf
+    checksum: 0f81610cfff20a91e8a4f7caacc9ab90a2b786ad0ef7c8bb876c68a9e00c04d23cf3a7042c10e921ac70e5fc8a305bdf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 4190944
-    sha384: ded916dd2f4915c08fa1cff7b2a0c44ccb37515a5858e8134862808d032e262d6bcd8212650257e97f0b86e83aaf914d
+    checksum: ded916dd2f4915c08fa1cff7b2a0c44ccb37515a5858e8134862808d032e262d6bcd8212650257e97f0b86e83aaf914d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet18-xnor-binary-onnx-0001/FP32-INT1/resnet18-xnor-binary-onnx-0001.bin
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
     size: 103138
-    sha384: 82b503e28562483daecaa843c499b12d660272c1f045d36c1b9afc1755825251879f29d8bdd44f6ae5ddb8730f6aade6
+    checksum: 82b503e28562483daecaa843c499b12d660272c1f045d36c1b9afc1755825251879f29d8bdd44f6ae5ddb8730f6aade6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml
   - name: FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
     size: 2782084
-    sha384: 3780755d60d1a6ca62ed971b0b223f5db2bb7f42c0fdfd3cd0f168e6e977b99d00d4d854ac21bb6692b7354310b62da3
+    checksum: 3780755d60d1a6ca62ed971b0b223f5db2bb7f42c0fdfd3cd0f168e6e977b99d00d4d854ac21bb6692b7354310b62da3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/resnet50-binary-0001/model.yml
+++ b/models/intel/resnet50-binary-0001/model.yml
@@ -18,19 +18,19 @@ task_type: classification
 files:
   - name: FP32-INT1/resnet50-binary-0001.xml
     size: 243387
-    sha384: 563cbcf87a60e5865f2e44bc0e942be13d64d7715572daddf22c429526a3ca6cb9b462ed38640c89c3fb5baaaf01601a
+    checksum: 563cbcf87a60e5865f2e44bc0e942be13d64d7715572daddf22c429526a3ca6cb9b462ed38640c89c3fb5baaaf01601a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.xml
   - name: FP32-INT1/resnet50-binary-0001.bin
     size: 22112984
-    sha384: cd1b5da6852e14d62daf6223db87799bd722651f46448164f61a8a71041956cad8a5897339d1714154523cbef1843a27
+    checksum: cd1b5da6852e14d62daf6223db87799bd722651f46448164f61a8a71041956cad8a5897339d1714154523cbef1843a27
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet50-binary-0001/FP32-INT1/resnet50-binary-0001.bin
   - name: FP16-INT1/resnet50-binary-0001.xml
     size: 243288
-    sha384: 6113d30f0f72cbb6930332d16361955fa72067c11e84db1ef62301da89dae2747d5e942e7ab4147ea39368321956c430
+    checksum: 6113d30f0f72cbb6930332d16361955fa72067c11e84db1ef62301da89dae2747d5e942e7ab4147ea39368321956c430
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.xml
   - name: FP16-INT1/resnet50-binary-0001.bin
     size: 12348792
-    sha384: bf03f7f722af21afbeeb315218d3d311a8a0a64780e3e122f45ea78a7b4c21d75f79c972b80f5244d21607934d63530a
+    checksum: bf03f7f722af21afbeeb315218d3d311a8a0a64780e3e122f45ea78a7b4c21d75f79c972b80f5244d21607934d63530a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/resnet50-binary-0001/FP16-INT1/resnet50-binary-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/road-segmentation-adas-0001/model.yml
+++ b/models/intel/road-segmentation-adas-0001/model.yml
@@ -19,27 +19,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/road-segmentation-adas-0001.xml
     size: 401509
-    sha384: 4ef4d0946949829b615766977fcab52459f1fe1012459e2c1110274208c748c01650a003a09557c75dfd5d8c74ea42af
+    checksum: 4ef4d0946949829b615766977fcab52459f1fe1012459e2c1110274208c748c01650a003a09557c75dfd5d8c74ea42af
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.xml
   - name: FP32/road-segmentation-adas-0001.bin
     size: 737192
-    sha384: 79f494aff63c53e76692aa14b7d5bf7df8cb8dd0c2e815dd5136c0462ba33e8604fc67424d47ba560b80b6b45d53e16c
+    checksum: 79f494aff63c53e76692aa14b7d5bf7df8cb8dd0c2e815dd5136c0462ba33e8604fc67424d47ba560b80b6b45d53e16c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP32/road-segmentation-adas-0001.bin
   - name: FP16/road-segmentation-adas-0001.xml
     size: 401354
-    sha384: 2d0848ee5233402af72e8edd3dce48b14281f7a7a37e55f6da17757931613e43990d419fec602e8a93b0fad5b7e3b728
+    checksum: 2d0848ee5233402af72e8edd3dce48b14281f7a7a37e55f6da17757931613e43990d419fec602e8a93b0fad5b7e3b728
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.xml
   - name: FP16/road-segmentation-adas-0001.bin
     size: 368620
-    sha384: 776b06a7b1d83ff4e0fd670b6189a71dda77c0f6ab6d4efb2a371a965fb026ea3fb47ad918c9a85cf658745adce857d3
+    checksum: 776b06a7b1d83ff4e0fd670b6189a71dda77c0f6ab6d4efb2a371a965fb026ea3fb47ad918c9a85cf658745adce857d3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP16/road-segmentation-adas-0001.bin
   - name: FP16-INT8/road-segmentation-adas-0001.xml
     size: 1114191
-    sha384: d7666e74bdafd067544367a7c385fc84b0ba90063882abf3dd848910d2d7e4f3651a56a605e05c953960e0ba7af4c99f
+    checksum: d7666e74bdafd067544367a7c385fc84b0ba90063882abf3dd848910d2d7e4f3651a56a605e05c953960e0ba7af4c99f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.xml
   - name: FP16-INT8/road-segmentation-adas-0001.bin
     size: 188927
-    sha384: b8cc16cd85f320b853cfc1777f0f3a36b12331f74957e106e305fecb9569a33891aad5797424a053fdc17250a1e63d83
+    checksum: b8cc16cd85f320b853cfc1777f0f3a36b12331f74957e106e305fecb9569a33891aad5797424a053fdc17250a1e63d83
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/road-segmentation-adas-0001/FP16-INT8/road-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/semantic-segmentation-adas-0001/model.yml
+++ b/models/intel/semantic-segmentation-adas-0001/model.yml
@@ -20,27 +20,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/semantic-segmentation-adas-0001.xml
     size: 214195
-    sha384: 856f3c9d4d033ce190d667d93940868160e691b65d636e09201590923aeda10b25354691d0d7ec8ff1a03f4e33d7d655
+    checksum: 856f3c9d4d033ce190d667d93940868160e691b65d636e09201590923aeda10b25354691d0d7ec8ff1a03f4e33d7d655
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.xml
   - name: FP32/semantic-segmentation-adas-0001.bin
     size: 26743556
-    sha384: 7b1bf43cdd4b12c3f86d88e98407be64113720e96dc56d5b1f893b4004897afef97082659cb1da48f276093aaee772ad
+    checksum: 7b1bf43cdd4b12c3f86d88e98407be64113720e96dc56d5b1f893b4004897afef97082659cb1da48f276093aaee772ad
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP32/semantic-segmentation-adas-0001.bin
   - name: FP16/semantic-segmentation-adas-0001.xml
     size: 214114
-    sha384: 92ad3e8cf14beec01af5f919eeb1dcee4d6aef99f094bf7fafe07ce2a693060533942895c6ce99909621312331ebb961
+    checksum: 92ad3e8cf14beec01af5f919eeb1dcee4d6aef99f094bf7fafe07ce2a693060533942895c6ce99909621312331ebb961
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.xml
   - name: FP16/semantic-segmentation-adas-0001.bin
     size: 13371812
-    sha384: 97707e34ab3db3dacbf3216fedc249608ce418e143d1a86750a3ee90809dfd59c311ff757a6354274d1c0ae513293143
+    checksum: 97707e34ab3db3dacbf3216fedc249608ce418e143d1a86750a3ee90809dfd59c311ff757a6354274d1c0ae513293143
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP16/semantic-segmentation-adas-0001.bin
   - name: FP16-INT8/semantic-segmentation-adas-0001.xml
     size: 536811
-    sha384: 8db2b38745da8e6a7ad62b2ce69146e4dd498cd66ba97f4c0d4689be0f37beda3a3cd3501290a1ff6d7cd92ba4428754
+    checksum: 8db2b38745da8e6a7ad62b2ce69146e4dd498cd66ba97f4c0d4689be0f37beda3a3cd3501290a1ff6d7cd92ba4428754
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP16-INT8/semantic-segmentation-adas-0001.xml
   - name: FP16-INT8/semantic-segmentation-adas-0001.bin
     size: 6757670
-    sha384: 8e35daf848f2dcec5d328bf8b02d88a81b5461b28fee4aba5998ebd128006c1df75a17474f7f6e53a45f1c8a5747a9dc
+    checksum: 8e35daf848f2dcec5d328bf8b02d88a81b5461b28fee4aba5998ebd128006c1df75a17474f7f6e53a45f1c8a5747a9dc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/semantic-segmentation-adas-0001/FP16-INT8/semantic-segmentation-adas-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1032/model.yml
+++ b/models/intel/single-image-super-resolution-1032/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1032.xml
     size: 82030
-    sha384: 7d8b48361204fa6da774af855f80fcdb40d3caa5907062a4fcc3127a97c28a8fd34b2a848a03d337ff61bae5c7fc9fb3
+    checksum: 7d8b48361204fa6da774af855f80fcdb40d3caa5907062a4fcc3127a97c28a8fd34b2a848a03d337ff61bae5c7fc9fb3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.xml
   - name: FP32/single-image-super-resolution-1032.bin
     size: 119436
-    sha384: 5b03e4f2095df69bddb041da7dba7c8126223f5ac8e73c9a12c4627598f5a14447a7efd2effa21278026e3ead8756e6d
+    checksum: 5b03e4f2095df69bddb041da7dba7c8126223f5ac8e73c9a12c4627598f5a14447a7efd2effa21278026e3ead8756e6d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP32/single-image-super-resolution-1032.bin
   - name: FP16/single-image-super-resolution-1032.xml
     size: 81953
-    sha384: 3a8d7b1f16d2cfd60a8ad10c4628018204e34830bbdf6c7fc9cfb5f5d160f3a259d29be60d78602c406bd40a50f05b9d
+    checksum: 3a8d7b1f16d2cfd60a8ad10c4628018204e34830bbdf6c7fc9cfb5f5d160f3a259d29be60d78602c406bd40a50f05b9d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.xml
   - name: FP16/single-image-super-resolution-1032.bin
     size: 59762
-    sha384: 4cee28140fe9e171c023690dec8376eff8937d7cae39998ebcad317b96268fa8c9e8ec226af088ea45a7664a920a7d92
+    checksum: 4cee28140fe9e171c023690dec8376eff8937d7cae39998ebcad317b96268fa8c9e8ec226af088ea45a7664a920a7d92
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP16/single-image-super-resolution-1032.bin
   - name: FP16-INT8/single-image-super-resolution-1032.xml
     size: 166898
-    sha384: 2830fd4871555e73b6f6a241f2bcc5d81986a0313b69d070be2c6fd40c9ea92dd64c50003b7ee6d33e4847608054deb7
+    checksum: 2830fd4871555e73b6f6a241f2bcc5d81986a0313b69d070be2c6fd40c9ea92dd64c50003b7ee6d33e4847608054deb7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.xml
   - name: FP16-INT8/single-image-super-resolution-1032.bin
     size: 31042
-    sha384: f05a3b99b40380f857a8e05c03d6e1755063ad087a2c5e2e460687f90a6c5e323bcbd305b1ca498c9e7816c7f7f28b4e
+    checksum: f05a3b99b40380f857a8e05c03d6e1755063ad087a2c5e2e460687f90a6c5e323bcbd305b1ca498c9e7816c7f7f28b4e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1032/FP16-INT8/single-image-super-resolution-1032.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/single-image-super-resolution-1033/model.yml
+++ b/models/intel/single-image-super-resolution-1033/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/single-image-super-resolution-1033.xml
     size: 57397
-    sha384: 900fe4dbf9cba6ecc9c6fcebfb2dd918df5860a6bc4c12ae0bc7eaa5566eb2beea3af064371d5b7c7325817f0ee9164d
+    checksum: 900fe4dbf9cba6ecc9c6fcebfb2dd918df5860a6bc4c12ae0bc7eaa5566eb2beea3af064371d5b7c7325817f0ee9164d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.xml
   - name: FP32/single-image-super-resolution-1033.bin
     size: 121780
-    sha384: 7395229a259f7371276750d1c43ee62240ee999f7272c84d7136377d3eb61feab649b4b32ad1c03a2d46e0f67822d32e
+    checksum: 7395229a259f7371276750d1c43ee62240ee999f7272c84d7136377d3eb61feab649b4b32ad1c03a2d46e0f67822d32e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP32/single-image-super-resolution-1033.bin
   - name: FP16/single-image-super-resolution-1033.xml
     size: 57354
-    sha384: 1775e9e3d85b0a144fad10029d8a2e0976ccd8d0539b4ccc92a7b4049ff125452a58b813cc49b5df7994e51bab313ef2
+    checksum: 1775e9e3d85b0a144fad10029d8a2e0976ccd8d0539b4ccc92a7b4049ff125452a58b813cc49b5df7994e51bab313ef2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.xml
   - name: FP16/single-image-super-resolution-1033.bin
     size: 60938
-    sha384: a944b9287810c9d054a1fe7614f6e827fca275c956c1c0e1f32e17bb1daf9a32463bbc1a13f6f2dca1c8b9ccb0334795
+    checksum: a944b9287810c9d054a1fe7614f6e827fca275c956c1c0e1f32e17bb1daf9a32463bbc1a13f6f2dca1c8b9ccb0334795
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP16/single-image-super-resolution-1033.bin
   - name: FP16-INT8/single-image-super-resolution-1033.xml
     size: 139173
-    sha384: 8f2d2e65b37e99d0fcd559d86fbf7e56ec04c22e6ffd46816ecc3f569b4f955eb9a21e716f779c67d77070015ae8fe6b
+    checksum: 8f2d2e65b37e99d0fcd559d86fbf7e56ec04c22e6ffd46816ecc3f569b4f955eb9a21e716f779c67d77070015ae8fe6b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.xml
   - name: FP16-INT8/single-image-super-resolution-1033.bin
     size: 31672
-    sha384: 871e869422db03f938ef603093f808f46a2f41b6940788de1e76ed09b76ab56ef99c3e43497547627e03f549876559d9
+    checksum: 871e869422db03f938ef603093f808f46a2f41b6940788de1e76ed09b76ab56ef99c3e43497547627e03f549876559d9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/single-image-super-resolution-1033/FP16-INT8/single-image-super-resolution-1033.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0003/model.yml
+++ b/models/intel/text-detection-0003/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0003.xml
     size: 256837
-    sha384: 31e613b695783a0e0fc3ff64eb74d6be8b50fbbc09e030a214edd5519b332d2f2c64bc78833c7cffb16bee676c09c1f1
+    checksum: 31e613b695783a0e0fc3ff64eb74d6be8b50fbbc09e030a214edd5519b332d2f2c64bc78833c7cffb16bee676c09c1f1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP32/text-detection-0003.xml
   - name: FP32/text-detection-0003.bin
     size: 26986296
-    sha384: 2899e851dd4a3aed189d245e9768471ef04450669819b3bf2e936ddf5eb5ace0057c96ba11e0e95d0c742052356e80b8
+    checksum: 2899e851dd4a3aed189d245e9768471ef04450669819b3bf2e936ddf5eb5ace0057c96ba11e0e95d0c742052356e80b8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP32/text-detection-0003.bin
   - name: FP16/text-detection-0003.xml
     size: 256757
-    sha384: 1eebcb3ee6d4ae3d1a3abadac9da7bea45d109b45a63258d6c08425264b1b06be775786033d479ff88ec87840928aa42
+    checksum: 1eebcb3ee6d4ae3d1a3abadac9da7bea45d109b45a63258d6c08425264b1b06be775786033d479ff88ec87840928aa42
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP16/text-detection-0003.xml
   - name: FP16/text-detection-0003.bin
     size: 13493072
-    sha384: 66fb9f9b1f895923c78578990facc15238ec317b17cb50383a66cd77592d44025cb9c33447ab5b436d61ab65f123241f
+    checksum: 66fb9f9b1f895923c78578990facc15238ec317b17cb50383a66cd77592d44025cb9c33447ab5b436d61ab65f123241f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP16/text-detection-0003.bin
   - name: FP16-INT8/text-detection-0003.xml
     size: 659532
-    sha384: ff2b9d0a5da184337367e480c2d3b4cc03f17b013444f4f8503d9e0aa2bdc236420eab48b7c8dc9c1ce51fa8e8493643
+    checksum: ff2b9d0a5da184337367e480c2d3b4cc03f17b013444f4f8503d9e0aa2bdc236420eab48b7c8dc9c1ce51fa8e8493643
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP16-INT8/text-detection-0003.xml
   - name: FP16-INT8/text-detection-0003.bin
     size: 6894808
-    sha384: 917185a72c900080ec8d3e4d9c23fdb513e485a933ff5cbe09a1de1c2a59745a589986321a699030de2c1d1ae2458abc
+    checksum: 917185a72c900080ec8d3e4d9c23fdb513e485a933ff5cbe09a1de1c2a59745a589986321a699030de2c1d1ae2458abc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0003/FP16-INT8/text-detection-0003.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-detection-0004/model.yml
+++ b/models/intel/text-detection-0004/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-detection-0004.xml
     size: 246789
-    sha384: 9500ffb2f778e2f1c1252b061929dea2160f73f906ea6c70bb5190b32586fb5248304364f9983e8601e630f02d0f1037
+    checksum: 9500ffb2f778e2f1c1252b061929dea2160f73f906ea6c70bb5190b32586fb5248304364f9983e8601e630f02d0f1037
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP32/text-detection-0004.xml
   - name: FP32/text-detection-0004.bin
     size: 17312244
-    sha384: 0bf757ac6f3c18c2e2532ebb4fda5fd368d73ad5f81ae7b534ea1b9d8b28c6fd3c9829961fbb207c6d51a7e123f319ce
+    checksum: 0bf757ac6f3c18c2e2532ebb4fda5fd368d73ad5f81ae7b534ea1b9d8b28c6fd3c9829961fbb207c6d51a7e123f319ce
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP32/text-detection-0004.bin
   - name: FP16/text-detection-0004.xml
     size: 246648
-    sha384: 45be5d6a88eff3feaaa37067142dddccaaa6cbf4accf3e47f75a5b94ab74f5d3eabef51357a61ae880d7add1840d0d23
+    checksum: 45be5d6a88eff3feaaa37067142dddccaaa6cbf4accf3e47f75a5b94ab74f5d3eabef51357a61ae880d7add1840d0d23
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP16/text-detection-0004.xml
   - name: FP16/text-detection-0004.bin
     size: 8656078
-    sha384: e5d7cbb190500406629942f656c285d02caa59ea5d82a1a955cbfda8729e4f2aa3f922ea574b1195faa866b6ee98c3a4
+    checksum: e5d7cbb190500406629942f656c285d02caa59ea5d82a1a955cbfda8729e4f2aa3f922ea574b1195faa866b6ee98c3a4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP16/text-detection-0004.bin
   - name: FP16-INT8/text-detection-0004.xml
     size: 555082
-    sha384: e20abae947b675283eab0a5433dd5ad8732372036b0723fac0eab50d482780b0f82e6514c59748ec4b7aad18afebf81a
+    checksum: e20abae947b675283eab0a5433dd5ad8732372036b0723fac0eab50d482780b0f82e6514c59748ec4b7aad18afebf81a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP16-INT8/text-detection-0004.xml
   - name: FP16-INT8/text-detection-0004.bin
     size: 4475586
-    sha384: 907db8401406443d37cb9e30f3abf070a20341341e15913571301300d323b153ceec65cbbaea68d88623f013b04692b6
+    checksum: 907db8401406443d37cb9e30f3abf070a20341341e15913571301300d323b153ceec65cbbaea68d88623f013b04692b6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-detection-0004/FP16-INT8/text-detection-0004.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-image-super-resolution-0001/model.yml
+++ b/models/intel/text-image-super-resolution-0001/model.yml
@@ -18,27 +18,27 @@ task_type: image_processing
 files:
   - name: FP32/text-image-super-resolution-0001.xml
     size: 11701
-    sha384: d99cfa351334e7ec53f1f70acd6f99d357a381342428aec083bfd4e7b89247f67368d18ddcbaa857d8763835808e39fa
+    checksum: d99cfa351334e7ec53f1f70acd6f99d357a381342428aec083bfd4e7b89247f67368d18ddcbaa857d8763835808e39fa
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.xml
   - name: FP32/text-image-super-resolution-0001.bin
     size: 10836
-    sha384: 985a5cbb9dcb529188f79e3f4e80e5d26828cba04a77b908321dcc8647ada5b97d72a8e1a9fd915bd9f3bca527e3b570
+    checksum: 985a5cbb9dcb529188f79e3f4e80e5d26828cba04a77b908321dcc8647ada5b97d72a8e1a9fd915bd9f3bca527e3b570
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP32/text-image-super-resolution-0001.bin
   - name: FP16/text-image-super-resolution-0001.xml
     size: 11691
-    sha384: e96d6c883e3ca8cff8955570d6bd70d51ba76b446220f4955ce5b4494de7bd6036700c79be9e007da2993c5c10ddb8c2
+    checksum: e96d6c883e3ca8cff8955570d6bd70d51ba76b446220f4955ce5b4494de7bd6036700c79be9e007da2993c5c10ddb8c2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.xml
   - name: FP16/text-image-super-resolution-0001.bin
     size: 5418
-    sha384: 3403c611e626cf9e647f0cc7674e5379129af4385c4fe747cec9556fbb114708a7a6793a321e2d072a7e3cd4c0190cb7
+    checksum: 3403c611e626cf9e647f0cc7674e5379129af4385c4fe747cec9556fbb114708a7a6793a321e2d072a7e3cd4c0190cb7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP16/text-image-super-resolution-0001.bin
   - name: FP16-INT8/text-image-super-resolution-0001.xml
     size: 25162
-    sha384: 39d8a717ae6c3f2ede2f2e7ba06fa6d30dee7e7c668cea6829bcb72c7c96925b0be66cfbd9966ef16b1ee1bcffcb9d1b
+    checksum: 39d8a717ae6c3f2ede2f2e7ba06fa6d30dee7e7c668cea6829bcb72c7c96925b0be66cfbd9966ef16b1ee1bcffcb9d1b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.xml
   - name: FP16-INT8/text-image-super-resolution-0001.bin
     size: 4222
-    sha384: 73d5bc184cef993f27c5910082f566cb70d0fe0464f42e8e87773d8079105c3b0e7a088ba5b38d31db28102fc14b5015
+    checksum: 73d5bc184cef993f27c5910082f566cb70d0fe0464f42e8e87773d8079105c3b0e7a088ba5b38d31db28102fc14b5015
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-image-super-resolution-0001/FP16-INT8/text-image-super-resolution-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0012/model.yml
+++ b/models/intel/text-recognition-0012/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/text-recognition-0012.xml
     size: 112650
-    sha384: c3a796d348f687bc3389f2e6843d9db16b5f4b8b1b211b920a7175b142255711f70aa7c107bc0ce871511b867ec6bbdc
+    checksum: c3a796d348f687bc3389f2e6843d9db16b5f4b8b1b211b920a7175b142255711f70aa7c107bc0ce871511b867ec6bbdc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP32/text-recognition-0012.xml
   - name: FP32/text-recognition-0012.bin
     size: 47470852
-    sha384: aac0d9c1b32cb526d8287b10733009625282bba3934318b9898978172c45e0e5022069b9fd954310bf13aa308cfb9cd5
+    checksum: aac0d9c1b32cb526d8287b10733009625282bba3934318b9898978172c45e0e5022069b9fd954310bf13aa308cfb9cd5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP32/text-recognition-0012.bin
   - name: FP16/text-recognition-0012.xml
     size: 112618
-    sha384: 49b64f5ae7140e47c6f785bc8c10820beee3ca2271c5281f76e14324ca18fa4d1ab1007f8e715d108723aa75de61935f
+    checksum: 49b64f5ae7140e47c6f785bc8c10820beee3ca2271c5281f76e14324ca18fa4d1ab1007f8e715d108723aa75de61935f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP16/text-recognition-0012.xml
   - name: FP16/text-recognition-0012.bin
     size: 23735478
-    sha384: 93ae52ee585409f4450dbc7946a6ddfaa5678f0bcbc7baa08f6111de6e21da17ee4166ecc46c7fce6edef71843677f8b
+    checksum: 93ae52ee585409f4450dbc7946a6ddfaa5678f0bcbc7baa08f6111de6e21da17ee4166ecc46c7fce6edef71843677f8b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP16/text-recognition-0012.bin
   - name: FP16-INT8/text-recognition-0012.xml
     size: 147892
-    sha384: 247dbd3d6444b8b67bdee04aedbd959543b3cfa3e2b98738ffd5bea201a6a28dea2c3ceaa99b9bfd557b6e5cdc32e9cb
+    checksum: 247dbd3d6444b8b67bdee04aedbd959543b3cfa3e2b98738ffd5bea201a6a28dea2c3ceaa99b9bfd557b6e5cdc32e9cb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP16-INT8/text-recognition-0012.xml
   - name: FP16-INT8/text-recognition-0012.bin
     size: 18217000
-    sha384: 885625e0d64828d2633a910be7f9012a48a748218276f53a6330078b495630a221389018ba63403a7fdb9a8f559b0351
+    checksum: 885625e0d64828d2633a910be7f9012a48a748218276f53a6330078b495630a221389018ba63403a7fdb9a8f559b0351
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0012/FP16-INT8/text-recognition-0012.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0014/model.yml
+++ b/models/intel/text-recognition-0014/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/text-recognition-0014.xml
     size: 220869
-    sha384: 7bdb7f11588aca22656014e096b10b98bdf204c90a2557da25cea52f9955b2b6ff858df111ac9bc25627c73b7cdee512
+    checksum: 7bdb7f11588aca22656014e096b10b98bdf204c90a2557da25cea52f9955b2b6ff858df111ac9bc25627c73b7cdee512
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP32/text-recognition-0014.xml
   - name: FP32/text-recognition-0014.bin
     size: 36555752
-    sha384: 270e5a11e9a73c1f72df468c6acf60cfeda87bcbf4f2876584e0ce5fd5cd9740cd0edba4762dc45859ad8598ce044338
+    checksum: 270e5a11e9a73c1f72df468c6acf60cfeda87bcbf4f2876584e0ce5fd5cd9740cd0edba4762dc45859ad8598ce044338
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP32/text-recognition-0014.bin
   - name: FP16/text-recognition-0014.xml
     size: 220711
-    sha384: 14c4ed52cf9a178e951cdbb298c21628d4e8b6873ce2f4eda72f1379b9d07e3ef3bcd38a1d77ef36f98ac60a115984c0
+    checksum: 14c4ed52cf9a178e951cdbb298c21628d4e8b6873ce2f4eda72f1379b9d07e3ef3bcd38a1d77ef36f98ac60a115984c0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP16/text-recognition-0014.xml
   - name: FP16/text-recognition-0014.bin
     size: 18278038
-    sha384: a0be445dcca932082f26c5db40f96b263f86c17ef14826fe647c3cede719f6fffd57057be8a52921c7c5011b51c15da4
+    checksum: a0be445dcca932082f26c5db40f96b263f86c17ef14826fe647c3cede719f6fffd57057be8a52921c7c5011b51c15da4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP16/text-recognition-0014.bin
   - name: FP16-INT8/text-recognition-0014.xml
     size: 346571
-    sha384: 005376c823635b302109c688e5f02b71683a7147c26990cc6b14ee39f735c481ead60a247564045b6afdd496ea5737ee
+    checksum: 005376c823635b302109c688e5f02b71683a7147c26990cc6b14ee39f735c481ead60a247564045b6afdd496ea5737ee
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP16-INT8/text-recognition-0014.xml
   - name: FP16-INT8/text-recognition-0014.bin
     size: 15485590
-    sha384: 215d50460e102c089c9c78fbc6975ff3d6f2737d2c43cf42aa5354630a0bf3e8670bfe105a1d350527ec7cc8dfba69ae
+    checksum: 215d50460e102c089c9c78fbc6975ff3d6f2737d2c43cf42aa5354630a0bf3e8670bfe105a1d350527ec7cc8dfba69ae
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0014/FP16-INT8/text-recognition-0014.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0015/text-recognition-0015-decoder/model.yml
+++ b/models/intel/text-recognition-0015/text-recognition-0015-decoder/model.yml
@@ -18,19 +18,19 @@ task_type: token_recognition
 files:
   - name: FP32/text-recognition-0015-decoder.xml
     size: 55509
-    sha384: 20d747e5724c6286f8542c908b343b766c8605fa6448daeaaf791f582ceb496e07865d6a23bf44589bbecae1ec1dd662
+    checksum: 20d747e5724c6286f8542c908b343b766c8605fa6448daeaaf791f582ceb496e07865d6a23bf44589bbecae1ec1dd662
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-decoder/FP32/text-recognition-0015-decoder.xml
   - name: FP32/text-recognition-0015-decoder.bin
     size: 42516860
-    sha384: be2fdb03cb98748790b1268512f2406c0d90fd603cd436f30434da2476e053c227282702fa51ccc684bb71caccf3f550
+    checksum: be2fdb03cb98748790b1268512f2406c0d90fd603cd436f30434da2476e053c227282702fa51ccc684bb71caccf3f550
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-decoder/FP32/text-recognition-0015-decoder.bin
   - name: FP16/text-recognition-0015-decoder.xml
     size: 55504
-    sha384: 12e1ca286909963860795dcbbef3c8d37a3d91b5eccbc4d6119579c48441f9c656c7b39396ece3405f2a0e6ab396c693
+    checksum: 12e1ca286909963860795dcbbef3c8d37a3d91b5eccbc4d6119579c48441f9c656c7b39396ece3405f2a0e6ab396c693
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-decoder/FP16/text-recognition-0015-decoder.xml
   - name: FP16/text-recognition-0015-decoder.bin
     size: 21258488
-    sha384: 4aff6e7905aab6f6f50daba44c58faceae6487595f84414e535dd11acad7930f0ffde60677bd5440e6815b73bd7037e3
+    checksum: 4aff6e7905aab6f6f50daba44c58faceae6487595f84414e535dd11acad7930f0ffde60677bd5440e6815b73bd7037e3
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-decoder/FP16/text-recognition-0015-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-recognition-0015/text-recognition-0015-encoder/model.yml
+++ b/models/intel/text-recognition-0015/text-recognition-0015-encoder/model.yml
@@ -18,19 +18,19 @@ task_type: feature_extraction
 files:
   - name: FP32/text-recognition-0015-encoder.xml
     size: 326445
-    sha384: 27441bbe12dee3d4c9dff93d25516883915ff89f1095cbc6674b0897d8d22da4ff986a809eaa5f79dccc2550a67f8dba
+    checksum: 27441bbe12dee3d4c9dff93d25516883915ff89f1095cbc6674b0897d8d22da4ff986a809eaa5f79dccc2550a67f8dba
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-encoder/FP32/text-recognition-0015-encoder.xml
   - name: FP32/text-recognition-0015-encoder.bin
     size: 1592248036
-    sha384: 8e54bd82adf517bb3e08a45d673a4b1626698819ce4b90c8a0cf702ffad1e89853327cc16e9e44b8a8d8dce58ee5dbdc
+    checksum: 8e54bd82adf517bb3e08a45d673a4b1626698819ce4b90c8a0cf702ffad1e89853327cc16e9e44b8a8d8dce58ee5dbdc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-encoder/FP32/text-recognition-0015-encoder.bin
   - name: FP16/text-recognition-0015-encoder.xml
     size: 326304
-    sha384: 3871c35a68ebe3f4f93e3c763cfe0c8a06b2e6d23c583e976eee57e79f0316587df9524448fdceafbf9f1bd579cad2d2
+    checksum: 3871c35a68ebe3f4f93e3c763cfe0c8a06b2e6d23c583e976eee57e79f0316587df9524448fdceafbf9f1bd579cad2d2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-encoder/FP16/text-recognition-0015-encoder.xml
   - name: FP16/text-recognition-0015-encoder.bin
     size: 796124044
-    sha384: b34ab56d2ff2fb80a6fac649aede61d382bb81543531ea4f0a24001c0cce698de2b31eebd381dc3861c96657df1b9bd9
+    checksum: b34ab56d2ff2fb80a6fac649aede61d382bb81543531ea4f0a24001c0cce698de2b31eebd381dc3861c96657df1b9bd9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-recognition-0015/text-recognition-0015-encoder/FP16/text-recognition-0015-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0005/text-spotting-0005-detector/model.yml
+++ b/models/intel/text-spotting-0005/text-spotting-0005-detector/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/text-spotting-0005-detector.xml
     size: 787322
-    sha384: 2bf03b8bd98b1feb1daab5af6a678cdaf765e346e4a4d714db32be4f424fd2d466826bcf8da10ff6c77974314960fdf1
+    checksum: 2bf03b8bd98b1feb1daab5af6a678cdaf765e346e4a4d714db32be4f424fd2d466826bcf8da10ff6c77974314960fdf1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP32/text-spotting-0005-detector.xml
   - name: FP32/text-spotting-0005-detector.bin
     size: 103797576
-    sha384: 159e28ee53a290ee166d126c0ea988f3883d0672e5e0a9921877f706831c07bc7d46dcb718faf77d772cc19984469f93
+    checksum: 159e28ee53a290ee166d126c0ea988f3883d0672e5e0a9921877f706831c07bc7d46dcb718faf77d772cc19984469f93
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP32/text-spotting-0005-detector.bin
   - name: FP16/text-spotting-0005-detector.xml
     size: 787207
-    sha384: d31dfb7bf3990c067590ec5759dc968735f644f73b921a56a846420d3cf23c3572326fdbc8ab1d672a580dfca58199ef
+    checksum: d31dfb7bf3990c067590ec5759dc968735f644f73b921a56a846420d3cf23c3572326fdbc8ab1d672a580dfca58199ef
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP16/text-spotting-0005-detector.xml
   - name: FP16/text-spotting-0005-detector.bin
     size: 51899008
-    sha384: 923c409f4f8fc26c15026a1e2cfb6d5b4b5cd225a437a73d6d448858e1f42fdf910a1e6c27f1b0a6788562404f48f35f
+    checksum: 923c409f4f8fc26c15026a1e2cfb6d5b4b5cd225a437a73d6d448858e1f42fdf910a1e6c27f1b0a6788562404f48f35f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP16/text-spotting-0005-detector.bin
   - name: FP16-INT8/text-spotting-0005-detector.xml
     size: 1141663
-    sha384: 880ae56c5a3a7c9099a3a76ba7aa89d0ca399068dbf789daf4ec85e0ae7bf02ad800a72d837e55f046576c612055861f
+    checksum: 880ae56c5a3a7c9099a3a76ba7aa89d0ca399068dbf789daf4ec85e0ae7bf02ad800a72d837e55f046576c612055861f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP16-INT8/text-spotting-0005-detector.xml
   - name: FP16-INT8/text-spotting-0005-detector.bin
     size: 15611019
-    sha384: 0f5fc06a2377bff04b4fe110e255bfa429a55ff13e9af3d6a0c65591d6f8163a69a2e0525abedaa47af3ad942251134c
+    checksum: 0f5fc06a2377bff04b4fe110e255bfa429a55ff13e9af3d6a0c65591d6f8163a69a2e0525abedaa47af3ad942251134c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-detector/FP16-INT8/text-spotting-0005-detector.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0005/text-spotting-0005-recognizer-decoder/model.yml
+++ b/models/intel/text-spotting-0005/text-spotting-0005-recognizer-decoder/model.yml
@@ -19,27 +19,27 @@ task_type: optical_character_recognition
 files:
   - name: FP32/text-spotting-0005-recognizer-decoder.xml
     size: 52801
-    sha384: ef3525ed3b211d76be6e431d1de9baf0d1505ce432bd79549f3b4034be3231317e2db2b04570f857f68618a430580b35
+    checksum: ef3525ed3b211d76be6e431d1de9baf0d1505ce432bd79549f3b4034be3231317e2db2b04570f857f68618a430580b35
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP32/text-spotting-0005-recognizer-decoder.xml
   - name: FP32/text-spotting-0005-recognizer-decoder.bin
     size: 2707724
-    sha384: 4a0edc8073e167328870e098e82e40bded9a993af805ad7e19a9ee57dd14de49811292698358f7bf06ed6ff04ba6d6b4
+    checksum: 4a0edc8073e167328870e098e82e40bded9a993af805ad7e19a9ee57dd14de49811292698358f7bf06ed6ff04ba6d6b4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP32/text-spotting-0005-recognizer-decoder.bin
   - name: FP16/text-spotting-0005-recognizer-decoder.xml
     size: 52793
-    sha384: e3166251c48e54bb713ef64ddf0dc99db5a0e42b65519ff131703fbe911273c5a0fc12bfbb3d86e63d50e16ee6df0dc4
+    checksum: e3166251c48e54bb713ef64ddf0dc99db5a0e42b65519ff131703fbe911273c5a0fc12bfbb3d86e63d50e16ee6df0dc4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP16/text-spotting-0005-recognizer-decoder.xml
   - name: FP16/text-spotting-0005-recognizer-decoder.bin
     size: 1353920
-    sha384: dbb69793304dcd4d49a91b6a193859127e4b05b4cb01e227a0c3dd8ac6217f3966f54fda5d6121136c8f5b241d51fbca
+    checksum: dbb69793304dcd4d49a91b6a193859127e4b05b4cb01e227a0c3dd8ac6217f3966f54fda5d6121136c8f5b241d51fbca
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP16/text-spotting-0005-recognizer-decoder.bin
   - name: FP16-INT8/text-spotting-0005-recognizer-decoder.xml
     size: 80802
-    sha384: b7887e00d558fa7b81e808bba5ed0f2014cdef5ede3471e577e3deec060fb8c4e9da5ad003a29b27593b7e3bb12ea7d6
+    checksum: b7887e00d558fa7b81e808bba5ed0f2014cdef5ede3471e577e3deec060fb8c4e9da5ad003a29b27593b7e3bb12ea7d6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP16-INT8/text-spotting-0005-recognizer-decoder.xml
   - name: FP16-INT8/text-spotting-0005-recognizer-decoder.bin
     size: 1085540
-    sha384: 6e145f52addd1294d43c50bef5a5d1c7f02891d5171411048c0be9229a355cc9f48f33a397c841767efab17f8062d3cb
+    checksum: 6e145f52addd1294d43c50bef5a5d1c7f02891d5171411048c0be9229a355cc9f48f33a397c841767efab17f8062d3cb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-decoder/FP16-INT8/text-spotting-0005-recognizer-decoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-spotting-0005/text-spotting-0005-recognizer-encoder/model.yml
+++ b/models/intel/text-spotting-0005/text-spotting-0005-recognizer-encoder/model.yml
@@ -19,27 +19,27 @@ task_type: feature_extraction
 files:
   - name: FP32/text-spotting-0005-recognizer-encoder.xml
     size: 10223
-    sha384: f3a7415851daf8651b605c854afe237963e8baecd4b33eed8388ec172cb2b6139568206c360c8c3f24e448aaef5a1f2c
+    checksum: f3a7415851daf8651b605c854afe237963e8baecd4b33eed8388ec172cb2b6139568206c360c8c3f24e448aaef5a1f2c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP32/text-spotting-0005-recognizer-encoder.xml
   - name: FP32/text-spotting-0005-recognizer-encoder.bin
     size: 5311488
-    sha384: c39b30d4c4ab709a183104daff4d033d003be3f71f33404ef66b948cb5a60b19d1e1028909f4bf197ab48d68ccc48bc0
+    checksum: c39b30d4c4ab709a183104daff4d033d003be3f71f33404ef66b948cb5a60b19d1e1028909f4bf197ab48d68ccc48bc0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP32/text-spotting-0005-recognizer-encoder.bin
   - name: FP16/text-spotting-0005-recognizer-encoder.xml
     size: 10220
-    sha384: 745566b3e17ccddb291aeb005b9180a257dbb4f8c672640f3214d294e8691ed5f078fef9703d2bf2f9d43d7745b55b19
+    checksum: 745566b3e17ccddb291aeb005b9180a257dbb4f8c672640f3214d294e8691ed5f078fef9703d2bf2f9d43d7745b55b19
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP16/text-spotting-0005-recognizer-encoder.xml
   - name: FP16/text-spotting-0005-recognizer-encoder.bin
     size: 2655744
-    sha384: cbd2231d9080903deccd16711eb79d30add22f60f314f0a5c37f4207d12f7260b67a335cacd92c95aa682128c2697065
+    checksum: cbd2231d9080903deccd16711eb79d30add22f60f314f0a5c37f4207d12f7260b67a335cacd92c95aa682128c2697065
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP16/text-spotting-0005-recognizer-encoder.bin
   - name: FP16-INT8/text-spotting-0005-recognizer-encoder.xml
     size: 25295
-    sha384: b7651fc064862c3b24de8e529c16058d9f5babf82d7ca9de9091b9c017823447a41639c9ebd4729e7f58ef30ebf3d73b
+    checksum: b7651fc064862c3b24de8e529c16058d9f5babf82d7ca9de9091b9c017823447a41639c9ebd4729e7f58ef30ebf3d73b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP16-INT8/text-spotting-0005-recognizer-encoder.xml
   - name: FP16-INT8/text-spotting-0005-recognizer-encoder.bin
     size: 1317880
-    sha384: 6b88c969521742dfb47fe18a241d3b1092d69f3f5887be0831e768050b0052b0ed2c061ea8e0d487607441b0a9ab14e5
+    checksum: 6b88c969521742dfb47fe18a241d3b1092d69f3f5887be0831e768050b0052b0ed2c061ea8e0d487607441b0a9ab14e5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-spotting-0005/text-spotting-0005-recognizer-encoder/FP16-INT8/text-spotting-0005-recognizer-encoder.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/model.yml
+++ b/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-0001-duration-prediction.xml
     size: 562415
-    sha384: b2fe945cadb40f6563142eb889c67377dddb985d878abf3a0cc412c103f642be64023003707f48227cb3a17e7af0f238
+    checksum: b2fe945cadb40f6563142eb889c67377dddb985d878abf3a0cc412c103f642be64023003707f48227cb3a17e7af0f238
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/FP32/text-to-speech-en-0001-duration-prediction.xml
   - name: FP32/text-to-speech-en-0001-duration-prediction.bin
     size: 54275772
-    sha384: 08188f25e553273ff47da4c5999bc9a8a84ba4365d7d6b26755843e0ec11a3462bf642abf6470c28e1a6df19348ed083
+    checksum: 08188f25e553273ff47da4c5999bc9a8a84ba4365d7d6b26755843e0ec11a3462bf642abf6470c28e1a6df19348ed083
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/FP32/text-to-speech-en-0001-duration-prediction.bin
   - name: FP16/text-to-speech-en-0001-duration-prediction.xml
     size: 562152
-    sha384: 6bdb2eef76fa8551154cb11cf56fd21b22ad8e4eb8889dbfa6912642e1ded13cc874b9dd090d7207fcd07ac72b11ac7c
+    checksum: 6bdb2eef76fa8551154cb11cf56fd21b22ad8e4eb8889dbfa6912642e1ded13cc874b9dd090d7207fcd07ac72b11ac7c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/FP16/text-to-speech-en-0001-duration-prediction.xml
   - name: FP16/text-to-speech-en-0001-duration-prediction.bin
     size: 27137958
-    sha384: f19ccade135499b4ded95e5348332b3f05ee6339fa900d66a8378babbecb1b398dc2c63223478c532ef2f14478f6efef
+    checksum: f19ccade135499b4ded95e5348332b3f05ee6339fa900d66a8378babbecb1b398dc2c63223478c532ef2f14478f6efef
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-duration-prediction/FP16/text-to-speech-en-0001-duration-prediction.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-generation/model.yml
+++ b/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-generation/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-0001-generation.xml
     size: 219853
-    sha384: 9fe0946358b75854dc0b457bb6089c73808d2bcc85e033d979f2559faba6634dfe3887a985c4a20612867eeb0e17adcb
+    checksum: 9fe0946358b75854dc0b457bb6089c73808d2bcc85e033d979f2559faba6634dfe3887a985c4a20612867eeb0e17adcb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-generation/FP32/text-to-speech-en-0001-generation.xml
   - name: FP32/text-to-speech-en-0001-generation.bin
     size: 51082868
-    sha384: f67813865d59c12af57110a668619a3572a304db0912cbd29ee7d4984d4e2bfb4c8d4472916758f5261bc3b6a858927d
+    checksum: f67813865d59c12af57110a668619a3572a304db0912cbd29ee7d4984d4e2bfb4c8d4472916758f5261bc3b6a858927d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-generation/FP32/text-to-speech-en-0001-generation.bin
   - name: FP16/text-to-speech-en-0001-generation.xml
     size: 219850
-    sha384: 4b7f879bf8bbdd8336ae3e9061dc9e24f8b4fcbc5478d7ea552a0a25573c86ec46950608c7cd044e5b1d23c3de34f088
+    checksum: 4b7f879bf8bbdd8336ae3e9061dc9e24f8b4fcbc5478d7ea552a0a25573c86ec46950608c7cd044e5b1d23c3de34f088
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-generation/FP16/text-to-speech-en-0001-generation.xml
   - name: FP16/text-to-speech-en-0001-generation.bin
     size: 25541548
-    sha384: 13d7a863b5b433aeed4c328fc94f59c3079c26d20e0876ac7b8a8f35c933490f27ce7b42961f631c147119fff0f215a0
+    checksum: 13d7a863b5b433aeed4c328fc94f59c3079c26d20e0876ac7b8a8f35c933490f27ce7b42961f631c147119fff0f215a0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-generation/FP16/text-to-speech-en-0001-generation.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-regression/model.yml
+++ b/models/intel/text-to-speech-en-0001/text-to-speech-en-0001-regression/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-0001-regression.xml
     size: 573812
-    sha384: f1e74e0a4ee58b9ae8ffb192f7d9d40f588e442b08e2c2032dbabb4e6be11838fef5dfdd4739cbdf402fb44c6b70477c
+    checksum: f1e74e0a4ee58b9ae8ffb192f7d9d40f588e442b08e2c2032dbabb4e6be11838fef5dfdd4739cbdf402fb44c6b70477c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-regression/FP32/text-to-speech-en-0001-regression.xml
   - name: FP32/text-to-speech-en-0001-regression.bin
     size: 19851412
-    sha384: f1e0327eda382eaf181281658a8c6c07d9113a50e2a6246b7d1b6efe4caf0e5c96d01bbb3057520ac4d7ada0642adc58
+    checksum: f1e0327eda382eaf181281658a8c6c07d9113a50e2a6246b7d1b6efe4caf0e5c96d01bbb3057520ac4d7ada0642adc58
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-regression/FP32/text-to-speech-en-0001-regression.bin
   - name: FP16/text-to-speech-en-0001-regression.xml
     size: 573558
-    sha384: 1b2034169aca7a74c421634aa2721ed107c41030783da16ed6660d170cd12992145c94e814b731c9a6a7d870e3675649
+    checksum: 1b2034169aca7a74c421634aa2721ed107c41030783da16ed6660d170cd12992145c94e814b731c9a6a7d870e3675649
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-regression/FP16/text-to-speech-en-0001-regression.xml
   - name: FP16/text-to-speech-en-0001-regression.bin
     size: 9925782
-    sha384: 19169015055c826107816009a1f5467939ffd39aa01b2930b75432e13a93511080bcd4bf82884c33c2228811f2086ae2
+    checksum: 19169015055c826107816009a1f5467939ffd39aa01b2930b75432e13a93511080bcd4bf82884c33c2228811f2086ae2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-0001/text-to-speech-en-0001-regression/FP16/text-to-speech-en-0001-regression.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/model.yml
+++ b/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-multi-0001-duration-prediction.xml
     size: 650961
-    sha384: 34eb221cef25ffd33d2faeb772d7c9a778d5285fec2622e136e6994b28832b4a5c4e68ac3d10009004e62329c1a070d5
+    checksum: 34eb221cef25ffd33d2faeb772d7c9a778d5285fec2622e136e6994b28832b4a5c4e68ac3d10009004e62329c1a070d5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/FP32/text-to-speech-en-multi-0001-duration-prediction.xml
   - name: FP32/text-to-speech-en-multi-0001-duration-prediction.bin
     size: 104707900
-    sha384: 2e68205d17f202a294a98e966918e0d4af73f323dda7de5823a61b92fa81cc19ee62aa09b789cd56c28590b849733632
+    checksum: 2e68205d17f202a294a98e966918e0d4af73f323dda7de5823a61b92fa81cc19ee62aa09b789cd56c28590b849733632
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/FP32/text-to-speech-en-multi-0001-duration-prediction.bin
   - name: FP16/text-to-speech-en-multi-0001-duration-prediction.xml
     size: 650523
-    sha384: e4b259dd9da771a3757e449db417c4dfc81d14f9be643cb69faa7b134b0eefdc7e180cba5a41e47fe097752c1aeba7e6
+    checksum: e4b259dd9da771a3757e449db417c4dfc81d14f9be643cb69faa7b134b0eefdc7e180cba5a41e47fe097752c1aeba7e6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/FP16/text-to-speech-en-multi-0001-duration-prediction.xml
   - name: FP16/text-to-speech-en-multi-0001-duration-prediction.bin
     size: 52354022
-    sha384: f66571d2063aed0ad598e14f971afa8b0c3306089e1274647915d180d4c1bc84362997fad4d5ecc6770bb937552896f4
+    checksum: f66571d2063aed0ad598e14f971afa8b0c3306089e1274647915d180d4c1bc84362997fad4d5ecc6770bb937552896f4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-duration-prediction/FP16/text-to-speech-en-multi-0001-duration-prediction.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/model.yml
+++ b/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-multi-0001-generation.xml
     size: 232924
-    sha384: a1dd56f33d09b6ee1c745788e626dbf5846688a28f62eafd58050737ce47a9f8070a19654803e4d45ed14a9b70a2f5f9
+    checksum: a1dd56f33d09b6ee1c745788e626dbf5846688a28f62eafd58050737ce47a9f8070a19654803e4d45ed14a9b70a2f5f9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/FP32/text-to-speech-en-multi-0001-generation.xml
   - name: FP32/text-to-speech-en-multi-0001-generation.bin
     size: 51082860
-    sha384: 34f69abdc93df984c7771149b2bc127509649230f7ef41fe9ea8f4eaea3ecbe1fd3856ac005079339fc89b071c46b08c
+    checksum: 34f69abdc93df984c7771149b2bc127509649230f7ef41fe9ea8f4eaea3ecbe1fd3856ac005079339fc89b071c46b08c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/FP32/text-to-speech-en-multi-0001-generation.bin
   - name: FP16/text-to-speech-en-multi-0001-generation.xml
     size: 232908
-    sha384: 56eb0e3a7fd49e1defbcfdff565df95342a696abc591f3312f9af2303563fe3b938cf590215fe082c77a88e64b4c79cf
+    checksum: 56eb0e3a7fd49e1defbcfdff565df95342a696abc591f3312f9af2303563fe3b938cf590215fe082c77a88e64b4c79cf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/FP16/text-to-speech-en-multi-0001-generation.xml
   - name: FP16/text-to-speech-en-multi-0001-generation.bin
     size: 25541540
-    sha384: 0a36ab0702b9fc6cfc1a2023b9ef46f1aa0d01d01e87c0bc011fbdf4b3806ed9f57448976e6658835b7c8d6f9d49de9b
+    checksum: 0a36ab0702b9fc6cfc1a2023b9ef46f1aa0d01d01e87c0bc011fbdf4b3806ed9f57448976e6658835b7c8d6f9d49de9b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-generation/FP16/text-to-speech-en-multi-0001-generation.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/model.yml
+++ b/models/intel/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/model.yml
@@ -19,19 +19,19 @@ task_type: text_to_speech
 files:
   - name: FP32/text-to-speech-en-multi-0001-regression.xml
     size: 604296
-    sha384: 6920d3ace9a6280c310e489cfc173d3e11bfad69d54c1dcadd19344f9960b00819fb9c670a1fea6cf7105a687517f755
+    checksum: 6920d3ace9a6280c310e489cfc173d3e11bfad69d54c1dcadd19344f9960b00819fb9c670a1fea6cf7105a687517f755
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/FP32/text-to-speech-en-multi-0001-regression.xml
   - name: FP32/text-to-speech-en-multi-0001-regression.bin
     size: 20493524
-    sha384: 9a3af6ac6fecc2ae930633fdec371b4e3924fb97dc52fc1af8f927b5a123a88beaa84e412b2ead226e162410ec2b2ea4
+    checksum: 9a3af6ac6fecc2ae930633fdec371b4e3924fb97dc52fc1af8f927b5a123a88beaa84e412b2ead226e162410ec2b2ea4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/FP32/text-to-speech-en-multi-0001-regression.bin
   - name: FP16/text-to-speech-en-multi-0001-regression.xml
     size: 604045
-    sha384: 914ed67a0cb152d032e481f64e8dfbcb4b7253368e96bb49aff4140796df8d4d99fc49146a98b108e001ff5495972018
+    checksum: 914ed67a0cb152d032e481f64e8dfbcb4b7253368e96bb49aff4140796df8d4d99fc49146a98b108e001ff5495972018
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/FP16/text-to-speech-en-multi-0001-regression.xml
   - name: FP16/text-to-speech-en-multi-0001-regression.bin
     size: 10246838
-    sha384: f8193bf84b91e15e3d6de6af07d0a2d6be4eb8065ba2ad359839d03c258f894fbec70ed0933f59aaa7a0e0e0c19bb6d9
+    checksum: f8193bf84b91e15e3d6de6af07d0a2d6be4eb8065ba2ad359839d03c258f894fbec70ed0933f59aaa7a0e0e0c19bb6d9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/text-to-speech-en-multi-0001/text-to-speech-en-multi-0001-regression/FP16/text-to-speech-en-multi-0001-regression.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/time-series-forecasting-electricity-0001/model.yml
+++ b/models/intel/time-series-forecasting-electricity-0001/model.yml
@@ -19,19 +19,19 @@ task_type: time_series
 files:
   - name: FP32/time-series-forecasting-electricity-0001.xml
     size: 408392
-    sha384: 86d30b897c606aafabb18801b29930aec5cdf8a34d23e01d8ddad59fd0d6ac41f996026346d20f940dadbf82022c5832
+    checksum: 86d30b897c606aafabb18801b29930aec5cdf8a34d23e01d8ddad59fd0d6ac41f996026346d20f940dadbf82022c5832
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/time-series-forecasting-electricity-0001/FP32/time-series-forecasting-electricity-0001.xml
   - name: FP32/time-series-forecasting-electricity-0001.bin
     size: 10054892
-    sha384: 5a1128c2365fa81acca926e032fce199d33b9f3b9a982e3fe7985e6a9f6d289bbedbc12620a65667873b124ccb6a4eb1
+    checksum: 5a1128c2365fa81acca926e032fce199d33b9f3b9a982e3fe7985e6a9f6d289bbedbc12620a65667873b124ccb6a4eb1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/time-series-forecasting-electricity-0001/FP32/time-series-forecasting-electricity-0001.bin
   - name: FP16/time-series-forecasting-electricity-0001.xml
     size: 408243
-    sha384: 7c4e6da2e7534aac33d6dc8dfe6ed925e5234de1a32b1ca11e84eb7275296904be9f12002638147ee9d7f23fab90ff4f
+    checksum: 7c4e6da2e7534aac33d6dc8dfe6ed925e5234de1a32b1ca11e84eb7275296904be9f12002638147ee9d7f23fab90ff4f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/time-series-forecasting-electricity-0001/FP16/time-series-forecasting-electricity-0001.xml
   - name: FP16/time-series-forecasting-electricity-0001.bin
     size: 5046088
-    sha384: 1dfc3af25e4e38bf7863ef7156893378a5afc75cd1cc8cdbebbe3631e6d2e536609469974e4ff13bc85de483032a5e7c
+    checksum: 1dfc3af25e4e38bf7863ef7156893378a5afc75cd1cc8cdbebbe3631e6d2e536609469974e4ff13bc85de483032a5e7c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/time-series-forecasting-electricity-0001/FP16/time-series-forecasting-electricity-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/unet-camvid-onnx-0001/model.yml
+++ b/models/intel/unet-camvid-onnx-0001/model.yml
@@ -18,27 +18,27 @@ task_type: semantic_segmentation
 files:
   - name: FP32/unet-camvid-onnx-0001.xml
     size: 68693
-    sha384: 421ae16926146770eb17b8394c6a1a191c6b32035cbd532033d4cbaca9d1f3f63357d9021ecfe587d97d7248703414f9
+    checksum: 421ae16926146770eb17b8394c6a1a191c6b32035cbd532033d4cbaca9d1f3f63357d9021ecfe587d97d7248703414f9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.xml
   - name: FP32/unet-camvid-onnx-0001.bin
     size: 124129876
-    sha384: f6163e1f896b6745c2e47c75b288a57937978227c8639085666cf5fbbeca4a39f575f1192b47cdce4733fdd58130f88c
+    checksum: f6163e1f896b6745c2e47c75b288a57937978227c8639085666cf5fbbeca4a39f575f1192b47cdce4733fdd58130f88c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP32/unet-camvid-onnx-0001.bin
   - name: FP16/unet-camvid-onnx-0001.xml
     size: 68647
-    sha384: ef3109735adb5be3415bf69c30de77a4ddc960f438ba24c930ec6488908d04f8b10209003b0d7272b779710545c06b6d
+    checksum: ef3109735adb5be3415bf69c30de77a4ddc960f438ba24c930ec6488908d04f8b10209003b0d7272b779710545c06b6d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.xml
   - name: FP16/unet-camvid-onnx-0001.bin
     size: 62064942
-    sha384: 1f235fb2ee5720d07ed795a0ab15ac6929d219f2ca5876b690b5030d42b46d1f79b3a4220e0e2493667b8ef08f986cac
+    checksum: 1f235fb2ee5720d07ed795a0ab15ac6929d219f2ca5876b690b5030d42b46d1f79b3a4220e0e2493667b8ef08f986cac
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP16/unet-camvid-onnx-0001.bin
   - name: FP16-INT8/unet-camvid-onnx-0001.xml
     size: 146408
-    sha384: 7e0630b00fbffd25ff0305304b418d1700c1181355ee8a05ece11187d498b959b7aeb797c39209bdb50f1ce46e548553
+    checksum: 7e0630b00fbffd25ff0305304b418d1700c1181355ee8a05ece11187d498b959b7aeb797c39209bdb50f1ce46e548553
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.xml
   - name: FP16-INT8/unet-camvid-onnx-0001.bin
     size: 28699774
-    sha384: 59d79662ebbe0ded23086935087aa24665a38f8df40042ed62233f76d75232b6e92552198e9b7032dfa3c5f6d6dc6e15
+    checksum: 59d79662ebbe0ded23086935087aa24665a38f8df40042ed62233f76d75232b6e92552198e9b7032dfa3c5f6d6dc6e15
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/unet-camvid-onnx-0001/FP16-INT8/unet-camvid-onnx-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0039.xml
     size: 39740
-    sha384: fa1e30c9d9d351f80fd85585fbb1f81a34fd1935a884c149fcc0c305811bdacdcdab4f581b5531d7bacc57fec7cd367b
+    checksum: fa1e30c9d9d351f80fd85585fbb1f81a34fd1935a884c149fcc0c305811bdacdcdab4f581b5531d7bacc57fec7cd367b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0039.bin
     size: 2504028
-    sha384: ba8839771af476bb32aadcff6defb07169016f148e5c8b12dd3cd15a4d9b6c79ee26ef40b7c1c5f84b8fe8a169e53020
+    checksum: ba8839771af476bb32aadcff6defb07169016f148e5c8b12dd3cd15a4d9b6c79ee26ef40b7c1c5f84b8fe8a169e53020
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP32/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0039.xml
     size: 39727
-    sha384: 94183fc503a928a2d8b21799031405bf72c555378c4b27955dcb44f57a8077dee19c7370224e4ac00333a6004eb7f300
+    checksum: 94183fc503a928a2d8b21799031405bf72c555378c4b27955dcb44f57a8077dee19c7370224e4ac00333a6004eb7f300
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0039.bin
     size: 1252026
-    sha384: b706f6671c035f6529ba8a13fd8cec59779e80eef57accffbb29064281e19d97a04374de4ae660e7aff27245b276d223
+    checksum: b706f6671c035f6529ba8a13fd8cec59779e80eef57accffbb29064281e19d97a04374de4ae660e7aff27245b276d223
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16/vehicle-attributes-recognition-barrier-0039.bin
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0039.xml
     size: 100522
-    sha384: 1d8a1dd78b3181a6247d2c6d9106ffc025112d759680ef468eeb537a5db8af6e4728daf9be7da648d64f0779de46264f
+    checksum: 1d8a1dd78b3181a6247d2c6d9106ffc025112d759680ef468eeb537a5db8af6e4728daf9be7da648d64f0779de46264f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.xml
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0039.bin
     size: 631140
-    sha384: 77e7e693dd22961b63d4b6293e0ac03aa30a9f5e43492690319017ede1c1428074aa647dea958276299646cb94d6a872
+    checksum: 77e7e693dd22961b63d4b6293e0ac03aa30a9f5e43492690319017ede1c1428074aa647dea958276299646cb94d6a872
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0039/FP16-INT8/vehicle-attributes-recognition-barrier-0039.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-attributes-recognition-barrier-0042/model.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0042/model.yml
@@ -18,27 +18,27 @@ task_type: object_attributes
 files:
   - name: FP32/vehicle-attributes-recognition-barrier-0042.xml
     size: 71368
-    sha384: 611ea88b55868c85177fa7e29f4cf6b668b0244d52010ab924a2ed4b02a8bc1beb3b3065245e54cc57abe83119d3fdb6
+    checksum: 611ea88b55868c85177fa7e29f4cf6b668b0244d52010ab924a2ed4b02a8bc1beb3b3065245e54cc57abe83119d3fdb6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.xml
   - name: FP32/vehicle-attributes-recognition-barrier-0042.bin
     size: 44709500
-    sha384: ee20edb45203dd7e6543ee903d285875cef47ed71702d25af93f1634b43b65115964db5d89cfcd3838e2e8e35e810d83
+    checksum: ee20edb45203dd7e6543ee903d285875cef47ed71702d25af93f1634b43b65115964db5d89cfcd3838e2e8e35e810d83
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP32/vehicle-attributes-recognition-barrier-0042.bin
   - name: FP16/vehicle-attributes-recognition-barrier-0042.xml
     size: 71342
-    sha384: 9d0222795c1a66a4c0a4bf420c137f6069716543e8e5287cdbf98ede65b5e3d70d3a1b524688bbfb26d9c50d77d6b42b
+    checksum: 9d0222795c1a66a4c0a4bf420c137f6069716543e8e5287cdbf98ede65b5e3d70d3a1b524688bbfb26d9c50d77d6b42b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.xml
   - name: FP16/vehicle-attributes-recognition-barrier-0042.bin
     size: 22354778
-    sha384: 181fee3d2e46be561c75135de0c299419322ea374bdb778b962d9f19e7518fca5368521f3fa4313819f7ef2a89f7872e
+    checksum: 181fee3d2e46be561c75135de0c299419322ea374bdb778b962d9f19e7518fca5368521f3fa4313819f7ef2a89f7872e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16/vehicle-attributes-recognition-barrier-0042.bin
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0042.xml
     size: 174799
-    sha384: 60e9db666d37b2d55a0da5704247e4eb4632efaa061b79de0ef6a41898154dd9fee79c18fde3954c82cb3c1b705f2062
+    checksum: 60e9db666d37b2d55a0da5704247e4eb4632efaa061b79de0ef6a41898154dd9fee79c18fde3954c82cb3c1b705f2062
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16-INT8/vehicle-attributes-recognition-barrier-0042.xml
   - name: FP16-INT8/vehicle-attributes-recognition-barrier-0042.bin
     size: 11208728
-    sha384: df329c622a4e61b33c89a965a66409c363d03749577059bf1b307bc2371a7d43274ef85b9ef307a1e923167bf45f3e93
+    checksum: df329c622a4e61b33c89a965a66409c363d03749577059bf1b307bc2371a7d43274ef85b9ef307a1e923167bf45f3e93
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-attributes-recognition-barrier-0042/FP16-INT8/vehicle-attributes-recognition-barrier-0042.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-0200/model.yml
+++ b/models/intel/vehicle-detection-0200/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-detection-0200.xml
     size: 200422
-    sha384: 11f190a2676ef7e57166bd6dcc3767517db783289dfda9982aa89c6c13c595a393a8cce70d3b63b40471f762cc4fd425
+    checksum: 11f190a2676ef7e57166bd6dcc3767517db783289dfda9982aa89c6c13c595a393a8cce70d3b63b40471f762cc4fd425
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP32/vehicle-detection-0200.xml
   - name: FP32/vehicle-detection-0200.bin
     size: 7269168
-    sha384: 8a1ed6e7aa1860ae52ab11143b1f034a33d869bcfaf975312e07739c26571ab059324c8aafc7a56059cfbf88fb35172b
+    checksum: 8a1ed6e7aa1860ae52ab11143b1f034a33d869bcfaf975312e07739c26571ab059324c8aafc7a56059cfbf88fb35172b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP32/vehicle-detection-0200.bin
   - name: FP16/vehicle-detection-0200.xml
     size: 200359
-    sha384: 76dd41714e87ec0967d146bbb071e3a7ea858317d757ac2bd32f74b203f2087d1fa5ae19c7f3b24fb059e457065bb2e7
+    checksum: 76dd41714e87ec0967d146bbb071e3a7ea858317d757ac2bd32f74b203f2087d1fa5ae19c7f3b24fb059e457065bb2e7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP16/vehicle-detection-0200.xml
   - name: FP16/vehicle-detection-0200.bin
     size: 3634626
-    sha384: 8d1487683f9ca2a570f4b2ed4ac2c29ce8add11ccd6fc01180380adf4a997f42385b160d18e8e712a730586910519dbf
+    checksum: 8d1487683f9ca2a570f4b2ed4ac2c29ce8add11ccd6fc01180380adf4a997f42385b160d18e8e712a730586910519dbf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP16/vehicle-detection-0200.bin
   - name: FP16-INT8/vehicle-detection-0200.xml
     size: 482340
-    sha384: 4205b249e71e1ca586bdf97b59a862ab0d100fe78e71f4326e2d2d05091adbb46924b131feb691e41b6f02d36b7104bb
+    checksum: 4205b249e71e1ca586bdf97b59a862ab0d100fe78e71f4326e2d2d05091adbb46924b131feb691e41b6f02d36b7104bb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP16-INT8/vehicle-detection-0200.xml
   - name: FP16-INT8/vehicle-detection-0200.bin
     size: 1921618
-    sha384: 8d3227b5f9c4286ca13bde56bd4c8a65c2632320bebeed4460bb73e2b61c2730eb340c7ea91a91e961b513e0e6bc96b6
+    checksum: 8d3227b5f9c4286ca13bde56bd4c8a65c2632320bebeed4460bb73e2b61c2730eb340c7ea91a91e961b513e0e6bc96b6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0200/FP16-INT8/vehicle-detection-0200.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-0201/model.yml
+++ b/models/intel/vehicle-detection-0201/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-detection-0201.xml
     size: 200613
-    sha384: 16aaa4d1643977a783df4d100762865ae1570f361da50150174e4fc5ca93f5185b80ce6508e66f97ddd33b4aaad65d47
+    checksum: 16aaa4d1643977a783df4d100762865ae1570f361da50150174e4fc5ca93f5185b80ce6508e66f97ddd33b4aaad65d47
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP32/vehicle-detection-0201.xml
   - name: FP32/vehicle-detection-0201.bin
     size: 7269168
-    sha384: 32d4a9904743351b0e6509869c1138b30792cdd7d8352431c9abb37f2c61031786359ef90f796663305b05859ac12b55
+    checksum: 32d4a9904743351b0e6509869c1138b30792cdd7d8352431c9abb37f2c61031786359ef90f796663305b05859ac12b55
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP32/vehicle-detection-0201.bin
   - name: FP16/vehicle-detection-0201.xml
     size: 200550
-    sha384: 6f41497e388b16a47483d9a1b97ebff6614ab580df36b9bd2ae7f87d060e0139b201631522038da268627d86f536963a
+    checksum: 6f41497e388b16a47483d9a1b97ebff6614ab580df36b9bd2ae7f87d060e0139b201631522038da268627d86f536963a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP16/vehicle-detection-0201.xml
   - name: FP16/vehicle-detection-0201.bin
     size: 3634626
-    sha384: 380a4f18299e78a76733230d9598f2197c1c427ec23af6f9dceb58be8bc8a2eadab6950602b9b8f742f87c0fa8ee8a94
+    checksum: 380a4f18299e78a76733230d9598f2197c1c427ec23af6f9dceb58be8bc8a2eadab6950602b9b8f742f87c0fa8ee8a94
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP16/vehicle-detection-0201.bin
   - name: FP16-INT8/vehicle-detection-0201.xml
     size: 482561
-    sha384: 45a7fd48dc9b494b2194d9baff92e8b449318647536274403f9c2d08718d4dfc8477c033eaaab76cb6c2ece91b53d501
+    checksum: 45a7fd48dc9b494b2194d9baff92e8b449318647536274403f9c2d08718d4dfc8477c033eaaab76cb6c2ece91b53d501
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP16-INT8/vehicle-detection-0201.xml
   - name: FP16-INT8/vehicle-detection-0201.bin
     size: 1921618
-    sha384: 138e630fb89370810d876ea59bcf6513624e1697314d0d6aa734694344d2624d9afa53f13ed7565564e95b2544e585c5
+    checksum: 138e630fb89370810d876ea59bcf6513624e1697314d0d6aa734694344d2624d9afa53f13ed7565564e95b2544e585c5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0201/FP16-INT8/vehicle-detection-0201.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-0202/model.yml
+++ b/models/intel/vehicle-detection-0202/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-detection-0202.xml
     size: 200694
-    sha384: 7ec74bd0d96e71ac51f13f9efaed35fe3b0f4f088a0f4cb4350d120c58c98f0999fb48ec52e74a1545085e04d1ca0e4d
+    checksum: 7ec74bd0d96e71ac51f13f9efaed35fe3b0f4f088a0f4cb4350d120c58c98f0999fb48ec52e74a1545085e04d1ca0e4d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP32/vehicle-detection-0202.xml
   - name: FP32/vehicle-detection-0202.bin
     size: 7269168
-    sha384: b14356dcfefb87d913bb85d35e697a118cc3d0837944d672a6dbea36ed02cc116d32f636a08c36a7d62eb8f41c0103fe
+    checksum: b14356dcfefb87d913bb85d35e697a118cc3d0837944d672a6dbea36ed02cc116d32f636a08c36a7d62eb8f41c0103fe
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP32/vehicle-detection-0202.bin
   - name: FP16/vehicle-detection-0202.xml
     size: 200631
-    sha384: 13219e91027dd83bea5f9eaba5e963d05214dfd672246ec579871b6c588ea32b8408af3650f4b9be2e31c0887a9cf0a0
+    checksum: 13219e91027dd83bea5f9eaba5e963d05214dfd672246ec579871b6c588ea32b8408af3650f4b9be2e31c0887a9cf0a0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP16/vehicle-detection-0202.xml
   - name: FP16/vehicle-detection-0202.bin
     size: 3634626
-    sha384: add1d413846fdaa02eb0e8aea96d3bb0c25d4d75cbc11986ade7911aa19bad7d03fdae7afc83f52322681308dedf0b5e
+    checksum: add1d413846fdaa02eb0e8aea96d3bb0c25d4d75cbc11986ade7911aa19bad7d03fdae7afc83f52322681308dedf0b5e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP16/vehicle-detection-0202.bin
   - name: FP16-INT8/vehicle-detection-0202.xml
     size: 482673
-    sha384: f6682cc137cd795c52b42577b66c73745567a214c4850b7a33b17b8e4ae8271726d76c848391b0da8750d6fbd278ce1b
+    checksum: f6682cc137cd795c52b42577b66c73745567a214c4850b7a33b17b8e4ae8271726d76c848391b0da8750d6fbd278ce1b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP16-INT8/vehicle-detection-0202.xml
   - name: FP16-INT8/vehicle-detection-0202.bin
     size: 1921616
-    sha384: 4c47ab4ebc0c896b41e2f2d75061421fca539b8dd9a9f68908d22c7a43f1fb1cd12d21e65e72c8d9a280ad4259d9c252
+    checksum: 4c47ab4ebc0c896b41e2f2d75061421fca539b8dd9a9f68908d22c7a43f1fb1cd12d21e65e72c8d9a280ad4259d9c252
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-0202/FP16-INT8/vehicle-detection-0202.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-detection-adas-0002/model.yml
+++ b/models/intel/vehicle-detection-adas-0002/model.yml
@@ -19,27 +19,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-detection-adas-0002.xml
     size: 217197
-    sha384: a6366d033c85aa559cd6c3167cc818cdfe0e61a1b5db3a4f7714d87d87d6db9f463370f61c12063000aaa75ca85daa6b
+    checksum: a6366d033c85aa559cd6c3167cc818cdfe0e61a1b5db3a4f7714d87d87d6db9f463370f61c12063000aaa75ca85daa6b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.xml
   - name: FP32/vehicle-detection-adas-0002.bin
     size: 4314552
-    sha384: 369480a4c62856db8d10585f556c03df2fc75dd58077ef5e0e74f188d52fff91aec4792d2c94c7ca036803a527fbe676
+    checksum: 369480a4c62856db8d10585f556c03df2fc75dd58077ef5e0e74f188d52fff91aec4792d2c94c7ca036803a527fbe676
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP32/vehicle-detection-adas-0002.bin
   - name: FP16/vehicle-detection-adas-0002.xml
     size: 217151
-    sha384: 9ed86f48be6f5918c25f856fb02931a2801a18ee622151a0b6fd7ab93cc09d7ff0227412bf85d0f5edab8efec82323ed
+    checksum: 9ed86f48be6f5918c25f856fb02931a2801a18ee622151a0b6fd7ab93cc09d7ff0227412bf85d0f5edab8efec82323ed
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.xml
   - name: FP16/vehicle-detection-adas-0002.bin
     size: 2157328
-    sha384: 85053fee25588f780040ad6897804632e53b28dfec643dc8ff49e99c5f4722e70fbcacb4240159a69aaa6003e913e8e6
+    checksum: 85053fee25588f780040ad6897804632e53b28dfec643dc8ff49e99c5f4722e70fbcacb4240159a69aaa6003e913e8e6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP16/vehicle-detection-adas-0002.bin
   - name: FP16-INT8/vehicle-detection-adas-0002.xml
     size: 440420
-    sha384: a926b2d083558d9810a4dc3d08167a896dc466d276cae0111b189fe04ca6f25897273d6efb0d0c426942de9ec9c57b84
+    checksum: a926b2d083558d9810a4dc3d08167a896dc466d276cae0111b189fe04ca6f25897273d6efb0d0c426942de9ec9c57b84
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.xml
   - name: FP16-INT8/vehicle-detection-adas-0002.bin
     size: 1123348
-    sha384: 58a9b1f0435321d79eb9e95744fdac21f512fe8d901cad7d23b43a434eae4696ae4d4ceaa9fdefbcf037b4a58f83c012
+    checksum: 58a9b1f0435321d79eb9e95744fdac21f512fe8d901cad7d23b43a434eae4696ae4d4ceaa9fdefbcf037b4a58f83c012
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-detection-adas-0002/FP16-INT8/vehicle-detection-adas-0002.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/vehicle-license-plate-detection-barrier-0106.xml
     size: 242320
-    sha384: 29d5d667e0b21e67d6da7632c0b624f744752cd862f5c4045697700fc25e59831bbf1062cfb7b9a6d3767ce6d955aab0
+    checksum: 29d5d667e0b21e67d6da7632c0b624f744752cd862f5c4045697700fc25e59831bbf1062cfb7b9a6d3767ce6d955aab0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP32/vehicle-license-plate-detection-barrier-0106.bin
     size: 2573373
-    sha384: 3a22679505ee688ce30e91e3649268130606e972b18b5fe19be7be575c13ca19907bd81d77e12222c3d83e57ee474a4b
+    checksum: 3a22679505ee688ce30e91e3649268130606e972b18b5fe19be7be575c13ca19907bd81d77e12222c3d83e57ee474a4b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP32/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP16/vehicle-license-plate-detection-barrier-0106.xml
     size: 242253
-    sha384: 5e5130e891bfcbc84d7324821ea24a305174376ffc0d8f9cb664078e0a56d1b34e75ef51d176daceacf1ca4a179dad46
+    checksum: 5e5130e891bfcbc84d7324821ea24a305174376ffc0d8f9cb664078e0a56d1b34e75ef51d176daceacf1ca4a179dad46
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP16/vehicle-license-plate-detection-barrier-0106.bin
     size: 1286755
-    sha384: f5182f5b913dbe1bc1f2ecf11633c94c779a3548d7d71580e7ff4f78101f1ad51eb276c0cc654e471de8b57c2ce85c72
+    checksum: f5182f5b913dbe1bc1f2ecf11633c94c779a3548d7d71580e7ff4f78101f1ad51eb276c0cc654e471de8b57c2ce85c72
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16/vehicle-license-plate-detection-barrier-0106.bin
   - name: FP16-INT8/vehicle-license-plate-detection-barrier-0106.xml
     size: 565981
-    sha384: f4dfd8206e67f93312a55d74a836cf0e2384550698f747f97ccdc8917e77381615e124c6b1cbc45765830d7a9c14fa2c
+    checksum: f4dfd8206e67f93312a55d74a836cf0e2384550698f747f97ccdc8917e77381615e124c6b1cbc45765830d7a9c14fa2c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16-INT8/vehicle-license-plate-detection-barrier-0106.xml
   - name: FP16-INT8/vehicle-license-plate-detection-barrier-0106.bin
     size: 693931
-    sha384: 6385cb3ed52f001c12eb06d57ad925f26510ecb9663d17f707b782efd7b42434c7b3e8bc5ebcc09218181aea2ed45f4d
+    checksum: 6385cb3ed52f001c12eb06d57ad925f26510ecb9663d17f707b782efd7b42434c7b3e8bc5ebcc09218181aea2ed45f4d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/vehicle-license-plate-detection-barrier-0106/FP16-INT8/vehicle-license-plate-detection-barrier-0106.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/weld-porosity-detection-0001/model.yml
+++ b/models/intel/weld-porosity-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: action_recognition
 files:
   - name: FP32/weld-porosity-detection-0001.xml
     size: 63294
-    sha384: 714957312fd633b31c437c05300577c0f5a4a975484769c407faf258c6609f5f2d3d2dce8e0edc42a20e74c2846d0cf4
+    checksum: 714957312fd633b31c437c05300577c0f5a4a975484769c407faf258c6609f5f2d3d2dce8e0edc42a20e74c2846d0cf4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.xml
   - name: FP32/weld-porosity-detection-0001.bin
     size: 44693044
-    sha384: 34b2decb3f381810b706083da42fad6462c96d98a1447df4e332fd2dc3f7208991bb16dd4167cee965fee7845e097035
+    checksum: 34b2decb3f381810b706083da42fad6462c96d98a1447df4e332fd2dc3f7208991bb16dd4167cee965fee7845e097035
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP32/weld-porosity-detection-0001.bin
   - name: FP16/weld-porosity-detection-0001.xml
     size: 63269
-    sha384: 5fbab58adb5b24453c2c7636ed2ee1d2a359f9ff9b51b48a2b26c318cbbe5d79d7b28cb428599b8ad2d149d8485ef456
+    checksum: 5fbab58adb5b24453c2c7636ed2ee1d2a359f9ff9b51b48a2b26c318cbbe5d79d7b28cb428599b8ad2d149d8485ef456
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.xml
   - name: FP16/weld-porosity-detection-0001.bin
     size: 22346530
-    sha384: e7aa38cf7377e709280f353a2949029c220edfa9a0141e13ec0466669d73de00174d59820b4de107af0a0358f0bcf48d
+    checksum: e7aa38cf7377e709280f353a2949029c220edfa9a0141e13ec0466669d73de00174d59820b4de107af0a0358f0bcf48d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP16/weld-porosity-detection-0001.bin
   - name: FP16-INT8/weld-porosity-detection-0001.xml
     size: 162672
-    sha384: edb0137a41e63c40fce55e83dbf110716a999dcba79df97b0174b6483e3d44c1de3098708d600231ec211df5f87360b1
+    checksum: edb0137a41e63c40fce55e83dbf110716a999dcba79df97b0174b6483e3d44c1de3098708d600231ec211df5f87360b1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP16-INT8/weld-porosity-detection-0001.xml
   - name: FP16-INT8/weld-porosity-detection-0001.bin
     size: 11197380
-    sha384: 7b879ca13c8bb8e913400b645ef476652d4ada31bcac512b05c6b7b4969aacdde616be3dd4f4a5f5e3f08e635cc253af
+    checksum: 7b879ca13c8bb8e913400b645ef476652d4ada31bcac512b05c6b7b4969aacdde616be3dd4f4a5f5e3f08e635cc253af
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/weld-porosity-detection-0001/FP16-INT8/weld-porosity-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-0001/model.yml
+++ b/models/intel/yolo-v2-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-0001.xml
     size: 84732
-    sha384: 94fa2b370a9367d9e1f609b775f2bd6a901a81e7d8e8484bde35bb130700194c0f80f44a4853268c29788f67ec4a366a
+    checksum: 94fa2b370a9367d9e1f609b775f2bd6a901a81e7d8e8484bde35bb130700194c0f80f44a4853268c29788f67ec4a366a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.xml
   - name: FP32/yolo-v2-ava-0001.bin
     size: 202580240
-    sha384: 4d25c6def4815cfc68261ea8b646b3995db8d374f8e11760f21eeb026addab87c2ab0e751458f2a5dbd9ccee9d05a5dc
+    checksum: 4d25c6def4815cfc68261ea8b646b3995db8d374f8e11760f21eeb026addab87c2ab0e751458f2a5dbd9ccee9d05a5dc
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP32/yolo-v2-ava-0001.bin
   - name: FP16/yolo-v2-ava-0001.xml
     size: 84703
-    sha384: b3fa31cb8dbbea60cb465ddf3de2db07feb76350b2625823be23ece9db05ea676fd450fb76bc083d47eab5ed39104a35
+    checksum: b3fa31cb8dbbea60cb465ddf3de2db07feb76350b2625823be23ece9db05ea676fd450fb76bc083d47eab5ed39104a35
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.xml
   - name: FP16/yolo-v2-ava-0001.bin
     size: 101290122
-    sha384: a687bb2b57479b05595bef2c0d2515766128271535f3c078178e533bfb08fd6982362121bb2ee44f3d68af67bfcce103
+    checksum: a687bb2b57479b05595bef2c0d2515766128271535f3c078178e533bfb08fd6982362121bb2ee44f3d68af67bfcce103
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP16/yolo-v2-ava-0001.bin
   - name: FP16-INT8/yolo-v2-ava-0001.xml
     size: 182973
-    sha384: cba03125b8a09e4cc14bfc23f2a417514bc3aa75c1658ae00155d71431a47d425c000f2fadf6f2d807ed0a1caa4bde84
+    checksum: cba03125b8a09e4cc14bfc23f2a417514bc3aa75c1658ae00155d71431a47d425c000f2fadf6f2d807ed0a1caa4bde84
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.xml
   - name: FP16-INT8/yolo-v2-ava-0001.bin
     size: 50697466
-    sha384: 1e799cff915cc09cd01026ee322ad70f10551e12c00f3fd3699cd8711a604214588743e78690b60392fafc31f6b5c790
+    checksum: 1e799cff915cc09cd01026ee322ad70f10551e12c00f3fd3699cd8711a604214588743e78690b60392fafc31f6b5c790
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-0001/FP16-INT8/yolo-v2-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-sparse-35-0001/model.yml
+++ b/models/intel/yolo-v2-ava-sparse-35-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-sparse-35-0001.xml
     size: 84752
-    sha384: cc76a7d7da8bd188cca4ac6fdce586d6779cb9eea9446aee5ed7a93e35c9ba909b98aedf23deaf17b4940d4ad1c5a50d
+    checksum: cc76a7d7da8bd188cca4ac6fdce586d6779cb9eea9446aee5ed7a93e35c9ba909b98aedf23deaf17b4940d4ad1c5a50d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.xml
   - name: FP32/yolo-v2-ava-sparse-35-0001.bin
     size: 202580240
-    sha384: d887541ef0f13745d3e6052ef8b553b0e9ccfa716890c761ead59a614075751f14c2312fb2a2f90ffdec29c58d0d7da7
+    checksum: d887541ef0f13745d3e6052ef8b553b0e9ccfa716890c761ead59a614075751f14c2312fb2a2f90ffdec29c58d0d7da7
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP32/yolo-v2-ava-sparse-35-0001.bin
   - name: FP16/yolo-v2-ava-sparse-35-0001.xml
     size: 84723
-    sha384: 9789afffec6bd72644773d97f62f1b9f9a80411f80c50f1ce0876680ec0929b7b09850304b28445ef212a6f51d74a873
+    checksum: 9789afffec6bd72644773d97f62f1b9f9a80411f80c50f1ce0876680ec0929b7b09850304b28445ef212a6f51d74a873
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.xml
   - name: FP16/yolo-v2-ava-sparse-35-0001.bin
     size: 101290122
-    sha384: 44c744390d7179672f71bac0ef36f9ef4ed9091b907cdc0dc5585e5834995868c00f49a8e5a0a6bd90676a3d023d219b
+    checksum: 44c744390d7179672f71bac0ef36f9ef4ed9091b907cdc0dc5585e5834995868c00f49a8e5a0a6bd90676a3d023d219b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16/yolo-v2-ava-sparse-35-0001.bin
   - name: FP16-INT8/yolo-v2-ava-sparse-35-0001.xml
     size: 183003
-    sha384: 36cb9f586d6b548714caf8016439fc642874cb967b8a511162bbc122460417586f77c1da8cc522a8d8392165df2c27b2
+    checksum: 36cb9f586d6b548714caf8016439fc642874cb967b8a511162bbc122460417586f77c1da8cc522a8d8392165df2c27b2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.xml
   - name: FP16-INT8/yolo-v2-ava-sparse-35-0001.bin
     size: 50697466
-    sha384: 764f84bb97efc85f2be904126eb7affef17edfd45c2ae1a2bf2628e1280895019d122c1a98b03aa5ad2427580525df6e
+    checksum: 764f84bb97efc85f2be904126eb7affef17edfd45c2ae1a2bf2628e1280895019d122c1a98b03aa5ad2427580525df6e
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-35-0001/FP16-INT8/yolo-v2-ava-sparse-35-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-ava-sparse-70-0001/model.yml
+++ b/models/intel/yolo-v2-ava-sparse-70-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-ava-sparse-70-0001.xml
     size: 84752
-    sha384: 78ff7a5c752cd03f36c3b0e01cd2b80dc0e9454312ff615ec90b6992514d247922c665aa707647beb22bb6ddc2e4af5f
+    checksum: 78ff7a5c752cd03f36c3b0e01cd2b80dc0e9454312ff615ec90b6992514d247922c665aa707647beb22bb6ddc2e4af5f
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.xml
   - name: FP32/yolo-v2-ava-sparse-70-0001.bin
     size: 202580240
-    sha384: 1af872f5720415517836565506c6ca1fe5de3625e03ba7bded0ce9703801f40e1e5a98d66c9ae3f2c13632f8cf984dad
+    checksum: 1af872f5720415517836565506c6ca1fe5de3625e03ba7bded0ce9703801f40e1e5a98d66c9ae3f2c13632f8cf984dad
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP32/yolo-v2-ava-sparse-70-0001.bin
   - name: FP16/yolo-v2-ava-sparse-70-0001.xml
     size: 84723
-    sha384: 5ffe79d15a41c9ff5b5b93bffd96a34fd8c6b704f2e79ab7885178266f03f7d5db6e068a88dc3137b3710ea92b863456
+    checksum: 5ffe79d15a41c9ff5b5b93bffd96a34fd8c6b704f2e79ab7885178266f03f7d5db6e068a88dc3137b3710ea92b863456
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.xml
   - name: FP16/yolo-v2-ava-sparse-70-0001.bin
     size: 101290122
-    sha384: 18c05dae73e8b21e1f4dbdd0b5727ff45bf90950b4270fbda98db2a44fb93ffb937389b9ac01b3ae339441be22a41688
+    checksum: 18c05dae73e8b21e1f4dbdd0b5727ff45bf90950b4270fbda98db2a44fb93ffb937389b9ac01b3ae339441be22a41688
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16/yolo-v2-ava-sparse-70-0001.bin
   - name: FP16-INT8/yolo-v2-ava-sparse-70-0001.xml
     size: 183003
-    sha384: 0ba687281bac1d4405f36e369c6de3e7c0abaf7b0c7a016cee305df94da1672b7fd1a970fa76f708b801f2164900da46
+    checksum: 0ba687281bac1d4405f36e369c6de3e7c0abaf7b0c7a016cee305df94da1672b7fd1a970fa76f708b801f2164900da46
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.xml
   - name: FP16-INT8/yolo-v2-ava-sparse-70-0001.bin
     size: 50697466
-    sha384: 789c868b3d616016ab5af2d57f2c180dbab7fb7622a83a46c5da69e01046ede5d6717dc508fad626f2e819e34bd1e7a4
+    checksum: 789c868b3d616016ab5af2d57f2c180dbab7fb7622a83a46c5da69e01046ede5d6717dc508fad626f2e819e34bd1e7a4
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-ava-sparse-70-0001/FP16-INT8/yolo-v2-ava-sparse-70-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-0001.xml
     size: 37012
-    sha384: 56b7f9c4d5f062b431fe81449b86057f4dfff728cd1d2488b7aeacf42b308eb6e5bc281f1defce2b50a3bbb68edbe408
+    checksum: 56b7f9c4d5f062b431fe81449b86057f4dfff728cd1d2488b7aeacf42b308eb6e5bc281f1defce2b50a3bbb68edbe408
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.xml
   - name: FP32/yolo-v2-tiny-ava-0001.bin
     size: 63434896
-    sha384: fb44b2ca04828542ea80c0f31f9c5f6e86627d448296f34435bc485c1a0210542f64a8d40acd4309b05d83da31894c78
+    checksum: fb44b2ca04828542ea80c0f31f9c5f6e86627d448296f34435bc485c1a0210542f64a8d40acd4309b05d83da31894c78
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP32/yolo-v2-tiny-ava-0001.bin
   - name: FP16/yolo-v2-tiny-ava-0001.xml
     size: 36991
-    sha384: 2a404227ff6c1a4087c0d3e1113f84eb955e8f76cdba120cdae05e5aa7257e639aef0afb9f452392a391841b4c4314c1
+    checksum: 2a404227ff6c1a4087c0d3e1113f84eb955e8f76cdba120cdae05e5aa7257e639aef0afb9f452392a391841b4c4314c1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.xml
   - name: FP16/yolo-v2-tiny-ava-0001.bin
     size: 31717450
-    sha384: 0b40d67bf5c5b8bbfd8d821eadd07a51c652bbeb28003f1fbdc833dda35c172e055c0bec9d832a1369fb820d084de151
+    checksum: 0b40d67bf5c5b8bbfd8d821eadd07a51c652bbeb28003f1fbdc833dda35c172e055c0bec9d832a1369fb820d084de151
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP16/yolo-v2-tiny-ava-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-0001.xml
     size: 76415
-    sha384: 1d995298cf8db513a4196be5b02f13fec5905fefe9056c7f38fbe6c14f6f1ebe0464a3b6b98832221392616e2ac34a92
+    checksum: 1d995298cf8db513a4196be5b02f13fec5905fefe9056c7f38fbe6c14f6f1ebe0464a3b6b98832221392616e2ac34a92
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-0001.bin
     size: 15874674
-    sha384: 88919d7d8d1ef93b8cc68e163a42bca1b021a72cd3247f73af60fa3f489f0e3d7bb6de5d8a4b0f4ae0ad718c625fb30a
+    checksum: 88919d7d8d1ef93b8cc68e163a42bca1b021a72cd3247f73af60fa3f489f0e3d7bb6de5d8a4b0f4ae0ad718c625fb30a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-0001/FP16-INT8/yolo-v2-tiny-ava-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-sparse-30-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-30-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 37032
-    sha384: ec9f653e58f9c2be0fd43f3da8267c82f6397f8620003211101b17b2703d83caddcb566de14013b7a5843d271f056fbb
+    checksum: ec9f653e58f9c2be0fd43f3da8267c82f6397f8620003211101b17b2703d83caddcb566de14013b7a5843d271f056fbb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP32/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 63434896
-    sha384: ae614e7ce18287f93b9c27deb0920cc8b815faaab6a37ffd4e3fb993d4c30374af8f837a875194622576057d17ab2b2a
+    checksum: ae614e7ce18287f93b9c27deb0920cc8b815faaab6a37ffd4e3fb993d4c30374af8f837a875194622576057d17ab2b2a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP32/yolo-v2-tiny-ava-sparse-30-0001.bin
   - name: FP16/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 37011
-    sha384: db2a0dea5a858eb1d245ef56741668c830b96a56042d776cb55cdb690b4b57399757702e803190ac8f3672d1517859ab
+    checksum: db2a0dea5a858eb1d245ef56741668c830b96a56042d776cb55cdb690b4b57399757702e803190ac8f3672d1517859ab
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP16/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 31717450
-    sha384: 7646bf6fe56fb975aa0210db9457cd30edc427561dee28563c930ecb082600018a5fcdb314ec480053dafca5d60da1e5
+    checksum: 7646bf6fe56fb975aa0210db9457cd30edc427561dee28563c930ecb082600018a5fcdb314ec480053dafca5d60da1e5
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16/yolo-v2-tiny-ava-sparse-30-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.xml
     size: 76445
-    sha384: 3d11074660107c4eae6b7bb0c28ad3eb58dc211bff85a3925c0619c44c53d2740d5264365360e75ef59ba4c5d889f83b
+    checksum: 3d11074660107c4eae6b7bb0c28ad3eb58dc211bff85a3925c0619c44c53d2740d5264365360e75ef59ba4c5d889f83b
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.bin
     size: 15874674
-    sha384: 5b9ec78732eeae55b5fd949a4cc1e63b2d3554ed1d3c7bb21d6d1960d4ac47342b50dc5d916eef47a4ad066165fb46e8
+    checksum: 5b9ec78732eeae55b5fd949a4cc1e63b2d3554ed1d3c7bb21d6d1960d4ac47342b50dc5d916eef47a4ad066165fb46e8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-30-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-30-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-ava-sparse-60-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-60-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 37080
-    sha384: d0316986a52946358b2473c9c1efa4ef6d456591fb8592571e9675ff2f8b17044e90a79b990004acd091d5576b1a540a
+    checksum: d0316986a52946358b2473c9c1efa4ef6d456591fb8592571e9675ff2f8b17044e90a79b990004acd091d5576b1a540a
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP32/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 63434896
-    sha384: 0c7d167da77164fd6cf35cd10d5e8b356188c0fc5d7d03d4b7f2ce408dd894aff3b9a1f957122311b258dcb2c74ad1b6
+    checksum: 0c7d167da77164fd6cf35cd10d5e8b356188c0fc5d7d03d4b7f2ce408dd894aff3b9a1f957122311b258dcb2c74ad1b6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP32/yolo-v2-tiny-ava-sparse-60-0001.bin
   - name: FP16/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 37059
-    sha384: a6eb2657893eb1b0b1db74cf9c5bda60ee4a0b88a99923610b21df4ea059959ed2ade512097f14d7ab872bb3f766c8a2
+    checksum: a6eb2657893eb1b0b1db74cf9c5bda60ee4a0b88a99923610b21df4ea059959ed2ade512097f14d7ab872bb3f766c8a2
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP16/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 31717450
-    sha384: 6050cfe35a1d2b857e48651fbc3692080cba3b14e16c879d1fdeb33b016721ac3d35796166a79ccb38fb6a4f77b569c9
+    checksum: 6050cfe35a1d2b857e48651fbc3692080cba3b14e16c879d1fdeb33b016721ac3d35796166a79ccb38fb6a4f77b569c9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16/yolo-v2-tiny-ava-sparse-60-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.xml
     size: 76509
-    sha384: 8d72483a8cd1dbfdbc6cec6bb5a713bc6e2b06b2e09dbe7b7986716e2c9dfdb026da1ebf6ab8a44f6ba8cea67aa06213
+    checksum: 8d72483a8cd1dbfdbc6cec6bb5a713bc6e2b06b2e09dbe7b7986716e2c9dfdb026da1ebf6ab8a44f6ba8cea67aa06213
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.bin
     size: 15874674
-    sha384: d90339e40377336df1b50a818bca85925d12dd96db239cdd96f16c7dd5933e7cb67b79349992fc460a6dc9ad5cf059f1
+    checksum: d90339e40377336df1b50a818bca85925d12dd96db239cdd96f16c7dd5933e7cb67b79349992fc460a6dc9ad5cf059f1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-ava-sparse-60-0001/FP16-INT8/yolo-v2-tiny-ava-sparse-60-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/intel/yolo-v2-tiny-vehicle-detection-0001/model.yml
+++ b/models/intel/yolo-v2-tiny-vehicle-detection-0001/model.yml
@@ -18,27 +18,27 @@ task_type: detection
 files:
   - name: FP32/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 33885
-    sha384: e761b69a6bb2319f600e238d5fa020ce270de6c35e149f4c95daa3cf2bdef550fe3d19187c6309951543074a3f77f5e9
+    checksum: e761b69a6bb2319f600e238d5fa020ce270de6c35e149f4c95daa3cf2bdef550fe3d19187c6309951543074a3f77f5e9
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP32/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 44918056
-    sha384: 89248f734724ec0653b50b688b661f9036949045a2cc977e06436800609b0d87df861c94b5c349b04bf3d0a837ac5cf8
+    checksum: 89248f734724ec0653b50b688b661f9036949045a2cc977e06436800609b0d87df861c94b5c349b04bf3d0a837ac5cf8
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP32/yolo-v2-tiny-vehicle-detection-0001.bin
   - name: FP16/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 33865
-    sha384: 1d73ecdbcd4a1f7d75e2bbe642bf1f78cf29da981a4f1473745ba7e2f4e0bb2a809d7503e5356923e26863da8a32e456
+    checksum: 1d73ecdbcd4a1f7d75e2bbe642bf1f78cf29da981a4f1473745ba7e2f4e0bb2a809d7503e5356923e26863da8a32e456
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP16/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 22459030
-    sha384: f37ede7420c148684f95daae1fc2dce4dac74f05dbf3f551670051098690759bf0dce1d141e462ce78c7f1d3986899ac
+    checksum: f37ede7420c148684f95daae1fc2dce4dac74f05dbf3f551670051098690759bf0dce1d141e462ce78c7f1d3986899ac
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16/yolo-v2-tiny-vehicle-detection-0001.bin
   - name: FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.xml
     size: 72378
-    sha384: 5a2550af977c2705dd028a7fb5cd3fb8a02937bd3c273c590ec3fb6bbbf0451aca459c677a055ae0ec167813422fc060
+    checksum: 5a2550af977c2705dd028a7fb5cd3fb8a02937bd3c273c590ec3fb6bbbf0451aca459c677a055ae0ec167813422fc060
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.xml
   - name: FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.bin
     size: 11244398
-    sha384: 6e0157516c54008bd28bc91c5aede1fa0cec7b5f168666611aaee2862efd66c72baecced96fe42dc52c3990c4f12e987
+    checksum: 6e0157516c54008bd28bc91c5aede1fa0cec7b5f168666611aaee2862efd66c72baecced96fe42dc52c3990c4f12e987
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2021.4/models_bin/3/yolo-v2-tiny-vehicle-detection-0001/FP16-INT8/yolo-v2-tiny-vehicle-detection-0001.bin
 framework: dldt
 license: https://raw.githubusercontent.com/openvinotoolkit/open_model_zoo/master/LICENSE

--- a/models/public/Sphereface/model.yml
+++ b/models/public/Sphereface/model.yml
@@ -18,11 +18,11 @@ task_type: face_recognition
 files:
   - name: Sphereface.prototxt
     size: 11090
-    sha384: 93065b7dd5a6683a96a9d9906ab2add3e7548b9d5043986476d8e1b8a45df021495c2a564d006fb8598f7995f332aaff
+    checksum: 93065b7dd5a6683a96a9d9906ab2add3e7548b9d5043986476d8e1b8a45df021495c2a564d006fb8598f7995f332aaff
     source: https://raw.githubusercontent.com/wy1iu/sphereface/7f9acb157c78a99dbefd041fce9f188400bbb4e5/train/code/sphereface_deploy.prototxt
   - name: Sphereface.caffemodel
     size: 90688218
-    sha384: 52c285241df28b9b2da263ff272d4b97d3a47d3e0c82881a0693097f286e9e53342650b0b8fc6cfef8202ab399b4bfdd
+    checksum: 52c285241df28b9b2da263ff272d4b97d3a47d3e0c82881a0693097f286e9e53342650b0b8fc6cfef8202ab399b4bfdd
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/Sphereface/sphereface_model.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,112,96]

--- a/models/public/aclnet-int8/model.yml
+++ b/models/public/aclnet-int8/model.yml
@@ -28,7 +28,7 @@ task_type: sound_classification
 files:
   - name: aclnet_des_53_int8.onnx
     size: 10988855
-    sha384: 5ea7239032a690b408c0d4e730beae2d6cd49afa918c5e7e374f3fc4c8c34ab0091725fd3de281e83c0560c717e51443
+    checksum: 5ea7239032a690b408c0d4e730beae2d6cd49afa918c5e7e374f3fc4c8c34ab0091725fd3de281e83c0560c717e51443
     source: https://storage.openvinotoolkit.org/models_contrib/sound_classification/aclnet/2021-02-04/aclnet_des_53_int8.onnx
 model_optimizer_args:
   - --input_shape=[1,1,1,16000]

--- a/models/public/aclnet/model.yml
+++ b/models/public/aclnet/model.yml
@@ -26,7 +26,7 @@ task_type: sound_classification
 files:
   - name: aclnet_des_53.onnx
     size: 10966521
-    sha384: 966d8b3e0eb46d7946b7b52baae2e38795a8b892bc9eb8ec6511c28c32caf6f230f0d32a1d4f3a5db97eac31475e990c
+    checksum: 966d8b3e0eb46d7946b7b52baae2e38795a8b892bc9eb8ec6511c28c32caf6f230f0d32a1d4f3a5db97eac31475e990c
     source: https://storage.openvinotoolkit.org/models_contrib/sound_classification/aclnet/2021-02-04/aclnet_des_53_fp32.onnx
 model_optimizer_args:
   - --input_shape=[1,1,1,16000]

--- a/models/public/alexnet/model.yml
+++ b/models/public/alexnet/model.yml
@@ -27,11 +27,11 @@ task_type: classification
 files:
   - name: alexnet.prototxt
     size: 3629
-    sha384: 6d620598b210369b6d33c0575b5ec2bd2dc7bce522591d80631b75f854a0324b8f30c4bb7f53dd3346aaf229510e9f2e
+    checksum: 6d620598b210369b6d33c0575b5ec2bd2dc7bce522591d80631b75f854a0324b8f30c4bb7f53dd3346aaf229510e9f2e
     source: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_alexnet/deploy.prototxt
   - name: alexnet.caffemodel
     size: 243862414
-    sha384: f102235bc9d8f422a04d5254a21fd1862986eae91c7337714fd5d78dcf37f835d05ed7943e80056ae19ca9e9c054c181
+    checksum: f102235bc9d8f422a04d5254a21fd1862986eae91c7337714fd5d78dcf37f835d05ed7943e80056ae19ca9e9c054c181
     source: http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/anti-spoof-mn3/model.yml
+++ b/models/public/anti-spoof-mn3/model.yml
@@ -22,7 +22,7 @@ task_type: classification
 files:
   - name: anti-spoof-mn3.onnx
     size: 12270179
-    sha384: 6de4534964b723397b3e8c995cadcf43bc007cc2f9930b95ae25f76adccece5d1d4d058d0b15117b9e4a9f758424f92a
+    checksum: 6de4534964b723397b3e8c995cadcf43bc007cc2f9930b95ae25f76adccece5d1d4d058d0b15117b9e4a9f758424f92a
     source:
       $type: google_drive
       id: 1KmM2vwGBuKxy7RE9hz1m5D0yyh2N9Amo

--- a/models/public/bert-base-ner/model.yml
+++ b/models/public/bert-base-ner/model.yml
@@ -31,23 +31,23 @@ task_type: named_entity_recognition
 files:
   - name: transformers-4.5.1-py3-none-any.whl
     size: 2060589
-    sha384: e9cb161eef172deac1068d491ed9f7918f5aaa087c9170f8d6356924ade6fd3f2be580c47cef37aa419a2be64db42a28
+    checksum: e9cb161eef172deac1068d491ed9f7918f5aaa087c9170f8d6356924ade6fd3f2be580c47cef37aa419a2be64db42a28
     source: https://files.pythonhosted.org/packages/d8/b2/57495b5309f09fa501866e225c84532d1fd89536ea62406b2181933fb418/transformers-4.5.1-py3-none-any.whl
   - name: bert-base-ner/pytorch_model.bin
     size: 433316646
-    sha384: 59e6fefd0f29534cab9681891a15e9762b1d2dd8d047f55a792b39243631a008ac91a0e354f2ca2aa942be443540a8cb
+    checksum: 59e6fefd0f29534cab9681891a15e9762b1d2dd8d047f55a792b39243631a008ac91a0e354f2ca2aa942be443540a8cb
     source: https://huggingface.co/dslim/bert-base-NER/resolve/main/pytorch_model.bin
   - name: bert-base-ner/config.json
     size: 829
-    sha384: 66d217d33ba89085a56afc3b485b4e997d278d5253519e6a536c234fce3e065fb80ef39d27894df176148cb457c1cfcb
+    checksum: 66d217d33ba89085a56afc3b485b4e997d278d5253519e6a536c234fce3e065fb80ef39d27894df176148cb457c1cfcb
     source: https://huggingface.co/dslim/bert-base-NER/resolve/main/config.json
   - name: bert-base-ner/vocab.txt
     size: 213450
-    sha384: b13bb7bd69958cf6d486a291894d90a8693adcea0cb177d1fbe652000def2b169dc82b292ef51736d1f6f15fee1ab486
+    checksum: b13bb7bd69958cf6d486a291894d90a8693adcea0cb177d1fbe652000def2b169dc82b292ef51736d1f6f15fee1ab486
     source: https://huggingface.co/dslim/bert-base-NER/resolve/main/vocab.txt
   - name: packaging-20.9-py2.py3-none-any.whl
     size: 40870
-    sha384: 422fac4cb009bed3eae42e9688b1712ee15dde1799c888f33c802792e925373dee046602d1d31c460d9d2af3ff6b93a1
+    checksum: 422fac4cb009bed3eae42e9688b1712ee15dde1799c888f33c802792e925373dee046602d1d31c460d9d2af3ff6b93a1
     source: https://files.pythonhosted.org/packages/3e/89/7ea760b4daa42653ece2380531c90f64788d979110a2ab51049d92f408af/packaging-20.9-py2.py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/brain-tumor-segmentation-0001/model.yml
+++ b/models/public/brain-tumor-segmentation-0001/model.yml
@@ -26,13 +26,13 @@ task_type: semantic_segmentation
 files:
   - name: brain-tumor-segmentation-0001-symbol.json
     size: 100106
-    sha384: 2a36d9609896409eb47268316b5b0ec23bd6f4db1c98cbb69e9dfd34cbf5e9fdfad9d286b1a675fe58c8aec547aaa14c
+    checksum: 2a36d9609896409eb47268316b5b0ec23bd6f4db1c98cbb69e9dfd34cbf5e9fdfad9d286b1a675fe58c8aec547aaa14c
     source:
       $type: google_drive
       id: 1HaExnmHtF2nl2PkcLfKJDzA_7IMmLyKJ
   - name: brain-tumor-segmentation-0001-0000.params
     size: 152788159
-    sha384: f418f3565b8d9c755ad6f407c979a12f2b2a7327170c881477bb75cac70d77f69d5613aaa06bed6a7913e14df5119c36
+    checksum: f418f3565b8d9c755ad6f407c979a12f2b2a7327170c881477bb75cac70d77f69d5613aaa06bed6a7913e14df5119c36
     source:
       $type: google_drive
       id: 1T2ldCISt5N2TEUfv6ggRB1dw0cucTqT2

--- a/models/public/brain-tumor-segmentation-0002/model.yml
+++ b/models/public/brain-tumor-segmentation-0002/model.yml
@@ -20,7 +20,7 @@ task_type: semantic_segmentation
 files:
   - name: brain-tumor-segmentation-0002.onnx
     size: 21735156
-    sha384: 3c7b1b9c2444b93bfc25e0e32b9ef588a1fed8ed0e367655300008e86959b1413717bff02794a58af96760df7fc293c0
+    checksum: 3c7b1b9c2444b93bfc25e0e32b9ef588a1fed8ed0e367655300008e86959b1413717bff02794a58af96760df7fc293c0
     source:
       $type: google_drive
       id: 1NhH51NgKJKhu0Bax_IKQ_Byvoe2bItPX

--- a/models/public/caffenet/model.yml
+++ b/models/public/caffenet/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: bvlc_reference_caffenet.caffemodel
     size: 243862418
-    sha384: 6677844301d6c7f68f5b6a299cf41c4f0955bab7d1fb8719375fae6d05b6173db9deccf3ac4aaa4225bf6c6e99d81a68
+    checksum: 6677844301d6c7f68f5b6a299cf41c4f0955bab7d1fb8719375fae6d05b6173db9deccf3ac4aaa4225bf6c6e99d81a68
     source: http://dl.caffe.berkeleyvision.org/bvlc_reference_caffenet.caffemodel
   - name: deploy.prototxt
     size: 2878
-    sha384: 0d8510160bffd5a656022173a962cdd5e73d857015d0911f4ec1b73e1a7a2f9a1e979170e55baf8830b16379c6b75340
+    checksum: 0d8510160bffd5a656022173a962cdd5e73d857015d0911f4ec1b73e1a7a2f9a1e979170e55baf8830b16379c6b75340
     source: https://raw.githubusercontent.com/BVLC/caffe/2cc3844cb2a4a72de10d321781dc8f994bef95c7/models/bvlc_reference_caffenet/deploy.prototxt
 model_optimizer_args:
   - --input_shape=[1,3,227,227]

--- a/models/public/cocosnet/model.yml
+++ b/models/public/cocosnet/model.yml
@@ -21,65 +21,65 @@ task_type: image_translation
 files:
   - name: model_files/util/__init__.py
     size: 72
-    sha384: dfc6f539e037c1d6a8a1747c8a64f20431a0847874461c845a60aa686936d51163d7db6a56fc5086558512f544051fac
+    checksum: dfc6f539e037c1d6a8a1747c8a64f20431a0847874461c845a60aa686936d51163d7db6a56fc5086558512f544051fac
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/util/__init__.py
   - name: model_files/util/util.py
     size: 17551
-    sha384: ada7dfbea39ed1a0bc97f03dab894fe1eac065bc0e0c7361def8e7a9e5bac75627eaa38d3c176ac6aa391945e0e221b3
+    checksum: ada7dfbea39ed1a0bc97f03dab894fe1eac065bc0e0c7361def8e7a9e5bac75627eaa38d3c176ac6aa391945e0e221b3
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/util/util.py
   - name: model_files/models/networks/__init__.py
     size: 2676
-    sha384: 9f1dae79e5600f33da16268485852627fe12bb62695f2c320abb12852f3232d6e76cfc9745fa5bc04994766d9e488114
+    checksum: 9f1dae79e5600f33da16268485852627fe12bb62695f2c320abb12852f3232d6e76cfc9745fa5bc04994766d9e488114
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/__init__.py
   - name: model_files/models/networks/architecture.py
     size: 7985
-    sha384: 4be0416ec80decdcdc177b31197794c6c683a05e74690b780ec8db85b8f47c3a03dfa8dbfde58e72aa4c6e4a49ed1204
+    checksum: 4be0416ec80decdcdc177b31197794c6c683a05e74690b780ec8db85b8f47c3a03dfa8dbfde58e72aa4c6e4a49ed1204
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/architecture.py
   - name: model_files/models/networks/base_network.py
     size: 2466
-    sha384: 2bd2cc5d29b71387dc4a756c7e3b8931c019d6a1e765bf71fa28443e34686716dacf77f1b5f58460517886148518332d
+    checksum: 2bd2cc5d29b71387dc4a756c7e3b8931c019d6a1e765bf71fa28443e34686716dacf77f1b5f58460517886148518332d
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/base_network.py
   - name: model_files/models/networks/correspondence.py
     size: 18453
-    sha384: 6a4aef47693a292715f8986ccc994e2e932db5d9d54dea790a3df9be34471ed7645f0fff6d1cbde87a26831a7b339c39
+    checksum: 6a4aef47693a292715f8986ccc994e2e932db5d9d54dea790a3df9be34471ed7645f0fff6d1cbde87a26831a7b339c39
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/correspondence.py
   - name: model_files/models/networks/generator.py
     size: 10874
-    sha384: 24a4fe9c52345aba6c161930bda8d27692ad511f00711b62c2aef97157d36a648c2439c27d2e15d52271ae87f5d1f339
+    checksum: 24a4fe9c52345aba6c161930bda8d27692ad511f00711b62c2aef97157d36a648c2439c27d2e15d52271ae87f5d1f339
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/generator.py
   - name: model_files/models/networks/normalization.py
     size: 11279
-    sha384: 6b95b80690a0ff4f79f72669132763876c855631b662a0f9a089ffde1597341a1e3f823ea90ba6b7be963272378b295c
+    checksum: 6b95b80690a0ff4f79f72669132763876c855631b662a0f9a089ffde1597341a1e3f823ea90ba6b7be963272378b295c
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/networks/normalization.py
   - name: model_files/models/__init__.py
     size: 1417
-    sha384: 307d0718d8268d5f27dc5b394a756d7910f9f2f36792d78e718295966208bdaed0055e3ca224db506baab7c847857a9a
+    checksum: 307d0718d8268d5f27dc5b394a756d7910f9f2f36792d78e718295966208bdaed0055e3ca224db506baab7c847857a9a
     source: https://raw.githubusercontent.com/microsoft/CoCosNet/33f98d092407094a15a08b0555d6f5359490cd3e/models/__init__.py
   - name: model_files/models/networks/sync_batchnorm/__init__.py
     size: 507
-    sha384: e5e64b8365cbfbb1c1dc5379cd6230ae468c38cde59c294e67e0103e4add0744ed658ac7f246efcc7abfc601463bc29b
+    checksum: e5e64b8365cbfbb1c1dc5379cd6230ae468c38cde59c294e67e0103e4add0744ed658ac7f246efcc7abfc601463bc29b
     source: https://raw.githubusercontent.com/vacancy/Synchronized-BatchNorm-PyTorch/5768ead395820b8a625cbe0da0bb9f949748a5dd/sync_batchnorm/__init__.py
   - name: model_files/models/networks/sync_batchnorm/batchnorm.py
     size: 15944
-    sha384: 8a282cac42d4a9e970c26deb8251c7e7ea30bc55ffbcba13f1a0e02cb78763a6b993c6c91e1ed6a90074ca6899242136
+    checksum: 8a282cac42d4a9e970c26deb8251c7e7ea30bc55ffbcba13f1a0e02cb78763a6b993c6c91e1ed6a90074ca6899242136
     source: https://raw.githubusercontent.com/vacancy/Synchronized-BatchNorm-PyTorch/5768ead395820b8a625cbe0da0bb9f949748a5dd/sync_batchnorm/batchnorm.py
   - name: model_files/models/networks/sync_batchnorm/replicate.py
     size: 3226
-    sha384: 9f662572ba39a396b98116ee8a4fe1b08fb5905fb2ba88cef3965a0827f6917409e7f25a5d1dcbf06acc986acea87d56
+    checksum: 9f662572ba39a396b98116ee8a4fe1b08fb5905fb2ba88cef3965a0827f6917409e7f25a5d1dcbf06acc986acea87d56
     source: https://raw.githubusercontent.com/vacancy/Synchronized-BatchNorm-PyTorch/5768ead395820b8a625cbe0da0bb9f949748a5dd/sync_batchnorm/replicate.py
   - name: model_files/models/networks/sync_batchnorm/comm.py
     size: 4449
-    sha384: 985fb49fbc665ecef6de44ba10c8e547b27733a2301d10ce47da78c7152dd14c78645baae5cd6c042a987bad59ec86dc
+    checksum: 985fb49fbc665ecef6de44ba10c8e547b27733a2301d10ce47da78c7152dd14c78645baae5cd6c042a987bad59ec86dc
     source: https://raw.githubusercontent.com/vacancy/Synchronized-BatchNorm-PyTorch/5768ead395820b8a625cbe0da0bb9f949748a5dd/sync_batchnorm/comm.py
   - name: model_files/ckpt/latest_net_Corr.pth
     size: 237624725
-    sha384: f756f61b5b4d7ca0e23b7a3208ec8c8d5307fd834cef0dbeea7b7d8bc051eda9ecee2b71a378a2ecc5086a769242fc9a
+    checksum: f756f61b5b4d7ca0e23b7a3208ec8c8d5307fd834cef0dbeea7b7d8bc051eda9ecee2b71a378a2ecc5086a769242fc9a
     source:
       $type: google_drive
       id: 1yNCapBY7YqMoKeyVWwTwceqrEKHpUzYN
   - name: model_files/ckpt/latest_net_G.pth
     size: 387069636
-    sha384: 25b790181bbb30c5bd09627756bd70c8bd528431c57c8508ea48f3f352fda987203f19cc129b5706927bd68878d46e0d
+    checksum: 25b790181bbb30c5bd09627756bd70c8bd528431c57c8508ea48f3f352fda987203f19cc129b5706927bd68878d46e0d
     source:
       $type: google_drive
       id: 1zVG4SnR1uI8bC8fagZrgxNYCI5GRmJuR

--- a/models/public/colorization-siggraph/model.yml
+++ b/models/public/colorization-siggraph/model.yml
@@ -25,19 +25,19 @@ task_type: colorization
 files:
   - name: ckpt/colorization-siggraph.pth
     size: 136787426
-    sha384: f6c42249eb7c51f6127ed14a06fdd8ade7bae810a1021c3db1f026a4751846577eff44e9da580677ae668c17d853fa13
+    checksum: f6c42249eb7c51f6127ed14a06fdd8ade7bae810a1021c3db1f026a4751846577eff44e9da580677ae668c17d853fa13
     source: https://colorizers.s3.us-east-2.amazonaws.com/siggraph17-df00044c.pth
   - name: model/__init__.py
     size: 96
-    sha384: 04b2675bb9d47bd3f05cb786ec74abd67b4118b6d3b424c0bc85d5136939605c39da443740d9b98b1e7f3f0ada05c885
+    checksum: 04b2675bb9d47bd3f05cb786ec74abd67b4118b6d3b424c0bc85d5136939605c39da443740d9b98b1e7f3f0ada05c885
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/__init__.py
   - name: model/base_color.py
     size: 454
-    sha384: 73f4fdae2d975c533530da98efc3c8a7089202492293b28fef447408d054cd59bdff0befc7f38b8336b1a001ce6f9e8d
+    checksum: 73f4fdae2d975c533530da98efc3c8a7089202492293b28fef447408d054cd59bdff0befc7f38b8336b1a001ce6f9e8d
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/base_color.py
   - name: model/siggraph17.py
     size: 7339
-    sha384: 9ae0be2f05ef6776f4d3fb801d2b3a1408196e4ff22c01e5977f38617f38918fec234fdd306bb957ba69b84493566f02
+    checksum: 9ae0be2f05ef6776f4d3fb801d2b3a1408196e4ff22c01e5977f38617f38918fec234fdd306bb957ba69b84493566f02
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/siggraph17.py
 postprocessing:
   - $type: regex_replace

--- a/models/public/colorization-v2/model.yml
+++ b/models/public/colorization-v2/model.yml
@@ -24,19 +24,19 @@ task_type: colorization
 files:
   - name: ckpt/colorization-v2-eccv16.pth
     size: 128976165
-    sha384: 65bc890b145efde14f6847e707ba49fe8a026a02d5dc91bdfa9708893a954547256935b997904280a7ae991da1aac53e
+    checksum: 65bc890b145efde14f6847e707ba49fe8a026a02d5dc91bdfa9708893a954547256935b997904280a7ae991da1aac53e
     source: https://colorizers.s3.us-east-2.amazonaws.com/colorization_release_v2-9b330a0b.pth
   - name: model/__init__.py
     size: 96
-    sha384: 04b2675bb9d47bd3f05cb786ec74abd67b4118b6d3b424c0bc85d5136939605c39da443740d9b98b1e7f3f0ada05c885
+    checksum: 04b2675bb9d47bd3f05cb786ec74abd67b4118b6d3b424c0bc85d5136939605c39da443740d9b98b1e7f3f0ada05c885
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/__init__.py
   - name: model/base_color.py
     size: 454
-    sha384: 73f4fdae2d975c533530da98efc3c8a7089202492293b28fef447408d054cd59bdff0befc7f38b8336b1a001ce6f9e8d
+    checksum: 73f4fdae2d975c533530da98efc3c8a7089202492293b28fef447408d054cd59bdff0befc7f38b8336b1a001ce6f9e8d
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/base_color.py
   - name: model/eccv16.py
     size: 4613
-    sha384: 121ed60312afef4c2d460298c78390714b3417914a82218185520ea6ae5a23da3bda99d5fffba3b586d54988a4919684
+    checksum: 121ed60312afef4c2d460298c78390714b3417914a82218185520ea6ae5a23da3bda99d5fffba3b586d54988a4919684
     source: https://raw.githubusercontent.com/richzhang/colorization/4f6009ed1495b1300231ebeb41cc4015557ddef7/colorizers/eccv16.py
 postprocessing:
   - $type: regex_replace

--- a/models/public/common-sign-language-0001/model.yml
+++ b/models/public/common-sign-language-0001/model.yml
@@ -24,7 +24,7 @@ task_type: action_recognition
 files:
   - name: s3d-rgb-mobilenet-v3-large-stream-jester.onnx
     size: 16647750
-    sha384: 4ed07ac7d6dc24c9c3369fbbd13e4539dd3803735440f460776715a904c5efd43fb740d4d6cfe7f61ce319ae7a25ab22
+    checksum: 4ed07ac7d6dc24c9c3369fbbd13e4539dd3803735440f460776715a904c5efd43fb740d4d6cfe7f61ce319ae7a25ab22
     source:
       $type: google_drive
       id: 1ZrqF1vp71WVi7SMo6QNa14mqyrhpuu2Q

--- a/models/public/ctdet_coco_dlav0_384/model.yml
+++ b/models/public/ctdet_coco_dlav0_384/model.yml
@@ -22,21 +22,21 @@ task_type: detection
 files:
   - name: ctdet_coco_dlav0_1x.pth
     size: 221889662
-    sha384: 74565ead2d6c42738f90c0c23abaca04048c9156fdd548130a6b9df94786a6d964b8d6f548a0a44208885243314eea64
+    checksum: 74565ead2d6c42738f90c0c23abaca04048c9156fdd548130a6b9df94786a6d964b8d6f548a0a44208885243314eea64
     source:
       $type: google_drive
       id: 18yBxWOlhTo32_swSug_HM4q3BeWgxp_N
   - name: CenterNet/src/lib/models/model.py
     size: 3415
-    sha384: 470f5591048628d23768d9422d9f960855190d092e31370c0dcdcb73d200adbfa9fa64ab5836ed83d171f1b6a6041147
+    checksum: 470f5591048628d23768d9422d9f960855190d092e31370c0dcdcb73d200adbfa9fa64ab5836ed83d171f1b6a6041147
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/models/model.py
   - name: CenterNet/src/lib/models/networks/dlav0.py
     size: 22682
-    sha384: 7b8ced5f89807a8a662917b105a26e5c8107ead638ba9f9ef8bc3e4b893ae10e3c69506960c4602ba5188ff70a7cb075
+    checksum: 7b8ced5f89807a8a662917b105a26e5c8107ead638ba9f9ef8bc3e4b893ae10e3c69506960c4602ba5188ff70a7cb075
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/models/networks/dlav0.py
   - name: CenterNet/src/lib/opts.py
     size: 18696
-    sha384: d002e405f083412de4e5f9b4df56aab695ca6efde9ba1e8d2230dcbee4e64b171d87ab344fe324530ff547cbcc5fbbd2
+    checksum: d002e405f083412de4e5f9b4df56aab695ca6efde9ba1e8d2230dcbee4e64b171d87ab344fe324530ff547cbcc5fbbd2
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/opts.py
 postprocessing:
   # disable imports and usages of components we don't need

--- a/models/public/ctdet_coco_dlav0_512/model.yml
+++ b/models/public/ctdet_coco_dlav0_512/model.yml
@@ -22,21 +22,21 @@ task_type: detection
 files:
   - name: ctdet_coco_dlav0_1x.pth
     size: 221889662
-    sha384: 74565ead2d6c42738f90c0c23abaca04048c9156fdd548130a6b9df94786a6d964b8d6f548a0a44208885243314eea64
+    checksum: 74565ead2d6c42738f90c0c23abaca04048c9156fdd548130a6b9df94786a6d964b8d6f548a0a44208885243314eea64
     source:
       $type: google_drive
       id: 18yBxWOlhTo32_swSug_HM4q3BeWgxp_N
   - name: CenterNet/src/lib/models/model.py
     size: 3415
-    sha384: 470f5591048628d23768d9422d9f960855190d092e31370c0dcdcb73d200adbfa9fa64ab5836ed83d171f1b6a6041147
+    checksum: 470f5591048628d23768d9422d9f960855190d092e31370c0dcdcb73d200adbfa9fa64ab5836ed83d171f1b6a6041147
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/models/model.py
   - name: CenterNet/src/lib/models/networks/dlav0.py
     size: 22682
-    sha384: 7b8ced5f89807a8a662917b105a26e5c8107ead638ba9f9ef8bc3e4b893ae10e3c69506960c4602ba5188ff70a7cb075
+    checksum: 7b8ced5f89807a8a662917b105a26e5c8107ead638ba9f9ef8bc3e4b893ae10e3c69506960c4602ba5188ff70a7cb075
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/models/networks/dlav0.py
   - name: CenterNet/src/lib/opts.py
     size: 18696
-    sha384: d002e405f083412de4e5f9b4df56aab695ca6efde9ba1e8d2230dcbee4e64b171d87ab344fe324530ff547cbcc5fbbd2
+    checksum: d002e405f083412de4e5f9b4df56aab695ca6efde9ba1e8d2230dcbee4e64b171d87ab344fe324530ff547cbcc5fbbd2
     source: https://github.com/xingyizhou/CenterNet/raw/8ef87b433529ac8f8bd4f95707f6bc05052c55e9/src/lib/opts.py
 postprocessing:
   # disable imports and usages of components we don't need

--- a/models/public/ctpn/model.yml
+++ b/models/public/ctpn/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: ctpn.pb
     size: 71638063
-    sha384: edc59e0375fb56fc51e0333f4cd2377494d50ef3b86cb64b81e801a6d1ed3256dce068fce80bb7b7fd665258fae76cb4
+    checksum: edc59e0375fb56fc51e0333f4cd2377494d50ef3b86cb64b81e801a6d1ed3256dce068fce80bb7b7fd665258fae76cb4
     source: https://github.com/eragonruan/text-detection-ctpn/releases/download/untagged-48d74c6337a71b6b5f87/ctpn.pb
 model_optimizer_args:
   - --input_shape=[1,600,600,3]

--- a/models/public/deblurgan-v2/model.yml
+++ b/models/public/deblurgan-v2/model.yml
@@ -23,23 +23,23 @@ task_type: image_processing
 files:
   - name: models/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/VITA-Group/DeblurGANv2/a95d6a7e003fc98e786cd26937e1e20814f533b0/models/__init__.py
   - name: models/fpn_mobilenet.py
     size: 5688
-    sha384: c3d9317a425bc848802ccaaa5cf22dcb434f9d1ae8b67461d476406290caf6ab1b0169e408ad98406bf7f503501b8a45
+    checksum: c3d9317a425bc848802ccaaa5cf22dcb434f9d1ae8b67461d476406290caf6ab1b0169e408ad98406bf7f503501b8a45
     source: https://raw.githubusercontent.com/VITA-Group/DeblurGANv2/a95d6a7e003fc98e786cd26937e1e20814f533b0/models/fpn_mobilenet.py
   - name: models/mobilenet_v2.py
     size: 4214
-    sha384: d704ddc6535f18f23edec4bd924977afa6cd1735efb96d52d60a0ddf236a5ec73df310050d742521dff398ec8336beae
+    checksum: d704ddc6535f18f23edec4bd924977afa6cd1735efb96d52d60a0ddf236a5ec73df310050d742521dff398ec8336beae
     source: https://raw.githubusercontent.com/VITA-Group/DeblurGANv2/a95d6a7e003fc98e786cd26937e1e20814f533b0/models/mobilenet_v2.py
   - name: models/networks.py
     size: 12779
-    sha384: 512fa90092d4a3edfd243cbcb74aec6d5c57b23fdbbdb290d3fe6629429dcbf49c260f5bfb37e4191e5895628655ef65
+    checksum: 512fa90092d4a3edfd243cbcb74aec6d5c57b23fdbbdb290d3fe6629429dcbf49c260f5bfb37e4191e5895628655ef65
     source: https://raw.githubusercontent.com/VITA-Group/DeblurGANv2/a95d6a7e003fc98e786cd26937e1e20814f533b0/models/networks.py
   - name: ckpt/fpn_mobilenet.h5
     size: 13505344
-    sha384: 93bd1ef8e8d6cc190a3310db6b556aee2df42a294b7015f689237cb1a1cad1f9327b9369e530804f8369195d4b286386
+    checksum: 93bd1ef8e8d6cc190a3310db6b556aee2df42a294b7015f689237cb1a1cad1f9327b9369e530804f8369195d4b286386
     source:
       $type: google_drive
       id: 1JhnT4BBeKBBSLqTo6UsJ13HeBXevarrU

--- a/models/public/deeplabv3/model.yml
+++ b/models/public/deeplabv3/model.yml
@@ -19,7 +19,7 @@ task_type: semantic_segmentation
 files:
   - name: deeplabv3.tar.gz
     size: 23882985
-    sha384: d3f2b27bb00c485ca45d68731f7198a23926cb865dd010fc444bcad9158e33413cd60da2588a9be3ff1e8c9b4557362b
+    checksum: d3f2b27bb00c485ca45d68731f7198a23926cb865dd010fc444bcad9158e33413cd60da2588a9be3ff1e8c9b4557362b
     source: http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_train_aug_2018_01_29.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/densenet-121-caffe2/model.yml
+++ b/models/public/densenet-121-caffe2/model.yml
@@ -21,11 +21,11 @@ task_type: classification
 files:
   - name: predict_net.pb
     size: 77239
-    sha384: c2bb28b1680d948ae273ea35e33ddddaccc4892e2db2e57a9869d26f877888d9495a7f806152738edc9168caeea38ce2
+    checksum: c2bb28b1680d948ae273ea35e33ddddaccc4892e2db2e57a9869d26f877888d9495a7f806152738edc9168caeea38ce2
     source: https://s3.amazonaws.com/download.caffe2.ai/models/densenet121/predict_net.pb
   - name: init_net.pb
     size: 40785727
-    sha384: 90176032f71fb6928f3ef71147895809e0a3874a7948900eeb3d15aca69df701a4cca146ef97a402bd0183745dc7f5fe
+    checksum: 90176032f71fb6928f3ef71147895809e0a3874a7948900eeb3d15aca69df701a4cca146ef97a402bd0183745dc7f5fe
     source: https://s3.amazonaws.com/download.caffe2.ai/models/densenet121/init_net.pb
 framework: caffe2
 quantizable: yes

--- a/models/public/densenet-121-tf/model.yml
+++ b/models/public/densenet-121-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: densenet121_weights_tf_dim_ordering_tf_kernels.h5
     size: 33188688
-    sha384: dcd6d36f6b07e0843ee35b1dce2c587204c8816d6ba25b7e1dbf2dc25fe2b51f49a2b9327579ce07904575f9325be8b6
+    checksum: dcd6d36f6b07e0843ee35b1dce2c587204c8816d6ba25b7e1dbf2dc25fe2b51f49a2b9327579ce07904575f9325be8b6
     source: https://storage.googleapis.com/tensorflow/keras-applications/densenet/densenet121_weights_tf_dim_ordering_tf_kernels.h5
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/densenet-121/model.yml
+++ b/models/public/densenet-121/model.yml
@@ -22,11 +22,11 @@ task_type: classification
 files:
   - name: densenet-121.prototxt
     size: 76474
-    sha384: e385fcce6416abba5b3c55f39df1392edc6d0c740f0905d923b4746ea2026812790fb2666e4b8729e15e5d3a6b505886
+    checksum: e385fcce6416abba5b3c55f39df1392edc6d0c740f0905d923b4746ea2026812790fb2666e4b8729e15e5d3a6b505886
     source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_121.prototxt
   - name: densenet-121.caffemodel
     size: 32303870
-    sha384: 6ecb7d9f607c817152a39ccdfcb4caa798bcdbe6a38150dba90ef0822b02907026c89157fa9088aa28173e9c98690ec6
+    checksum: 6ecb7d9f607c817152a39ccdfcb4caa798bcdbe6a38150dba90ef0822b02907026c89157fa9088aa28173e9c98690ec6
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/densenet-121/DenseNet_121.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/densenet-161-tf/model.yml
+++ b/models/public/densenet-161-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: tf-densenet161.tar.gz
     size: 110578586
-    sha384: 656d4d945bb8ea94baeba1c07089c4045e3b58a629bcb13427a1d84f8c0ac775d12b2cb6e752894fcabb1ba7b9c17359
+    checksum: 656d4d945bb8ea94baeba1c07089c4045e3b58a629bcb13427a1d84f8c0ac775d12b2cb6e752894fcabb1ba7b9c17359
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/densenet-161-tf/tf-densenet161.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/densenet-161/model.yml
+++ b/models/public/densenet-161/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: densenet-161.prototxt
     size: 101955
-    sha384: 5b2975947130026e7fcbc7986f3279e804f02f74575b1ff81d48e0d6b218d33abaf7be256bd6faab0faed9d61487bae7
+    checksum: 5b2975947130026e7fcbc7986f3279e804f02f74575b1ff81d48e0d6b218d33abaf7be256bd6faab0faed9d61487bae7
     source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_161.prototxt
   - name: densenet-161.caffemodel
     size: 115676075
-    sha384: fd6fd842cb7c4d3d384b35d3153fcfa3d27110aafe483524cf78c9bd0ef5b2351fbeef32b2a82c09aacbe3dca80168eb
+    checksum: fd6fd842cb7c4d3d384b35d3153fcfa3d27110aafe483524cf78c9bd0ef5b2351fbeef32b2a82c09aacbe3dca80168eb
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/densenet-161/DenseNet_161.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/densenet-169-tf/model.yml
+++ b/models/public/densenet-169-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: densenet169_weights_tf_dim_ordering_tf_kernels.h5
     size: 58541896
-    sha384: ce016db1b892e52fc784d96ec296b33ec94473d4c73b977175c2fb21bbcfbcf4f269ef15616a635ad337173ca3d0e813
+    checksum: ce016db1b892e52fc784d96ec296b33ec94473d4c73b977175c2fb21bbcfbcf4f269ef15616a635ad337173ca3d0e813
     source: https://storage.googleapis.com/tensorflow/keras-applications/densenet/densenet169_weights_tf_dim_ordering_tf_kernels.h5
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/densenet-169/model.yml
+++ b/models/public/densenet-169/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: densenet-169.prototxt
     size: 107050
-    sha384: 5600c42b2135cf05b5e4769f5753e4f430ee951f47735ada01a4edcea9b76016c91d2cd7eedc403cd302799d222940e4
+    checksum: 5600c42b2135cf05b5e4769f5753e4f430ee951f47735ada01a4edcea9b76016c91d2cd7eedc403cd302799d222940e4
     source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_169.prototxt
   - name: densenet-169.caffemodel
     size: 57307526
-    sha384: 653bacbd9bfbe84d400faea8bf6cf0c8c0bbe1b0883fe7129baa093984cb013e00cdd2604ec335bd3ec3d98c11489555
+    checksum: 653bacbd9bfbe84d400faea8bf6cf0c8c0bbe1b0883fe7129baa093984cb013e00cdd2604ec335bd3ec3d98c11489555
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/densenet-169/DenseNet_169.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/densenet-201-tf/model.yml
+++ b/models/public/densenet-201-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: densenet201_weights_tf_dim_ordering_tf_kernels.h5
     size: 82524592
-    sha384: 25ed149b2cb09d4d3715ac4f16f520a747c9091c1ed2355eca07684e95266eee732ea5d33875fe0f644e010ec77d3365
+    checksum: 25ed149b2cb09d4d3715ac4f16f520a747c9091c1ed2355eca07684e95266eee732ea5d33875fe0f644e010ec77d3365
     source: https://storage.googleapis.com/tensorflow/keras-applications/densenet/densenet201_weights_tf_dim_ordering_tf_kernels.h5
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/densenet-201/model.yml
+++ b/models/public/densenet-201/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: densenet-201.prototxt
     size: 127588
-    sha384: 93e208a3973cdd94ced115c7de65851d80ebad1da0be9063ed8f0507c4b23a201646205051ccd37b286c6cae33cd18d5
+    checksum: 93e208a3973cdd94ced115c7de65851d80ebad1da0be9063ed8f0507c4b23a201646205051ccd37b286c6cae33cd18d5
     source: https://raw.githubusercontent.com/shicai/DenseNet-Caffe/a68651c0b91d8dcb7c0ecd39d1fc76da523baf8a/DenseNet_201.prototxt
   - name: densenet-201.caffemodel
     size: 81062969
-    sha384: 477c169366ba6575646184bd6799f9ca814401cddc5282ab31f45b0bf1801e3d40914e327900d733237ee0f8252610bf
+    checksum: 477c169366ba6575646184bd6799f9ca814401cddc5282ab31f45b0bf1801e3d40914e327900d733237ee0f8252610bf
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/densenet-201/DenseNet_201.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/detr-resnet50/model.yml
+++ b/models/public/detr-resnet50/model.yml
@@ -28,27 +28,27 @@ task_type: detection
 files:
   - name: detr-r50-e632da11.pth
     size: 166618694
-    sha384: cba2c4acb7c6ec60e0d56dbd7bfb0dab73aef5ac86bf9819bc4e176fd943114fb1e5567e5046dc6d6a18b7e490dce680
+    checksum: cba2c4acb7c6ec60e0d56dbd7bfb0dab73aef5ac86bf9819bc4e176fd943114fb1e5567e5046dc6d6a18b7e490dce680
     source: https://dl.fbaipublicfiles.com/detr/detr-r50-e632da11.pth
   - name: models/detr.py
     size: 17089
-    sha384: ae1d9cc2b2b483dbd8fd095137e27bf1ec1d596ede1be55e842f771f02725a958763358631e7c8e69fecfe34059fb393
+    checksum: ae1d9cc2b2b483dbd8fd095137e27bf1ec1d596ede1be55e842f771f02725a958763358631e7c8e69fecfe34059fb393
     source: https://raw.githubusercontent.com/facebookresearch/detr/a54b77800eb8e64e3ad0d8237789fcbf2f8350c5/models/detr.py
   - name: models/backbone.py
     size: 4437
-    sha384: 2935015de1399c9b2037da55de0e8d90fa6c1d19739821df3aa9d986fdcb1c861a6b8d494165bfdb68ff52ab87494ad6
+    checksum: 2935015de1399c9b2037da55de0e8d90fa6c1d19739821df3aa9d986fdcb1c861a6b8d494165bfdb68ff52ab87494ad6
     source: https://raw.githubusercontent.com/facebookresearch/detr/a54b77800eb8e64e3ad0d8237789fcbf2f8350c5/models/backbone.py
   - name: models/transformer.py
     size: 12162
-    sha384: ae5bd31653d7b0a5809e71adec72b5e002a63ec95af8660c4c73310f040b01e0920816ce3ef8078131a4f1f35c406077
+    checksum: ae5bd31653d7b0a5809e71adec72b5e002a63ec95af8660c4c73310f040b01e0920816ce3ef8078131a4f1f35c406077
     source: https://raw.githubusercontent.com/facebookresearch/detr/a54b77800eb8e64e3ad0d8237789fcbf2f8350c5/models/transformer.py
   - name: models/position_encoding.py
     size: 3336
-    sha384: 9729adf8750340fcb730e26b688a925abbf934d2f0200a7aded338f512090f77be2327441f3b97da6cab5def77b8f767
+    checksum: 9729adf8750340fcb730e26b688a925abbf934d2f0200a7aded338f512090f77be2327441f3b97da6cab5def77b8f767
     source: https://raw.githubusercontent.com/facebookresearch/detr/a54b77800eb8e64e3ad0d8237789fcbf2f8350c5/models/position_encoding.py
   - name: util/misc.py
     size: 15284
-    sha384: 257e7a29d01882b709542bae492ef187796f08691cfaec3c141efedd77597eeca2ec9f549b0fc2794b260a19f3196098
+    checksum: 257e7a29d01882b709542bae492ef187796f08691cfaec3c141efedd77597eeca2ec9f549b0fc2794b260a19f3196098
     source: https://raw.githubusercontent.com/facebookresearch/detr/a54b77800eb8e64e3ad0d8237789fcbf2f8350c5/util/misc.py
 postprocessing:
   - $type: regex_replace

--- a/models/public/dla-34/model.yml
+++ b/models/public/dla-34/model.yml
@@ -22,15 +22,15 @@ task_type: classification
 files:
   - name: dla.py
     size: 14499
-    sha384: ceaa3db3e90e5edff2a644738e93a00bf3688499e670dde1e771055362ff4ec0ba087fc0af35bdaf175871f893e54511
+    checksum: ceaa3db3e90e5edff2a644738e93a00bf3688499e670dde1e771055362ff4ec0ba087fc0af35bdaf175871f893e54511
     source: https://raw.githubusercontent.com/ucbdrive/dla/master/dla.py
   - name: dataset.py
     size: 1776
-    sha384: 4fb6ed8cb467074f7b0229c7a623f7f27c5ec184c8fe5ef2d84ed70168c10f6c6019d228b80fd1022c8884bc5cf8c38c
+    checksum: 4fb6ed8cb467074f7b0229c7a623f7f27c5ec184c8fe5ef2d84ed70168c10f6c6019d228b80fd1022c8884bc5cf8c38c
     source: https://raw.githubusercontent.com/ucbdrive/dla/master/dataset.py
   - name: ckpt/dla34.pth
     size: 63228658
-    sha384: 38c035736538b6c67f2539bf1ca1cc1349c3691f41321bd58de9e97aa9eb83ea6f52c4aeef7c4cd54c92b6f8c3f3e89b
+    checksum: 38c035736538b6c67f2539bf1ca1cc1349c3691f41321bd58de9e97aa9eb83ea6f52c4aeef7c4cd54c92b6f8c3f3e89b
     source: http://dl.yf.io/dla/models/imagenet/dla34-ba72cf86.pth
 conversion_to_onnx_args:
   - --model-path=$dl_dir

--- a/models/public/drn-d-38/model.yml
+++ b/models/public/drn-d-38/model.yml
@@ -29,17 +29,17 @@ task_type: semantic_segmentation
 files:
   - name: drn_d_38_cityscapes.pth
     size: 104117210
-    sha384: 090859278d373c8ce160a21b256f6dcfa2a5d07b6d2aebbd18e598a1d3f2c48a97e188d13f1bc16751859a8ed8f8ec1a
+    checksum: 090859278d373c8ce160a21b256f6dcfa2a5d07b6d2aebbd18e598a1d3f2c48a97e188d13f1bc16751859a8ed8f8ec1a
     source:
       $type: google_drive
       id: 1Ck5cE5o6wsS5ITjeyBkvUYHnw4bIR6eg
   - name: models/drn.py
     size: 14175
-    sha384: 065d2584b6fc9528138f94fe60244e24669ca2b9870143e252f5e78684d037bff7971c3afacf22b8d481672fe4ab6f55
+    checksum: 065d2584b6fc9528138f94fe60244e24669ca2b9870143e252f5e78684d037bff7971c3afacf22b8d481672fe4ab6f55
     source: https://raw.githubusercontent.com/fyu/drn/d75db2ee7070426db7a9264ee61cf489f8cf178c/drn.py
   - name: models/segment.py
     size: 26909
-    sha384: d30346421bf9aee14fd72806fda6cc3acb857398b72b7e12715626e91eef4f39798fdde3bfea8c3f52a8cabd8bb32ffa
+    checksum: d30346421bf9aee14fd72806fda6cc3acb857398b72b7e12715626e91eef4f39798fdde3bfea8c3f52a8cabd8bb32ffa
     source: https://raw.githubusercontent.com/fyu/drn/d75db2ee7070426db7a9264ee61cf489f8cf178c/segment.py
 postprocessing:
   - $type: regex_replace

--- a/models/public/efficientdet-d0-tf/model.yml
+++ b/models/public/efficientdet-d0-tf/model.yml
@@ -22,67 +22,67 @@ task_type: detection
 files:
   - name: efficientdet-d0.tar.gz
     size: 28828936
-    sha384: 4107802535b036f846d856e55d0035f871bf900f28b25874874bcb72631f666d9f3a0ff8239c73e28a5fe9a0f816ac9f
+    checksum: 4107802535b036f846d856e55d0035f871bf900f28b25874874bcb72631f666d9f3a0ff8239c73e28a5fe9a0f816ac9f
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco2/efficientdet-d0.tar.gz
   - name: model/model_inspect.py
     size: 20388
-    sha384: d67e6eb34695a2ed0ab0c7444ecc763ff111834b4e7bb7183ec5bd66bc8b95443c5538b7322da2ffe589db8c4d4091f3
+    checksum: d67e6eb34695a2ed0ab0c7444ecc763ff111834b4e7bb7183ec5bd66bc8b95443c5538b7322da2ffe589db8c4d4091f3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/model_inspect.py
   - name: model/hparams_config.py
     size: 13750
-    sha384: 39b00fda7c2355fcb2849f440738a987b34e969d93961e6551e8e7092a8e08425cf4122c2af38173469ad3058f37f54b
+    checksum: 39b00fda7c2355fcb2849f440738a987b34e969d93961e6551e8e7092a8e08425cf4122c2af38173469ad3058f37f54b
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/hparams_config.py
   - name: model/inference.py
     size: 25076
-    sha384: 19aa8af0aacb45c3fee226a010b567358d08637ef7775fc93676046fcc0a3e133219475e6e5bfa198269eae0679435ce
+    checksum: 19aa8af0aacb45c3fee226a010b567358d08637ef7775fc93676046fcc0a3e133219475e6e5bfa198269eae0679435ce
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/inference.py
   - name: model/dataloader.py
     size: 19251
-    sha384: f764232d17c4c7c3289bcf846fe63b922194c7e89f33a5fbdc599bbe350afa534ff420477a3097af6773264a100f58f3
+    checksum: f764232d17c4c7c3289bcf846fe63b922194c7e89f33a5fbdc599bbe350afa534ff420477a3097af6773264a100f58f3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/dataloader.py
   - name: model/nms_np.py
     size: 11404
-    sha384: 20daf2a0a40df70441cd6cffbcffa7fabfaa8ddce617191311a5c7f27c4328d46516403ce0efb4f6945edd3942ebaef0
+    checksum: 20daf2a0a40df70441cd6cffbcffa7fabfaa8ddce617191311a5c7f27c4328d46516403ce0efb4f6945edd3942ebaef0
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/nms_np.py
   - name: model/utils.py
     size: 25677
-    sha384: 2cca479ebab14f9b2974076649d09e4069cab4870609eb47f7ec7a18d993be2bb44cd61f61e423dc70a4407b65a8dce5
+    checksum: 2cca479ebab14f9b2974076649d09e4069cab4870609eb47f7ec7a18d993be2bb44cd61f61e423dc70a4407b65a8dce5
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/utils.py
   - name: model/keras/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/__init__.py
   - name: model/keras/efficientdet_keras.py
     size: 32414
-    sha384: 50b8d1fd9500da82158f8edeec7b4e909c7c4910e1e59f2f4c92db516edea62acb7444c779ec722fd6eaefac460d4bde
+    checksum: 50b8d1fd9500da82158f8edeec7b4e909c7c4910e1e59f2f4c92db516edea62acb7444c779ec722fd6eaefac460d4bde
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/efficientdet_keras.py
   - name: model/backbone/efficientnet_builder.py
     size: 11609
-    sha384: fc75ab0fa3969111211958d06549afcb61ba4d4393b360ceaf05f225efa0190371b056aa2062645658445a0fae96d8d3
+    checksum: fc75ab0fa3969111211958d06549afcb61ba4d4393b360ceaf05f225efa0190371b056aa2062645658445a0fae96d8d3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/efficientnet_builder.py
   - name: model/backbone/efficientnet_model.py
     size: 27419
-    sha384: b4f23f043c5d84bf6770087c89ec82b5e09f55e18f7a280b47b34ce831bef48444f42c840ad3a2c471536e4ab810e072
+    checksum: b4f23f043c5d84bf6770087c89ec82b5e09f55e18f7a280b47b34ce831bef48444f42c840ad3a2c471536e4ab810e072
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/efficientnet_model.py
   - name: model/backbone/backbone_factory.py
     size: 2963
-    sha384: 8a19848f09bfa0ffe955eaecb4076e6c7158bb7b72eca61f6c850d53e4b9f2ea4407bd2e000d0618e746528cbd07a00f
+    checksum: 8a19848f09bfa0ffe955eaecb4076e6c7158bb7b72eca61f6c850d53e4b9f2ea4407bd2e000d0618e746528cbd07a00f
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/backbone_factory.py
   - name: model/keras/anchors.py
     size: 9175
-    sha384: 4163b87f2b41e9bedcd82fe023af7eb1d5a9129c4ce4f71929ee87695c15ec3ae92123649614828e120f417fce203fa8
+    checksum: 4163b87f2b41e9bedcd82fe023af7eb1d5a9129c4ce4f71929ee87695c15ec3ae92123649614828e120f417fce203fa8
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/anchors.py
   - name: model/keras/util_keras.py
     size: 2198
-    sha384: 333b8e217b327ca853bb55e5b470486a19aa0fc3a5707b425873eee2eac3e7acc434af1cf485efb2824600864dce884a
+    checksum: 333b8e217b327ca853bb55e5b470486a19aa0fc3a5707b425873eee2eac3e7acc434af1cf485efb2824600864dce884a
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/util_keras.py
   - name: model/keras/fpn_configs.py
     size: 6120
-    sha384: edd2e1d3d139bda797bad1a7403c88397b9f355c1e809b089ffe83931629844a68c613e31f35ab9ba2c333b5bc29917e
+    checksum: edd2e1d3d139bda797bad1a7403c88397b9f355c1e809b089ffe83931629844a68c613e31f35ab9ba2c333b5bc29917e
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/fpn_configs.py
   - name: model/keras/postprocess.py
     size: 17677
-    sha384: 0ed3354ce9f09281ac3ab176a629fdb95109bf1c0c18b1fff3439f488069a56a9f73776d6cf5ccde489d6bbc57566cd8
+    checksum: 0ed3354ce9f09281ac3ab176a629fdb95109bf1c0c18b1fff3439f488069a56a9f73776d6cf5ccde489d6bbc57566cd8
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/postprocess.py
 postprocessing:
   # disable imports that aren't needed for this model and code that uses them

--- a/models/public/efficientdet-d1-tf/model.yml
+++ b/models/public/efficientdet-d1-tf/model.yml
@@ -22,67 +22,67 @@ task_type: detection
 files:
   - name: efficientdet-d1.tar.gz
     size: 48828228
-    sha384: 0178799e293b54bb7a478b1671accfe5fb14d947cc196434db829dae216f55fff5de972a0291a71b7d3b3186aed8dfe9
+    checksum: 0178799e293b54bb7a478b1671accfe5fb14d947cc196434db829dae216f55fff5de972a0291a71b7d3b3186aed8dfe9
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientdet/coco2/efficientdet-d1.tar.gz
   - name: model/model_inspect.py
     size: 20388
-    sha384: d67e6eb34695a2ed0ab0c7444ecc763ff111834b4e7bb7183ec5bd66bc8b95443c5538b7322da2ffe589db8c4d4091f3
+    checksum: d67e6eb34695a2ed0ab0c7444ecc763ff111834b4e7bb7183ec5bd66bc8b95443c5538b7322da2ffe589db8c4d4091f3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/model_inspect.py
   - name: model/hparams_config.py
     size: 13750
-    sha384: 39b00fda7c2355fcb2849f440738a987b34e969d93961e6551e8e7092a8e08425cf4122c2af38173469ad3058f37f54b
+    checksum: 39b00fda7c2355fcb2849f440738a987b34e969d93961e6551e8e7092a8e08425cf4122c2af38173469ad3058f37f54b
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/hparams_config.py
   - name: model/inference.py
     size: 25076
-    sha384: 19aa8af0aacb45c3fee226a010b567358d08637ef7775fc93676046fcc0a3e133219475e6e5bfa198269eae0679435ce
+    checksum: 19aa8af0aacb45c3fee226a010b567358d08637ef7775fc93676046fcc0a3e133219475e6e5bfa198269eae0679435ce
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/inference.py
   - name: model/dataloader.py
     size: 19251
-    sha384: f764232d17c4c7c3289bcf846fe63b922194c7e89f33a5fbdc599bbe350afa534ff420477a3097af6773264a100f58f3
+    checksum: f764232d17c4c7c3289bcf846fe63b922194c7e89f33a5fbdc599bbe350afa534ff420477a3097af6773264a100f58f3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/dataloader.py
   - name: model/nms_np.py
     size: 11404
-    sha384: 20daf2a0a40df70441cd6cffbcffa7fabfaa8ddce617191311a5c7f27c4328d46516403ce0efb4f6945edd3942ebaef0
+    checksum: 20daf2a0a40df70441cd6cffbcffa7fabfaa8ddce617191311a5c7f27c4328d46516403ce0efb4f6945edd3942ebaef0
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/nms_np.py
   - name: model/utils.py
     size: 25677
-    sha384: 2cca479ebab14f9b2974076649d09e4069cab4870609eb47f7ec7a18d993be2bb44cd61f61e423dc70a4407b65a8dce5
+    checksum: 2cca479ebab14f9b2974076649d09e4069cab4870609eb47f7ec7a18d993be2bb44cd61f61e423dc70a4407b65a8dce5
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/utils.py
   - name: model/keras/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/__init__.py
   - name: model/keras/efficientdet_keras.py
     size: 32414
-    sha384: 50b8d1fd9500da82158f8edeec7b4e909c7c4910e1e59f2f4c92db516edea62acb7444c779ec722fd6eaefac460d4bde
+    checksum: 50b8d1fd9500da82158f8edeec7b4e909c7c4910e1e59f2f4c92db516edea62acb7444c779ec722fd6eaefac460d4bde
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/efficientdet_keras.py
   - name: model/backbone/efficientnet_builder.py
     size: 11609
-    sha384: fc75ab0fa3969111211958d06549afcb61ba4d4393b360ceaf05f225efa0190371b056aa2062645658445a0fae96d8d3
+    checksum: fc75ab0fa3969111211958d06549afcb61ba4d4393b360ceaf05f225efa0190371b056aa2062645658445a0fae96d8d3
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/efficientnet_builder.py
   - name: model/backbone/efficientnet_model.py
     size: 27419
-    sha384: b4f23f043c5d84bf6770087c89ec82b5e09f55e18f7a280b47b34ce831bef48444f42c840ad3a2c471536e4ab810e072
+    checksum: b4f23f043c5d84bf6770087c89ec82b5e09f55e18f7a280b47b34ce831bef48444f42c840ad3a2c471536e4ab810e072
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/efficientnet_model.py
   - name: model/backbone/backbone_factory.py
     size: 2963
-    sha384: 8a19848f09bfa0ffe955eaecb4076e6c7158bb7b72eca61f6c850d53e4b9f2ea4407bd2e000d0618e746528cbd07a00f
+    checksum: 8a19848f09bfa0ffe955eaecb4076e6c7158bb7b72eca61f6c850d53e4b9f2ea4407bd2e000d0618e746528cbd07a00f
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/backbone/backbone_factory.py
   - name: model/keras/anchors.py
     size: 9175
-    sha384: 4163b87f2b41e9bedcd82fe023af7eb1d5a9129c4ce4f71929ee87695c15ec3ae92123649614828e120f417fce203fa8
+    checksum: 4163b87f2b41e9bedcd82fe023af7eb1d5a9129c4ce4f71929ee87695c15ec3ae92123649614828e120f417fce203fa8
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/anchors.py
   - name: model/keras/util_keras.py
     size: 2198
-    sha384: 333b8e217b327ca853bb55e5b470486a19aa0fc3a5707b425873eee2eac3e7acc434af1cf485efb2824600864dce884a
+    checksum: 333b8e217b327ca853bb55e5b470486a19aa0fc3a5707b425873eee2eac3e7acc434af1cf485efb2824600864dce884a
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/util_keras.py
   - name: model/keras/fpn_configs.py
     size: 6120
-    sha384: edd2e1d3d139bda797bad1a7403c88397b9f355c1e809b089ffe83931629844a68c613e31f35ab9ba2c333b5bc29917e
+    checksum: edd2e1d3d139bda797bad1a7403c88397b9f355c1e809b089ffe83931629844a68c613e31f35ab9ba2c333b5bc29917e
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/fpn_configs.py
   - name: model/keras/postprocess.py
     size: 17677
-    sha384: 0ed3354ce9f09281ac3ab176a629fdb95109bf1c0c18b1fff3439f488069a56a9f73776d6cf5ccde489d6bbc57566cd8
+    checksum: 0ed3354ce9f09281ac3ab176a629fdb95109bf1c0c18b1fff3439f488069a56a9f73776d6cf5ccde489d6bbc57566cd8
     source: https://raw.githubusercontent.com/google/automl/341af7d4da7805c3a874877484e133f33c420ec5/efficientdet/keras/postprocess.py
 postprocessing:
   # disable imports that aren't needed for this model and code that uses them

--- a/models/public/efficientnet-b0-pytorch/model.yml
+++ b/models/public/efficientnet-b0-pytorch/model.yml
@@ -30,27 +30,27 @@ task_type: classification
 files:
   - name: model/gen_efficientnet.py
     size: 40997
-    sha384: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
+    checksum: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/gen_efficientnet.py
   - name: model/efficientnet_builder.py
     size: 18446
-    sha384: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
+    checksum: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/efficientnet_builder.py
   - name: model/helpers.py
     size: 1097
-    sha384: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
+    checksum: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/helpers.py
   - name: model/conv2d_helpers.py
     size: 6175
-    sha384: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
+    checksum: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/conv2d_helpers.py
   - name: model/__init__.py
     size: 32
-    sha384: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
+    checksum: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
     source: https://github.com/rwightman/gen-efficientnet-pytorch/raw/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/__init__.py
   - name: efficientnet-b0.pth
     size: 21376958
-    sha384: f44c3ff7ceeeda4ccf95a6720483cf2bee89f2db59d47e8349d2a7d46024e006b76e92105b6723060b898505312e70ff
+    checksum: f44c3ff7ceeeda4ccf95a6720483cf2bee89f2db59d47e8349d2a7d46024e006b76e92105b6723060b898505312e70ff
     source: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/efficientnet_b0-d6904d92.pth
 conversion_to_onnx_args:
   - --model-path=$dl_dir

--- a/models/public/efficientnet-b0/model.yml
+++ b/models/public/efficientnet-b0/model.yml
@@ -22,7 +22,7 @@ task_type: classification
 files:
   - name: efficientnet-b0.tar.gz
     size: 47390720
-    sha384: 9e9f607453d154c3ca08a3bbc39e59cc0ab99da7647beb5a20b0bffe5da5399a48e0407b68fa3ee14f4acc81b18714ce
+    checksum: 9e9f607453d154c3ca08a3bbc39e59cc0ab99da7647beb5a20b0bffe5da5399a48e0407b68fa3ee14f4acc81b18714ce
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet/ckpts/efficientnet-b0.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/efficientnet-b0_auto_aug/model.yml
+++ b/models/public/efficientnet-b0_auto_aug/model.yml
@@ -23,7 +23,7 @@ task_type: classification
 files:
   - name: efficientnet-b0.tar.gz
     size: 39302973
-    sha384: 2e75646e36cb65046b205166e5f6f5a78daffcd81310899a0690492a591e23d6075fffc55585c1daf7d3279357991912
+    checksum: 2e75646e36cb65046b205166e5f6f5a78daffcd81310899a0690492a591e23d6075fffc55585c1daf7d3279357991912
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet/ckptsaug/efficientnet-b0.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/efficientnet-b5-pytorch/model.yml
+++ b/models/public/efficientnet-b5-pytorch/model.yml
@@ -30,27 +30,27 @@ task_type: classification
 files:
   - name: model/gen_efficientnet.py
     size: 40997
-    sha384: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
+    checksum: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/gen_efficientnet.py
   - name: model/efficientnet_builder.py
     size: 18446
-    sha384: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
+    checksum: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/efficientnet_builder.py
   - name: model/helpers.py
     size: 1097
-    sha384: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
+    checksum: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/helpers.py
   - name: model/conv2d_helpers.py
     size: 6175
-    sha384: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
+    checksum: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/conv2d_helpers.py
   - name: model/__init__.py
     size: 32
-    sha384: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
+    checksum: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
     source: https://github.com/rwightman/gen-efficientnet-pytorch/raw/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/__init__.py
   - name: tf-efficientnet-b5.pth
     size: 122398414
-    sha384: 3226227ffa80fb1006873455a21f33060e98f0c3c2d6d0470355ece92d9ac7d01e3e41b636ead551cf43874a483d5d82
+    checksum: 3226227ffa80fb1006873455a21f33060e98f0c3c2d6d0470355ece92d9ac7d01e3e41b636ead551cf43874a483d5d82
     source: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_aa-99018a74.pth
 postprocessing:
   - $type: regex_replace

--- a/models/public/efficientnet-b5/model.yml
+++ b/models/public/efficientnet-b5/model.yml
@@ -22,7 +22,7 @@ task_type: classification
 files:
   - name: efficientnet-b5.tar.gz
     size: 255918080
-    sha384: 7792544648d3ed72378345ea41c609b246ed5eabff366e01b693c35feef3831b7b0ac2839f18fa001b1d6983f7cb93fe
+    checksum: 7792544648d3ed72378345ea41c609b246ed5eabff366e01b693c35feef3831b7b0ac2839f18fa001b1d6983f7cb93fe
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet/ckpts/efficientnet-b5.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/efficientnet-b7-pytorch/model.yml
+++ b/models/public/efficientnet-b7-pytorch/model.yml
@@ -30,27 +30,27 @@ task_type: classification
 files:
   - name: model/gen_efficientnet.py
     size: 40997
-    sha384: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
+    checksum: b2868eed99002c95a8f54b0f20a975486d47dd0a4d8fda2fbeed68e0f83330b4617d6a09d60a08eaaf660f490a5906a9
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/gen_efficientnet.py
   - name: model/efficientnet_builder.py
     size: 18446
-    sha384: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
+    checksum: 5dbc9484139e3f23504508b63416a10251590c0f84e056e78830351d104a67f215fd6e180d7f22d20ad1eadd803c8bd6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/efficientnet_builder.py
   - name: model/helpers.py
     size: 1097
-    sha384: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
+    checksum: b1adc8c85422236df810c36de5333bd80f516f948be894633448ea9f12c098aba61be8bb6663cdedb0bd545b6ae986a6
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/helpers.py
   - name: model/conv2d_helpers.py
     size: 6175
-    sha384: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
+    checksum: cac2642f90d160a9f338bc83c423fd9cfa044a27f74c97726dc70b86adca7b6db32041676c64954ecac7acd5240975de
     source: https://raw.githubusercontent.com/rwightman/gen-efficientnet-pytorch/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/conv2d_helpers.py
   - name: model/__init__.py
     size: 32
-    sha384: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
+    checksum: 56056cd865f696313e48aa09cc4d6dd334dd5aa71ba9495bdc443ac209c42485d864c31c216ee3befd8dd03e723c2113
     source: https://github.com/rwightman/gen-efficientnet-pytorch/raw/a36e2b2cd1bd122a508a6fffeaa7606890f8c882/gen_efficientnet/__init__.py
   - name: tf-efficientnet-b7.pth
     size: 266843942
-    sha384: 56fd1ed71e016e7dabac6b92882a4e12a16640da790442d5f16923dd39eee124fdeca396d4e422cb8c3a0cecc8aba814
+    checksum: 56fd1ed71e016e7dabac6b92882a4e12a16640da790442d5f16923dd39eee124fdeca396d4e422cb8c3a0cecc8aba814
     source: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_aa-076e3472.pth
 postprocessing:
   - $type: regex_replace

--- a/models/public/efficientnet-b7_auto_aug/model.yml
+++ b/models/public/efficientnet-b7_auto_aug/model.yml
@@ -23,7 +23,7 @@ task_type: classification
 files:
   - name: efficientnet-b7.tar.gz
     size: 492077218
-    sha384: 43ab0eb7f7bfd1f50610996608668de6b502ada5846698bdcacc0c0e22025f01958e278774c4f2eaddcab1a6355c71ea
+    checksum: 43ab0eb7f7bfd1f50610996608668de6b502ada5846698bdcacc0c0e22025f01958e278774c4f2eaddcab1a6355c71ea
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/efficientnet/ckptsaug/efficientnet-b7.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/f3net/model.yml
+++ b/models/public/f3net/model.yml
@@ -19,15 +19,15 @@ task_type: salient_object_detection
 files:
   - name: f3net/net.py
     size: 8656
-    sha384: 17947bb60281d99ed16a5f646d0476a1fb439e21c70a8efbdd12151aad271599e4951bff546a89ac5fddf5058af7d6cb
+    checksum: 17947bb60281d99ed16a5f646d0476a1fb439e21c70a8efbdd12151aad271599e4951bff546a89ac5fddf5058af7d6cb
     source: https://raw.githubusercontent.com/weijun88/F3Net/eecace3adf1e8946b571a4f4397681252f9dc1b8/src/net.py
   - name: f3net/dataset.py
     size: 4497
-    sha384: 0a741a171f3faf065af323de147165bee85f627e572aad00529cfcddcf26c34b212e223c0da3d8d45ffa760c79ba4712
+    checksum: 0a741a171f3faf065af323de147165bee85f627e572aad00529cfcddcf26c34b212e223c0da3d8d45ffa760c79ba4712
     source: https://raw.githubusercontent.com/weijun88/F3Net/eecace3adf1e8946b571a4f4397681252f9dc1b8/src/dataset.py
   - name: f3net/model-32
     size: 102506472
-    sha384: 6476078ef447502af76f214b96161f6295662ccef6d412aec90d0aca03fc5d7759fdd880c9ddec146e656114805acfc2
+    checksum: 6476078ef447502af76f214b96161f6295662ccef6d412aec90d0aca03fc5d7759fdd880c9ddec146e656114805acfc2
     source:
       $type: google_drive
       id: 1jcsmxZHL6DGwDplLp93H4VeN2ZjqBsOF

--- a/models/public/face-detection-retail-0044/model.yml
+++ b/models/public/face-detection-retail-0044/model.yml
@@ -21,11 +21,11 @@ task_type: detection
 files:
   - name: face-detection-retail-0044.prototxt
     size: 27995
-    sha384: 308dd708e34a0993fdd2d41781c360972e12e5560f2e58fe67172a187df74fa072986142d7faeec7058d024d28f5c43a
+    checksum: 308dd708e34a0993fdd2d41781c360972e12e5560f2e58fe67172a187df74fa072986142d7faeec7058d024d28f5c43a
     source: https://raw.githubusercontent.com/opencv/training_toolbox_caffe/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/deploy.prototxt
   - name: face-detection-retail-0044.caffemodel
     size: 2410177
-    sha384: a86e975a6cad2ca8d0a28d8e9492cffbf45e3a9210baa456761e0c4708f09c024ac6c5f174c190e86b31a8bef77932fc
+    checksum: a86e975a6cad2ca8d0a28d8e9492cffbf45e3a9210baa456761e0c4708f09c024ac6c5f174c190e86b31a8bef77932fc
     source: https://github.com/opencv/training_toolbox_caffe/raw/63ccbbc328f0c1f414f459c284293b3929b09339/models/face_detection/face-detection-retail-0044.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,300,300]

--- a/models/public/face-recognition-resnet100-arcface-onnx/model.yml
+++ b/models/public/face-recognition-resnet100-arcface-onnx/model.yml
@@ -23,7 +23,7 @@ task_type: face_recognition
 files:
   - name: arcfaceresnet100-8.onnx
     size: 261036388
-    sha384: 4bceb34ee96c7c0b544012be53870d757f332d9d2972962065618de6942cf60f63b94f702f85fcc31844b21de326ec72
+    checksum: 4bceb34ee96c7c0b544012be53870d757f332d9d2972962065618de6942cf60f63b94f702f85fcc31844b21de326ec72
     source: https://media.githubusercontent.com/media/onnx/models/bb0d4cf3d4e2a5f7376c13a08d337e86296edbe8/vision/body_analysis/arcface/model/arcfaceresnet100-8.onnx
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/faceboxes-pytorch/model.yml
+++ b/models/public/faceboxes-pytorch/model.yml
@@ -19,11 +19,11 @@ task_type: detection
 files:
   - name: faceboxes.py
     size: 4999
-    sha384: 8ccecee302e753231d12db65c8bf8f872561b9f1fd2879dca6078ed04ec144fcd792b4ea507381b24b0fe620e684a0f6
+    checksum: 8ccecee302e753231d12db65c8bf8f872561b9f1fd2879dca6078ed04ec144fcd792b4ea507381b24b0fe620e684a0f6
     source: https://raw.githubusercontent.com/zisianw/FaceBoxes.PyTorch/ab8478c22627690899114950cae27f8093424c95/models/faceboxes.py
   - name: FaceBoxesProd.pth
     size: 4072492
-    sha384: 1277eb9bc0e94639b88be1a6455f80a7feeaeec2fed6bb979bf721004d5de5ff43b93c3c4f7d76f8e4f188301ae0a103
+    checksum: 1277eb9bc0e94639b88be1a6455f80a7feeaeec2fed6bb979bf721004d5de5ff43b93c3c4f7d76f8e4f188301ae0a103
     source:
       $type: google_drive
       id: 1tRVwOlu0QtjvADQ2H7vqrRwsWEmaqioI

--- a/models/public/facenet-20180408-102900/model.yml
+++ b/models/public/facenet-20180408-102900/model.yml
@@ -19,7 +19,7 @@ task_type: face_recognition
 files:
   - name: 20180408-102900.zip
     size: 195479980
-    sha384: f394011bacf7b191bdc7fd0157a0f6cb5a34c46d1cae2074ff3e8e9917f3eef79a6eeaed5d25395cf2dcad9854b7f8ee
+    checksum: f394011bacf7b191bdc7fd0157a0f6cb5a34c46d1cae2074ff3e8e9917f3eef79a6eeaed5d25395cf2dcad9854b7f8ee
     source:
       $type: google_drive
       id: 1R77HmFADxe87GmoLwzfgMu_HY0IhcyBz

--- a/models/public/fast-neural-style-mosaic-onnx/model.yml
+++ b/models/public/fast-neural-style-mosaic-onnx/model.yml
@@ -21,7 +21,7 @@ description: >-
 task_type: "style_transfer"
 files:
   - name: fast-neural-style-mosaic-onnx.onnx
-    sha384: 3333259b6f7014ecdcc6be4863322988935e23c9ae6bf9668aa6208a5991d2c603cd342881bab0a064f365e929eeb4d4
+    checksum: 3333259b6f7014ecdcc6be4863322988935e23c9ae6bf9668aa6208a5991d2c603cd342881bab0a064f365e929eeb4d4
     source: https://media.githubusercontent.com/media/onnx/models/111fab38a5757c8fc8db0aa13e73fb330e516c42/vision/style_transfer/fast_neural_style/model/mosaic-9.onnx
     size: 6728029
 model_optimizer_args:

--- a/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/model.yml
+++ b/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: faster_rcnn_inception_resnet_v2_atrous_coco_2018_01_28.tar.gz
     size: 672221478
-    sha384: 4b44a30cd9b989bc1c0d2f247977389a7daab590a0154b333d80a23fafa9570de6a4bc38226ee67c5cdd5549d8ea96d5
+    checksum: 4b44a30cd9b989bc1c0d2f247977389a7daab590a0154b333d80a23fafa9570de6a4bc38226ee67c5cdd5549d8ea96d5
     source: http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_resnet_v2_atrous_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/faster_rcnn_inception_v2_coco/model.yml
+++ b/models/public/faster_rcnn_inception_v2_coco/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: faster_rcnn_inception_v2_coco.tar.gz
     size: 149119618
-    sha384: d140529e5782595943a6910e5a918ecd6b9871dc615a37545db5dcfe6c304636ee2dc62e60a806c5c06028602dc1203a
+    checksum: d140529e5782595943a6910e5a918ecd6b9871dc615a37545db5dcfe6c304636ee2dc62e60a806c5c06028602dc1203a
     source: http://download.tensorflow.org/models/object_detection/faster_rcnn_inception_v2_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/faster_rcnn_resnet101_coco/model.yml
+++ b/models/public/faster_rcnn_resnet101_coco/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: faster_rcnn_resnet101_coco.tar.gz
     size: 593445323
-    sha384: d39799f52422740e78f66b9f8df2c360b232fb39a1d895d89dbebf71c4a9e65369b8d42f52e442552f13d11fe23ca758
+    checksum: d39799f52422740e78f66b9f8df2c360b232fb39a1d895d89dbebf71c4a9e65369b8d42f52e442552f13d11fe23ca758
     source: http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet101_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/faster_rcnn_resnet50_coco/model.yml
+++ b/models/public/faster_rcnn_resnet50_coco/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: faster_rcnn_resnet50_coco_2018_01_28.tar.gz
     size: 381355771
-    sha384: 905eb0e51f1894a02bb8391ed436601450df67e092a9aaee72fc3868d556bbf7410af97a18a06223b389bb818e489999
+    checksum: 905eb0e51f1894a02bb8391ed436601450df67e092a9aaee72fc3868d556bbf7410af97a18a06223b389bb818e489999
     source: http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/fastseg-large/model.yml
+++ b/models/public/fastseg-large/model.yml
@@ -25,31 +25,31 @@ task_type: semantic_segmentation
 files:
   - name: mobilev3large-lraspp-f128-9cbabfde.pt
     size: 26476800
-    sha384: f30098181481da6b3c4b2bc59896986e905e75768f5f454515dfd2a36433f11d292e503b1c9d0a7b05a8cfdcc2d58a3f
+    checksum: f30098181481da6b3c4b2bc59896986e905e75768f5f454515dfd2a36433f11d292e503b1c9d0a7b05a8cfdcc2d58a3f
     source: https://github.com/ekzhang/fastseg/releases/download/v0.1-weights/mobilev3large-lraspp-f128-9cbabfde.pt
   - name: model/geffnet-1.0.0-py3-none-any.whl
     size: 39902
-    sha384: 5f52af3fe57f79f9b24198fea8a8beddd1f53f6333feb2beeb8616abdad2b753dd26c8b1af97be5eee04970ded28e299
+    checksum: 5f52af3fe57f79f9b24198fea8a8beddd1f53f6333feb2beeb8616abdad2b753dd26c8b1af97be5eee04970ded28e299
     source: https://files.pythonhosted.org/packages/52/a2/d3f39e1e8c7f9717dd3195811b33238211b65e67c577abe23db49fecc654/geffnet-1.0.0-py3-none-any.whl
   - name: model/fastseg/model/mobilenetv3.py
     size: 4106
-    sha384: ba0d92274dabf4372ee7ce523abe2d634525cc9863b81ddc0c7bb880f91552dbeca9b27001fa814effbab88e83a2677e
+    checksum: ba0d92274dabf4372ee7ce523abe2d634525cc9863b81ddc0c7bb880f91552dbeca9b27001fa814effbab88e83a2677e
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/mobilenetv3.py
   - name: model/fastseg/model/lraspp.py
     size: 4882
-    sha384: f2a9f10e7bf348690cb35a087fb255b6b822eb639b4fb4ad0ebab717efe4f4f423e10542a9fe6c48dd7c403ad54c059f
+    checksum: f2a9f10e7bf348690cb35a087fb255b6b822eb639b4fb4ad0ebab717efe4f4f423e10542a9fe6c48dd7c403ad54c059f
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/lraspp.py
   - name: model/fastseg/model/utils.py
     size: 1792
-    sha384: df493f8e69a576a1ba4e428e56b0893418ee37bf09baade5186a202ff6f4e757879a2fbfb1275da90fec970f84369108
+    checksum: df493f8e69a576a1ba4e428e56b0893418ee37bf09baade5186a202ff6f4e757879a2fbfb1275da90fec970f84369108
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/utils.py
   - name: model/fastseg/model/base.py
     size: 4236
-    sha384: b0c919107bb436150b428977dd5ba1b8b1c1d5a76913a2be77cb6387796ae9f09f5f3801a2c587af08dc1e64a9d9f20d
+    checksum: b0c919107bb436150b428977dd5ba1b8b1c1d5a76913a2be77cb6387796ae9f09f5f3801a2c587af08dc1e64a9d9f20d
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/base.py
   - name: model/fastseg/__init__.py
     size: 55
-    sha384: 365d191d43379f5b4b0de21b466743c22eb385b00f4156404396f58905f9ec479250bd5f01fa1a927a2d1f997d5d2251
+    checksum: 365d191d43379f5b4b0de21b466743c22eb385b00f4156404396f58905f9ec479250bd5f01fa1a927a2d1f997d5d2251
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/__init__.py
 postprocessing:
   - $type: unpack_archive

--- a/models/public/fastseg-small/model.yml
+++ b/models/public/fastseg-small/model.yml
@@ -25,31 +25,31 @@ task_type: semantic_segmentation
 files:
   - name: mobilev3small-lraspp-f128-a39a1e4b.pt
     size: 9256712
-    sha384: 2620fcf3ffeea09ea5bc1a50f3ccbae8a15aa22bcdaca02aa7c581fa1d6a1fef7ef43732b5baf58ec30c25df8ec042c8
+    checksum: 2620fcf3ffeea09ea5bc1a50f3ccbae8a15aa22bcdaca02aa7c581fa1d6a1fef7ef43732b5baf58ec30c25df8ec042c8
     source: 'https://github.com/ekzhang/fastseg/releases/download/v0.1-weights/mobilev3small-lraspp-f128-a39a1e4b.pt'
   - name: model/geffnet-1.0.0-py3-none-any.whl
     size: 39902
-    sha384: 5f52af3fe57f79f9b24198fea8a8beddd1f53f6333feb2beeb8616abdad2b753dd26c8b1af97be5eee04970ded28e299
+    checksum: 5f52af3fe57f79f9b24198fea8a8beddd1f53f6333feb2beeb8616abdad2b753dd26c8b1af97be5eee04970ded28e299
     source: https://files.pythonhosted.org/packages/52/a2/d3f39e1e8c7f9717dd3195811b33238211b65e67c577abe23db49fecc654/geffnet-1.0.0-py3-none-any.whl
   - name: model/fastseg/model/mobilenetv3.py
     size: 4106
-    sha384: ba0d92274dabf4372ee7ce523abe2d634525cc9863b81ddc0c7bb880f91552dbeca9b27001fa814effbab88e83a2677e
+    checksum: ba0d92274dabf4372ee7ce523abe2d634525cc9863b81ddc0c7bb880f91552dbeca9b27001fa814effbab88e83a2677e
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/mobilenetv3.py
   - name: model/fastseg/model/lraspp.py
     size: 4882
-    sha384: f2a9f10e7bf348690cb35a087fb255b6b822eb639b4fb4ad0ebab717efe4f4f423e10542a9fe6c48dd7c403ad54c059f
+    checksum: f2a9f10e7bf348690cb35a087fb255b6b822eb639b4fb4ad0ebab717efe4f4f423e10542a9fe6c48dd7c403ad54c059f
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/lraspp.py
   - name: model/fastseg/model/utils.py
     size: 1792
-    sha384: df493f8e69a576a1ba4e428e56b0893418ee37bf09baade5186a202ff6f4e757879a2fbfb1275da90fec970f84369108
+    checksum: df493f8e69a576a1ba4e428e56b0893418ee37bf09baade5186a202ff6f4e757879a2fbfb1275da90fec970f84369108
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/utils.py
   - name: model/fastseg/model/base.py
     size: 4236
-    sha384: b0c919107bb436150b428977dd5ba1b8b1c1d5a76913a2be77cb6387796ae9f09f5f3801a2c587af08dc1e64a9d9f20d
+    checksum: b0c919107bb436150b428977dd5ba1b8b1c1d5a76913a2be77cb6387796ae9f09f5f3801a2c587af08dc1e64a9d9f20d
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/model/base.py
   - name: model/fastseg/__init__.py
     size: 55
-    sha384: 365d191d43379f5b4b0de21b466743c22eb385b00f4156404396f58905f9ec479250bd5f01fa1a927a2d1f997d5d2251
+    checksum: 365d191d43379f5b4b0de21b466743c22eb385b00f4156404396f58905f9ec479250bd5f01fa1a927a2d1f997d5d2251
     source: https://raw.githubusercontent.com/ekzhang/fastseg/91238cdf2251a82f3fe4d35e28873cf84f602c0a/fastseg/__init__.py
 postprocessing:
   - $type: unpack_archive

--- a/models/public/fbcnn/model.yml
+++ b/models/public/fbcnn/model.yml
@@ -23,11 +23,11 @@ task_type: image_processing
 files:
   - name: net.py
     size: 14063
-    sha384: 993649cebed4f249b35f92a64d797916bba297e6ff58c1f0081402d6c61cf63b661a3388f67c74eafc6ca9e587bd5b5b
+    checksum: 993649cebed4f249b35f92a64d797916bba297e6ff58c1f0081402d6c61cf63b661a3388f67c74eafc6ca9e587bd5b5b
     source: https://raw.githubusercontent.com/jiaxi-jiang/FBCNN/f599bc58e1e2ebe1ab473350ce3c887f491143e1/models/network_fbcnn.py
   - name: ckpt/fbcnn_color.pth
     size: 287755111
-    sha384: 11610eb602aa0b3f53568d572fadff03be04854dbc952d49a9b24d4edcba1eb42475b31c1496d669e0b549c431379128
+    checksum: 11610eb602aa0b3f53568d572fadff03be04854dbc952d49a9b24d4edcba1eb42475b31c1496d669e0b549c431379128
     source: https://github.com/jiaxi-jiang/FBCNN/releases/download/v1.0/fbcnn_color.pth
 postprocessing:
   - $type: regex_replace

--- a/models/public/fcrn-dp-nyu-depth-v2-tf/model.yml
+++ b/models/public/fcrn-dp-nyu-depth-v2-tf/model.yml
@@ -24,7 +24,7 @@ framework: tf
 files:
   - name: NYU_FCRN-checkpoint.zip
     size: 472588519
-    sha384: a7e281b3c8ed500f6d3d759febbb3c5a72ae66a8b432ca4e68b45d4defed0f9ca1f3606cbc34a136203283b9a5370122
+    checksum: a7e281b3c8ed500f6d3d759febbb3c5a72ae66a8b432ca4e68b45d4defed0f9ca1f3606cbc34a136203283b9a5370122
     source: http://campar.in.tum.de/files/rupprecht/depthpred/NYU_FCRN-checkpoint.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/forward-tacotron/forward-tacotron-duration-prediction/model.yml
+++ b/models/public/forward-tacotron/forward-tacotron-duration-prediction/model.yml
@@ -18,7 +18,7 @@ task_type: text_to_speech
 files:
   - name: forward-tacotron-duration-prediction.zip
     size: 54840281
-    sha384: abaa75849759d344010c2e549b140b22241e6c4f72fcf482ad3f47f84b5b992c8d622d95312f3b0a34db67744981f7f2
+    checksum: abaa75849759d344010c2e549b140b22241e6c4f72fcf482ad3f47f84b5b992c8d622d95312f3b0a34db67744981f7f2
     source: https://download.01.org/opencv/public_models/102020/forward-tacotron/forward-tacotron-duration-prediction.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/forward-tacotron/forward-tacotron-regression/model.yml
+++ b/models/public/forward-tacotron/forward-tacotron-regression/model.yml
@@ -18,7 +18,7 @@ task_type: text_to_speech
 files:
   - name: forward-tacotron-regression.zip
     size: 29948456
-    sha384: c58dc63650b2f1b45a30891ff2669cf205f7b5fbafff65a4a2a37ddebb2ba4521110dabf27752121ce3ef8369439004e
+    checksum: c58dc63650b2f1b45a30891ff2669cf205f7b5fbafff65a4a2a37ddebb2ba4521110dabf27752121ce3ef8369439004e
     source: https://download.01.org/opencv/public_models/102020/forward-tacotron/forward-tacotron-regression.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/gmcnn-places2-tf/model.yml
+++ b/models/public/gmcnn-places2-tf/model.yml
@@ -22,7 +22,7 @@ task_type: image_inpainting
 files:
   - name: gmcnn-places2-tf.zip
     size: 46187310
-    sha384: 35fbd27cfab9f23fe0e5cf87cce3bb6b200af657f3a21054f0d430b1a2b430a004a128a9acd19e0ee3bb6983d48cbbba
+    checksum: 35fbd27cfab9f23fe0e5cf87cce3bb6b200af657f3a21054f0d430b1a2b430a004a128a9acd19e0ee3bb6983d48cbbba
     source: https://download.01.org/opencv/public_models/092020/gmcnn-places2-tf/gmcnn-places2-tf.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/googlenet-v1-tf/model.yml
+++ b/models/public/googlenet-v1-tf/model.yml
@@ -21,27 +21,27 @@ task_type: classification
 files:
   - name: inception_v1_2016_08_28.tar.gz
     size: 24642554
-    sha384: d5e2af5f481cb99256ebf66e24b96cafa39a9d4088b63975ed108264596af3a49f927fb79419e068db95ee20504bf692
+    checksum: d5e2af5f481cb99256ebf66e24b96cafa39a9d4088b63975ed108264596af3a49f927fb79419e068db95ee20504bf692
     source: http://download.tensorflow.org/models/inception_v1_2016_08_28.tar.gz
   - name: models/research/slim/nets/inception.py
     size: 1676
-    sha384: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
+    checksum: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception.py
   - name: models/research/slim/nets/inception_utils.py
     size: 3079
-    sha384: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
+    checksum: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_utils.py
   - name: models/research/slim/nets/inception_v1.py
     size: 16875
-    sha384: 3532f7cf94cf0ea7de26972c3117d01eb939b13220413112c7e2766fc67ea94e7b6d0a9380ff80062b9ea9c856c74564
+    checksum: 3532f7cf94cf0ea7de26972c3117d01eb939b13220413112c7e2766fc67ea94e7b6d0a9380ff80062b9ea9c856c74564
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_v1.py
   - name: models/research/slim/nets/nets_factory.py
     size: 7253
-    sha384: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
+    checksum: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/nets_factory.py
   - name: models/research/slim/tf_slim-1.1.0-py2.py3-none-any.whl
     size: 352133
-    sha384: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
+    checksum: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
     source: https://files.pythonhosted.org/packages/02/97/b0f4a64df018ca018cc035d44f2ef08f91e2e8aa67271f6f19633a015ff7/tf_slim-1.1.0-py2.py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/googlenet-v1/model.yml
+++ b/models/public/googlenet-v1/model.yml
@@ -28,11 +28,11 @@ task_type: classification
 files:
   - name: googlenet-v1.prototxt
     size: 35862
-    sha384: 762e0669b2b1974cf5b544edb9dcf4e98203d35cdbb3f9f28363993712dece4b8d72def02b5b36c098a5a23b40f2c275
+    checksum: 762e0669b2b1974cf5b544edb9dcf4e98203d35cdbb3f9f28363993712dece4b8d72def02b5b36c098a5a23b40f2c275
     source: https://raw.githubusercontent.com/BVLC/caffe/88c96189bcbf3853b93e2b65c7b5e4948f9d5f67/models/bvlc_googlenet/deploy.prototxt
   - name: googlenet-v1.caffemodel
     size: 53533754
-    sha384: c95413cd55c390f439ccc9842ec5953b31f85090d5f262e3093e38c78f378acdfb069fa28da2f49dbb8b9e5c8a816276
+    checksum: c95413cd55c390f439ccc9842ec5953b31f85090d5f262e3093e38c78f378acdfb069fa28da2f49dbb8b9e5c8a816276
     source: http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/googlenet-v2-tf/model.yml
+++ b/models/public/googlenet-v2-tf/model.yml
@@ -21,27 +21,27 @@ task_type: classification
 files:
   - name: inception_v2_2016_08_28.tar.gz
     size: 41577079
-    sha384: c0b2efbae8fc5e237ae67637dca3f311d4b4f7da576b56067e83d95c398a2fccd50baff9cc0de64335f4d7b78e1adb07
+    checksum: c0b2efbae8fc5e237ae67637dca3f311d4b4f7da576b56067e83d95c398a2fccd50baff9cc0de64335f4d7b78e1adb07
     source: http://download.tensorflow.org/models/inception_v2_2016_08_28.tar.gz
   - name: models/research/slim/nets/inception.py
     size: 1676
-    sha384: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
+    checksum: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception.py
   - name: models/research/slim/nets/inception_utils.py
     size: 3079
-    sha384: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
+    checksum: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_utils.py
   - name: models/research/slim/nets/inception_v2.py
     size: 26623
-    sha384: 9f49cd1c9ff2590538018887502ad4c3b2b5e32b75dc5723a34db0262e1da2a6a3385d5e75f7533e7453bb3e6c2dde44
+    checksum: 9f49cd1c9ff2590538018887502ad4c3b2b5e32b75dc5723a34db0262e1da2a6a3385d5e75f7533e7453bb3e6c2dde44
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_v2.py
   - name: models/research/slim/nets/nets_factory.py
     size: 7253
-    sha384: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
+    checksum: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/nets_factory.py
   - name: models/research/slim/tf_slim-1.1.0-py2.py3-none-any.whl
     size: 352133
-    sha384: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
+    checksum: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
     source: https://files.pythonhosted.org/packages/02/97/b0f4a64df018ca018cc035d44f2ef08f91e2e8aa67271f6f19633a015ff7/tf_slim-1.1.0-py2.py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/googlenet-v2/model.yml
+++ b/models/public/googlenet-v2/model.yml
@@ -28,11 +28,11 @@ task_type: classification
 files:
   - name: googlenet-v2.prototxt
     size: 60274
-    sha384: 47eca6e38cc06c3313ce9f1361abdc6e5f0344e6becdc22f367147a6ba7783cab9858bc70b5e4807974fac96531bcbc3
+    checksum: 47eca6e38cc06c3313ce9f1361abdc6e5f0344e6becdc22f367147a6ba7783cab9858bc70b5e4807974fac96531bcbc3
     source: https://raw.githubusercontent.com/lim0606/caffe-googlenet-bn/d19caf526b7d8cad873ff91ba4cea602eadd58b3/deploy.prototxt
   - name: googlenet-v2.caffemodel
     size: 64445495
-    sha384: f3357581220899740821f9f2bfe8e68915df06204bcf14fb7e27c81f16879698b6c36fae937ead32d216a6744b0f1aa9
+    checksum: f3357581220899740821f9f2bfe8e68915df06204bcf14fb7e27c81f16879698b6c36fae937ead32d216a6744b0f1aa9
     source: https://github.com/lim0606/caffe-googlenet-bn/raw/d19caf526b7d8cad873ff91ba4cea602eadd58b3/snapshots/googlenet_bn_stepsize_6400_iter_1200000.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/googlenet-v3-pytorch/model.yml
+++ b/models/public/googlenet-v3-pytorch/model.yml
@@ -26,7 +26,7 @@ description: >-
 task_type: classification
 files:
   - name: inception_v3_google-1a9a5a14.pth
-    sha384: 6e4a35647ef131a8e109fd922ac16216a324a73b77429cf8af2b8e4ddb05ef50a529e9407f9eb1b59b24e5e9ad22c3e5
+    checksum: 6e4a35647ef131a8e109fd922ac16216a324a73b77429cf8af2b8e4ddb05ef50a529e9407f9eb1b59b24e5e9ad22c3e5
     size: 108857766
     source: https://download.pytorch.org/models/inception_v3_google-1a9a5a14.pth
 framework: pytorch

--- a/models/public/googlenet-v3/model.yml
+++ b/models/public/googlenet-v3/model.yml
@@ -20,7 +20,7 @@ task_type: classification
 files:
   - name: googlenet-v3.tar.gz
     size: 88668554
-    sha384: 5438688088e7610248f3bf09c36bb9225ca85efd5df11ed16c8ba446ced39ee5602bb2e84b077f9fb4d044ff18181e34
+    checksum: 5438688088e7610248f3bf09c36bb9225ca85efd5df11ed16c8ba446ced39ee5602bb2e84b077f9fb4d044ff18181e34
     source: https://storage.googleapis.com/download.tensorflow.org/models/inception_v3_2016_08_28_frozen.pb.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/googlenet-v4-tf/model.yml
+++ b/models/public/googlenet-v4-tf/model.yml
@@ -22,27 +22,27 @@ task_type: classification
 files:
   - name: inception_v4_2016_09_09.tar.gz
     size: 171177982
-    sha384: 97765872563bf059728f96faa4aef86fa20ffe10c099f7bc2990adacc9a41a73549c45e939441a7e4f1dc2f45127a2d2
+    checksum: 97765872563bf059728f96faa4aef86fa20ffe10c099f7bc2990adacc9a41a73549c45e939441a7e4f1dc2f45127a2d2
     source: http://download.tensorflow.org/models/inception_v4_2016_09_09.tar.gz
   - name: models/research/slim/nets/inception.py
     size: 1676
-    sha384: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
+    checksum: 1500832b0ca4ea2a8e70b7f865bc154162a01a496fb9d654d680bfe27bcc83c8c7140f60e1f2484904d1945d5906370b
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception.py
   - name: models/research/slim/nets/inception_utils.py
     size: 3079
-    sha384: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
+    checksum: 6b903694f0763da63a8108e8ffb8d26a7cc25c8b5f2a4a6ed21372ed2e5ffe19238d1107820ee941dfd97b05dd369a28
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_utils.py
   - name: models/research/slim/nets/inception_v4.py
     size: 16519
-    sha384: b4fa85412733b0800914ce2af14b9b3b340b9982fc1f491ba124d1b18d47751bf22e38cf8f902115ae6aca192028d7a6
+    checksum: b4fa85412733b0800914ce2af14b9b3b340b9982fc1f491ba124d1b18d47751bf22e38cf8f902115ae6aca192028d7a6
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/inception_v4.py
   - name: models/research/slim/nets/nets_factory.py
     size: 7253
-    sha384: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
+    checksum: 4941e0ba7991b80a03b7a8aedcf7d954e0b692e3c53cec2a4d06c0a7d576f704f0d7668d0cccb3d55567bc860c024ab6
     source: https://github.com/tensorflow/models/raw/d4a6670ade6ebd007b7974f85d70c4c879ba99d6/research/slim/nets/nets_factory.py
   - name: models/research/slim/tf_slim-1.1.0-py2.py3-none-any.whl
     size: 352133
-    sha384: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
+    checksum: eac0abda0ef71025cc4785a2b24cdb8a7ec9479b97ce12334e27711f92f2a2407945308ce3d5d2b0b1b0daa6212ee02f
     source: https://files.pythonhosted.org/packages/02/97/b0f4a64df018ca018cc035d44f2ef08f91e2e8aa67271f6f19633a015ff7/tf_slim-1.1.0-py2.py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/gpt-2/model.yml
+++ b/models/public/gpt-2/model.yml
@@ -27,27 +27,27 @@ task_type: text_prediction
 files:
   - name: transformers-4.9.1-py3-none-any.whl
     size: 2586799
-    sha384: 6bafef459543eba13c7952082bfe89e4b969fc5a8e0524d0c7f659845bd3449586f13102e06cec85906be40d6a76a7c2
+    checksum: 6bafef459543eba13c7952082bfe89e4b969fc5a8e0524d0c7f659845bd3449586f13102e06cec85906be40d6a76a7c2
     source: https://files.pythonhosted.org/packages/38/39/5238c128cef0f4405c568b1e8c9c7423202109dcbb1622333918d8de1cd3/transformers-4.9.1-py3-none-any.whl
   - name: gpt2/pytorch_model.bin
     size: 548118077
-    sha384: da7d73f86e4aaa2ea10ae5cca81af55f1914ad27a65127a8fe171c30fda2addb035bb81e02855c9ff7e4c0c411330d3d
+    checksum: da7d73f86e4aaa2ea10ae5cca81af55f1914ad27a65127a8fe171c30fda2addb035bb81e02855c9ff7e4c0c411330d3d
     source: https://huggingface.co/gpt2/resolve/main/pytorch_model.bin
   - name: gpt2/config.json
     size: 665
-    sha384: 7a725057662831dd8db64fa85aa42426d26a667f2357546bb674388f5598ee5169f653429aff8a2e48819dc251f7648f
+    checksum: 7a725057662831dd8db64fa85aa42426d26a667f2357546bb674388f5598ee5169f653429aff8a2e48819dc251f7648f
     source: https://huggingface.co/gpt2/resolve/main/config.json
   - name: gpt2/vocab.json
     size: 1042301
-    sha384: 43e578a41ade90c90c71fdc4bfc1457c2e288c0450b872f3fb4a27e9521cadcf881aa6f24e5fae208277d4134991c7b0
+    checksum: 43e578a41ade90c90c71fdc4bfc1457c2e288c0450b872f3fb4a27e9521cadcf881aa6f24e5fae208277d4134991c7b0
     source: https://huggingface.co/gpt2/resolve/main/vocab.json
   - name: gpt2/merges.txt
     size: 456318
-    sha384: f91aa09e8551d2e001b4d6d0bf9a350a194ffe19397b913094c5ad8da940093894fd4064fce8edde9792b3474c107038
+    checksum: f91aa09e8551d2e001b4d6d0bf9a350a194ffe19397b913094c5ad8da940093894fd4064fce8edde9792b3474c107038
     source: https://huggingface.co/gpt2/resolve/main/merges.txt
   - name: packaging-21.0-py3-none-any.whl
     size: 40357
-    sha384: 1c96c2a22c453058086c807e681af38377d9a78baeb79d9b189f82db2b04055a27b9748b7a24db9aa3e82786019c2182
+    checksum: 1c96c2a22c453058086c807e681af38377d9a78baeb79d9b189f82db2b04055a27b9748b7a24db9aa3e82786019c2182
     source: https://files.pythonhosted.org/packages/3c/77/e2362b676dc5008d81be423070dd9577fa03be5da2ba1105811900fda546/packaging-21.0-py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/hbonet-0.25/model.yml
+++ b/models/public/hbonet-0.25/model.yml
@@ -19,10 +19,10 @@ task_type: classification
 files:
   - name: hbonet.py
     size: 12548
-    sha384: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
+    checksum: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
     source: https://raw.githubusercontent.com/d-li14/HBONet/e9a76c15e3847b0f032a7000fe0c8138d6f2eb10/models/imagenet/hbonet.py
   - name: hbonet_0_25.pth
-    sha384: 836c1fe7b0e1ba55db92e7e1deb15641afac1f3ac7975d8a7bfa7bd08e407d4a7664b2eb7149553f1e241cd424adb5fc
+    checksum: 836c1fe7b0e1ba55db92e7e1deb15641afac1f3ac7975d8a7bfa7bd08e407d4a7664b2eb7149553f1e241cd424adb5fc
     size: 7863957
     source: https://raw.githubusercontent.com/d-li14/HBONet/master/pretrained/hbonet_0_25.pth
 framework: pytorch

--- a/models/public/hbonet-0.5/model.yml
+++ b/models/public/hbonet-0.5/model.yml
@@ -19,10 +19,10 @@ task_type: classification
 files:
   - name: hbonet.py
     size: 12548
-    sha384: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
+    checksum: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
     source: https://raw.githubusercontent.com/d-li14/HBONet/e9a76c15e3847b0f032a7000fe0c8138d6f2eb10/models/imagenet/hbonet.py
   - name: hbonet_0_5.pth
-    sha384: 3aeecf2621a52826a166bb9c7b0fb300964da0af407b63e3cf979e775510144fc38931fd9a08cf724fe3139fc878d4db
+    checksum: 3aeecf2621a52826a166bb9c7b0fb300964da0af407b63e3cf979e775510144fc38931fd9a08cf724fe3139fc878d4db
     size: 10307426
     source: https://raw.githubusercontent.com/d-li14/HBONet/master/pretrained/hbonet_0_5.pth
 framework: pytorch

--- a/models/public/hbonet-1.0/model.yml
+++ b/models/public/hbonet-1.0/model.yml
@@ -19,10 +19,10 @@ task_type: classification
 files:
   - name: hbonet.py
     size: 12548
-    sha384: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
+    checksum: 7b069ad80839ed050c9ce5a10d389db1bd529a74b77858648ca168976bc9736fc30715d946e54e55445a5cb23edc4342
     source: https://raw.githubusercontent.com/d-li14/HBONet/e9a76c15e3847b0f032a7000fe0c8138d6f2eb10/models/imagenet/hbonet.py
   - name: hbonet_1_0.pth
-    sha384: 27ea1715505128c6dd1cf22cc57e629b0f8c2acf7f9246894c5c003091b415e3f494cee156c7dbd330f5d6affce700ab
+    checksum: 27ea1715505128c6dd1cf22cc57e629b0f8c2acf7f9246894c5c003091b415e3f494cee156c7dbd330f5d6affce700ab
     size: 18467748
     source: https://raw.githubusercontent.com/d-li14/HBONet/master/pretrained/hbonet_1_0.pth
 framework: pytorch

--- a/models/public/higher-hrnet-w32-human-pose-estimation/model.yml
+++ b/models/public/higher-hrnet-w32-human-pose-estimation/model.yml
@@ -28,31 +28,31 @@ task_type: human_pose_estimation
 files:
   - name: models/__init__.py
     size: 412
-    sha384: fe099091a8545442577baf0886860846c2485fb991ce358e8632eeb10cc6a3827c54a64b1f0150c1fcb12ebeb103f625
+    checksum: fe099091a8545442577baf0886860846c2485fb991ce358e8632eeb10cc6a3827c54a64b1f0150c1fcb12ebeb103f625
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/lib/models/__init__.py
   - name: models/pose_higher_hrnet.py
     size: 21313
-    sha384: 2772ce487f9c3407b814e67c6b017ea107caafc23a1cb64f9b8f855239d16dbd2ad3030825e04c29ba81b8a31f80e034
+    checksum: 2772ce487f9c3407b814e67c6b017ea107caafc23a1cb64f9b8f855239d16dbd2ad3030825e04c29ba81b8a31f80e034
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/lib/models/pose_higher_hrnet.py
   - name: config/__init__.py
     size: 370
-    sha384: b1c2faece903938d66f5969981daee79fb2322c9e9998189ab92ede8e3a2c08a9b2d2c0e257e118938e5bf1c4cf7bffd
+    checksum: b1c2faece903938d66f5969981daee79fb2322c9e9998189ab92ede8e3a2c08a9b2d2c0e257e118938e5bf1c4cf7bffd
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/lib/config/__init__.py
   - name: config/default.py
     size: 6075
-    sha384: ad03d7165998982d22b8d7cdc3604f3b0bbbcebe8de4f1ff8d6897e8e297c3bffa0b83099c3ff1290407da5f29434220
+    checksum: ad03d7165998982d22b8d7cdc3604f3b0bbbcebe8de4f1ff8d6897e8e297c3bffa0b83099c3ff1290407da5f29434220
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/lib/config/default.py
   - name: config/models.py
     size: 2518
-    sha384: 2ae3fc62047e9838e8d1fbc59d2d127979f55a0672a5a2f43088447dabaa5f3d4039eb2f196c59f7f38d4e0d853ff58d
+    checksum: 2ae3fc62047e9838e8d1fbc59d2d127979f55a0672a5a2f43088447dabaa5f3d4039eb2f196c59f7f38d4e0d853ff58d
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/lib/config/models.py
   - name: experiments/higher_hrnet.yaml
     size: 2326
-    sha384: 1a8c79097c602a777ec1182a081258562844bfe98f9b4aadecbcb56e25f2f3ffed9db285121f9d819514eee4319228d4
+    checksum: 1a8c79097c602a777ec1182a081258562844bfe98f9b4aadecbcb56e25f2f3ffed9db285121f9d819514eee4319228d4
     source: https://raw.githubusercontent.com/HRNet/HigherHRNet-Human-Pose-Estimation/f97496fdaa5365ee33d44c7872da21375fb1a39c/experiments/coco/higher_hrnet/w32_512_adam_lr1e-3.yaml
   - name: ckpt/pose_higher_hrnet_w32_512.pth
     size: 115172215
-    sha384: d344fcc4e426308139397bd708be1c59500e038a540ea0979b6a10556b5f3530701d86c0cab276fc5710419f91879e3d
+    checksum: d344fcc4e426308139397bd708be1c59500e038a540ea0979b6a10556b5f3530701d86c0cab276fc5710419f91879e3d
     source:
       $type: google_drive
       id: 1V9Iz0ZYy9m8VeaspfKECDW0NKlGsYmO1

--- a/models/public/hrnet-v2-c1-segmentation/model.yml
+++ b/models/public/hrnet-v2-c1-segmentation/model.yml
@@ -25,75 +25,75 @@ task_type: semantic_segmentation
 files:
   - name: mit_semseg/lib/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/__init__.py
   - name: mit_semseg/lib/nn/__init__.py
     size: 110
-    sha384: 4050fd70a8d21b8aea922c6c0d73569cff84b28f66046ccb2113e83c8f12bf8f95db694b9a2bb42a08ad09a870dab9e7
+    checksum: 4050fd70a8d21b8aea922c6c0d73569cff84b28f66046ccb2113e83c8f12bf8f95db694b9a2bb42a08ad09a870dab9e7
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/__init__.py
   - name: mit_semseg/lib/nn/parallel/__init__.py
     size: 92
-    sha384: 7ca260234675a323f56408bea9267de912266a50093b1e0bfb189e0bfa7b5974c9fbf30df6d68e6c9277ef6c884a98eb
+    checksum: 7ca260234675a323f56408bea9267de912266a50093b1e0bfb189e0bfa7b5974c9fbf30df6d68e6c9277ef6c884a98eb
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/parallel/__init__.py
   - name: mit_semseg/lib/nn/parallel/data_parallel.py
     size: 3399
-    sha384: 410429adfdd581eecff4c6759a9fab2417812575459a06e43204fe7142347f31b0684fca9a16c112eeb399840751c4e9
+    checksum: 410429adfdd581eecff4c6759a9fab2417812575459a06e43204fe7142347f31b0684fca9a16c112eeb399840751c4e9
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/parallel/data_parallel.py
   - name: mit_semseg/lib/nn/modules/batchnorm.py
     size: 13813
-    sha384: 74a7edde7fabc84ce35f54b723010c5240e39182fa992b709cff57222b4c93eb191f736f225323cce18947b88b0a9039
+    checksum: 74a7edde7fabc84ce35f54b723010c5240e39182fa992b709cff57222b4c93eb191f736f225323cce18947b88b0a9039
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/modules/batchnorm.py
   - name: mit_semseg/lib/nn/modules/comm.py
     size: 4278
-    sha384: 6d6bee53d49e2c8c1e6b41f4c66d4cb71aaffcd0b7ba1772822c555f5820138a50d3381186ea96098b7149606582eaaa
+    checksum: 6d6bee53d49e2c8c1e6b41f4c66d4cb71aaffcd0b7ba1772822c555f5820138a50d3381186ea96098b7149606582eaaa
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/modules/comm.py
   - name: mit_semseg/lib/nn/modules/__init__.py
     size: 449
-    sha384: d206b7e26cd614aaea3b7fe4112b1d58a638c9ae71d4de479563f6fc60072899275b52454aa95875e65c039ebe97e51c
+    checksum: d206b7e26cd614aaea3b7fe4112b1d58a638c9ae71d4de479563f6fc60072899275b52454aa95875e65c039ebe97e51c
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/modules/__init__.py
   - name: mit_semseg/lib/nn/modules/replicate.py
     size: 3226
-    sha384: 9f662572ba39a396b98116ee8a4fe1b08fb5905fb2ba88cef3965a0827f6917409e7f25a5d1dcbf06acc986acea87d56
+    checksum: 9f662572ba39a396b98116ee8a4fe1b08fb5905fb2ba88cef3965a0827f6917409e7f25a5d1dcbf06acc986acea87d56
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/lib/nn/modules/replicate.py
   - name: mit_semseg/models/__init__.py
     size: 53
-    sha384: 072644401a4048275a5d5a6ee354254b648a30ff3ad4a5e9c08f69bc75ef304f634d0346ce6389459969f993f63ca291
+    checksum: 072644401a4048275a5d5a6ee354254b648a30ff3ad4a5e9c08f69bc75ef304f634d0346ce6389459969f993f63ca291
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/__init__.py
   - name: mit_semseg/models/hrnet.py
     size: 16811
-    sha384: 5399e58e38d4547dd44b37f36dce7acfe8a1eec323b0a64c58b94bc89164e7803b57feb0b218150811a099aa33f57f14
+    checksum: 5399e58e38d4547dd44b37f36dce7acfe8a1eec323b0a64c58b94bc89164e7803b57feb0b218150811a099aa33f57f14
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/hrnet.py
   - name: mit_semseg/models/mobilenet.py
     size: 4938
-    sha384: cc215b3f04289d458cc59a4be74cbb4fbe225dce8069dad35bae8953ca39fd4319e540050eae4f0fccebf572fd832ead
+    checksum: cc215b3f04289d458cc59a4be74cbb4fbe225dce8069dad35bae8953ca39fd4319e540050eae4f0fccebf572fd832ead
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/mobilenet.py
   - name: mit_semseg/models/models.py
     size: 21185
-    sha384: 3f2710e28e9169a69aa553220c18038bda7ea4509114bae0b27e326680effe61c154fa47f86604a59e2f85a639644511
+    checksum: 3f2710e28e9169a69aa553220c18038bda7ea4509114bae0b27e326680effe61c154fa47f86604a59e2f85a639644511
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/models.py
   - name: mit_semseg/models/resnet.py
     size: 6770
-    sha384: d1eb13b7aa05bbba2ef6b91094c183a6dbaca1a2df6ec1a93a6aae4015c63d086ba931f3670de1422ac0855f2f4047b7
+    checksum: d1eb13b7aa05bbba2ef6b91094c183a6dbaca1a2df6ec1a93a6aae4015c63d086ba931f3670de1422ac0855f2f4047b7
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/resnet.py
   - name: mit_semseg/models/resnext.py
     size: 5367
-    sha384: a4a6aa9c445c4e111a565456633e41946085e7dee4e16eb83389e6bf47e3d556d0b864921b9ce3759ece267d345ae91e
+    checksum: a4a6aa9c445c4e111a565456633e41946085e7dee4e16eb83389e6bf47e3d556d0b864921b9ce3759ece267d345ae91e
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/resnext.py
   - name: mit_semseg/models/utils.py
     size: 577
-    sha384: 966c87730a8883fa54adcd1b3147c9ddd4e5a1a8aca51213e58029bf1dfba19ee976d67b93ae8ff7acb1e4d6f4e6b906
+    checksum: 966c87730a8883fa54adcd1b3147c9ddd4e5a1a8aca51213e58029bf1dfba19ee976d67b93ae8ff7acb1e4d6f4e6b906
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/models/utils.py
   - name: mit_semseg/__init__.py
     size: 63
-    sha384: 6d7e00aba39cfd252198183cfcd63a51afb6bf841abb5d60b14316aa0ca7138f4c2e340480d30f2175a21c7b485db85f
+    checksum: 6d7e00aba39cfd252198183cfcd63a51afb6bf841abb5d60b14316aa0ca7138f4c2e340480d30f2175a21c7b485db85f
     source: https://raw.githubusercontent.com/CSAILVision/semantic-segmentation-pytorch/9aff40de31ee4b21f18514d31e5d6e4ba056924d/mit_semseg/__init__.py
   - name: ckpt/decoder_epoch_30.pth
     size: 4780389
-    sha384: 943a8e1974c5f678fec59b3eb5d5859c9c95f82be607f10aac5261730d2e813274440b177970fb55a08f29f2bc5bdf89
+    checksum: 943a8e1974c5f678fec59b3eb5d5859c9c95f82be607f10aac5261730d2e813274440b177970fb55a08f29f2bc5bdf89
     source: http://sceneparsing.csail.mit.edu/model/pytorch/ade20k-hrnetv2-c1/decoder_epoch_30.pth
   - name: ckpt/encoder_epoch_30.pth
     size: 262518297
-    sha384: e01539688455d218c189c41381f58e2d1e6383d7dad057cc921cada06fb3c0f014f6f72e7a44e4a082356d98417fddfb
+    checksum: e01539688455d218c189c41381f58e2d1e6383d7dad057cc921cada06fb3c0f014f6f72e7a44e4a082356d98417fddfb
     source: http://sceneparsing.csail.mit.edu/model/pytorch/ade20k-hrnetv2-c1/encoder_epoch_30.pth
 conversion_to_onnx_args:
   - --model-path=$config_dir

--- a/models/public/human-pose-estimation-3d-0001/model.yml
+++ b/models/public/human-pose-estimation-3d-0001/model.yml
@@ -19,7 +19,7 @@ description: >-
 task_type: human_pose_estimation
 files:
   - name: human-pose-estimation-3d-0001.tar.gz
-    sha384: 14d1b70eb2d4102969b29c7716cbcdf9d1acd35839e044d2e62d69fbce4b98aa06cb954bb703d411cf991ffd809c6ea9
+    checksum: 14d1b70eb2d4102969b29c7716cbcdf9d1acd35839e044d2e62d69fbce4b98aa06cb954bb703d411cf991ffd809c6ea9
     size: 18421831
     source: https://download.01.org/opencv/openvino_training_extensions/models/human_pose_estimation/human-pose-estimation-3d.tar.gz
 postprocessing:

--- a/models/public/hybrid-cs-model-mri/model.yml
+++ b/models/public/hybrid-cs-model-mri/model.yml
@@ -24,15 +24,15 @@ description: >-
 task_type: image_inpainting
 files:
   - name: wnet_20.hdf5
-    sha384: d52fc1fd1d698443041db4837551c787a0fd3da78d76b3ab1d6794b47a1da1f6ce8edb6014b4a52f1453f85cef48c2e9
+    checksum: d52fc1fd1d698443041db4837551c787a0fd3da78d76b3ab1d6794b47a1da1f6ce8edb6014b4a52f1453f85cef48c2e9
     size: 45478680
     source: https://raw.githubusercontent.com/rmsouza01/Hybrid-CS-Model-MRI/2ede2f96161ce70dcdc922371fe6b6b254aafcc8/Models/wnet_20.hdf5
   - name: stats_fs_unet_norm_20.npy
-    sha384: acf3e20ce39e94588981cbd7b6d9a642216c3ac2f689bb2a17a73819a3d2058705de6456d1a78d24df8dcb8fafab1f31
+    checksum: acf3e20ce39e94588981cbd7b6d9a642216c3ac2f689bb2a17a73819a3d2058705de6456d1a78d24df8dcb8fafab1f31
     size: 160
     source: https://raw.githubusercontent.com/rmsouza01/Hybrid-CS-Model-MRI/2ede2f96161ce70dcdc922371fe6b6b254aafcc8/Data/stats_fs_unet_norm_20.npy
   - name: frequency_spatial_network.py
-    sha384: 6b2b2542144617e3787ae6e3d1298a04b7171add0afe6fe2490bcb0a42a7af8a952454246071eb589f98ebfbad89cf88
+    checksum: 6b2b2542144617e3787ae6e3d1298a04b7171add0afe6fe2490bcb0a42a7af8a952454246071eb589f98ebfbad89cf88
     size: 9735
     source: https://raw.githubusercontent.com/rmsouza01/Hybrid-CS-Model-MRI/2ede2f96161ce70dcdc922371fe6b6b254aafcc8/Modules/frequency_spatial_network.py
 framework: tf

--- a/models/public/i3d-rgb-tf/model.yml
+++ b/models/public/i3d-rgb-tf/model.yml
@@ -23,7 +23,7 @@ description: >-
 task_type: action_recognition
 files:
   - name: i3d-rgb.frozen.pb
-    sha384: 8f1c32cc56cc1ca6880b7725430ae8ec369485e60f9bcce9724042ecb6e5bd97d25a04148c38bfde60b0ed00c918bc96
+    checksum: 8f1c32cc56cc1ca6880b7725430ae8ec369485e60f9bcce9724042ecb6e5bd97d25a04148c38bfde60b0ed00c918bc96
     size: 51046552
     source: https://download.01.org/opencv/public_models/032020/i3d-rgb/rgb.frozen.pb
 framework: tf

--- a/models/public/inception-resnet-v2-tf/model.yml
+++ b/models/public/inception-resnet-v2-tf/model.yml
@@ -20,7 +20,7 @@ task_type: classification
 files:
   - name: inception_resnet_v2_2018_04_27.tgz
     size: 225882079
-    sha384: 865828b072abc3b5e9d55d7949d39f8df59453f4673de0745182ea5c2489b1901f74e9288863052a2d4249a814952b07
+    checksum: 865828b072abc3b5e9d55d7949d39f8df59453f4673de0745182ea5c2489b1901f74e9288863052a2d4249a814952b07
     source: https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_resnet_v2_2018_04_27.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/license-plate-recognition-barrier-0007/model.yml
+++ b/models/public/license-plate-recognition-barrier-0007/model.yml
@@ -19,7 +19,7 @@ task_type: optical_character_recognition
 files:
   - name: license-plate-recognition-barrier-0007.tar.gz
     size: 20821887
-    sha384: cc57198a711592c865333bc6b86402a9b225e6e83470415b71ff8f91d6fe3e1c24e0ccc7f7758b4fdbd48fef3e0a0bcc
+    checksum: cc57198a711592c865333bc6b86402a9b225e6e83470415b71ff8f91d6fe3e1c24e0ccc7f7758b4fdbd48fef3e0a0bcc
     source: https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/lpr/chinese_lp/license-plate-recognition-barrier-0007.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/model.yml
+++ b/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/model.yml
@@ -20,7 +20,7 @@ task_type: instance_segmentation
 files:
   - name: mask_rcnn_inception_resnet_v2_atrous_coco_2018_01_28.tar.gz
     size: 727390102
-    sha384: fe7871a3b291e30b299b859ffddc2b73f25890c259aedcd5bde6fb6dd6b5507a24e7d370365e3bdd3497f1786a0f4d36
+    checksum: fe7871a3b291e30b299b859ffddc2b73f25890c259aedcd5bde6fb6dd6b5507a24e7d370365e3bdd3497f1786a0f4d36
     source: http://download.tensorflow.org/models/object_detection/mask_rcnn_inception_resnet_v2_atrous_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mask_rcnn_inception_v2_coco/model.yml
+++ b/models/public/mask_rcnn_inception_v2_coco/model.yml
@@ -20,7 +20,7 @@ task_type: instance_segmentation
 files:
   - name: mask_rcnn_inception_v2_coco_2018_01_28.tar.gz
     size: 177817887
-    sha384: 37702fbafdb4fcf37df60c9dde834dd2bb602cbe11e87b7bd83a0a1cabc23035703bddf086e42dc32866102d06b7f13d
+    checksum: 37702fbafdb4fcf37df60c9dde834dd2bb602cbe11e87b7bd83a0a1cabc23035703bddf086e42dc32866102d06b7f13d
     source: http://download.tensorflow.org/models/object_detection/mask_rcnn_inception_v2_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mask_rcnn_resnet101_atrous_coco/model.yml
+++ b/models/public/mask_rcnn_resnet101_atrous_coco/model.yml
@@ -19,7 +19,7 @@ task_type: instance_segmentation
 files:
   - name: mask_rcnn_resnet101_atrous_coco_2018_01_28.tar.gz
     size: 661899639
-    sha384: f8124e219d2a7bb92a8d8227ac23f2555cf1fc5f4fa268e6d16c8409b436e6dd97ee78bfcc137c723f43638b7c6efc18
+    checksum: f8124e219d2a7bb92a8d8227ac23f2555cf1fc5f4fa268e6d16c8409b436e6dd97ee78bfcc137c723f43638b7c6efc18
     source: http://download.tensorflow.org/models/object_detection/mask_rcnn_resnet101_atrous_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mask_rcnn_resnet50_atrous_coco/model.yml
+++ b/models/public/mask_rcnn_resnet50_atrous_coco/model.yml
@@ -20,7 +20,7 @@ task_type: instance_segmentation
 files:
   - name: mask_rcnn_resnet50_atrous_coco_2018_01_28.tar.gz
     size: 449505463
-    sha384: a61ae308c03f9b9554851f5d564b3cc09659a2d8d2a4dd2f4e57be92669fe4bdc9c505839eaa075b44926466e4073299
+    checksum: a61ae308c03f9b9554851f5d564b3cc09659a2d8d2a4dd2f4e57be92669fe4bdc9c505839eaa075b44926466e4073299
     source: http://download.tensorflow.org/models/object_detection/mask_rcnn_resnet50_atrous_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/midasnet/model.yml
+++ b/models/public/midasnet/model.yml
@@ -26,19 +26,19 @@ task_type: monocular_depth_estimation
 files:
   - name: models/midas_net.py
     size: 2662
-    sha384: ad8d94e07cfb60e463f383057763a0faa29e7547fe3b4482c787a5948050f37f0878c6f307d455f6759928237e43b78c
+    checksum: ad8d94e07cfb60e463f383057763a0faa29e7547fe3b4482c787a5948050f37f0878c6f307d455f6759928237e43b78c
     source: https://raw.githubusercontent.com/intel-isl/MiDaS/ffb70fd13361434114383ce7eb898c2f5bec6176/models/midas_net.py
   - name: models/base_model.py
     size: 355
-    sha384: cf959343ae280093bb38eb225f4d3b1de791ef7e245c35f02315bd984065379e7a29b5830010aad34d3ac38ca77bfa04
+    checksum: cf959343ae280093bb38eb225f4d3b1de791ef7e245c35f02315bd984065379e7a29b5830010aad34d3ac38ca77bfa04
     source: https://raw.githubusercontent.com/intel-isl/MiDaS/ffb70fd13361434114383ce7eb898c2f5bec6176/models/base_model.py
   - name: models/blocks.py
     size: 3596
-    sha384: 3bca3aadb2e7fc5990e4d909740e2c8c6cbedd326fc49ea858e06ebe97269d6410d2f28e0cec3ca2b5b466928c84fa2e
+    checksum: 3bca3aadb2e7fc5990e4d909740e2c8c6cbedd326fc49ea858e06ebe97269d6410d2f28e0cec3ca2b5b466928c84fa2e
     source: https://raw.githubusercontent.com/intel-isl/MiDaS/ffb70fd13361434114383ce7eb898c2f5bec6176/models/blocks.py
   - name: model.pt
     size: 422509849
-    sha384: 22219f664a4b235e797585d56a398c25e7cbb3cdb46f61bdc0e0596dc713495ece860ac57df8b22f7b530ea00c21b049
+    checksum: 22219f664a4b235e797585d56a398c25e7cbb3cdb46f61bdc0e0596dc713495ece860ac57df8b22f7b530ea00c21b049
     source: https://github.com/intel-isl/MiDaS/releases/download/v2_1/model-openvino.pt
 framework: pytorch
 postprocessing:

--- a/models/public/mixnet-l/model.yml
+++ b/models/public/mixnet-l/model.yml
@@ -26,7 +26,7 @@ task_type: classification
 files:
   - name: mixnet-l.tar.gz
     size: 54302843
-    sha384: 6207ab87851c7e2c8f3dafe716a596b2f52dd88c6c5db0d51795e312f3cad62c715a35c1f03311084f43566660ac691b
+    checksum: 6207ab87851c7e2c8f3dafe716a596b2f52dd88c6c5db0d51795e312f3cad62c715a35c1f03311084f43566660ac691b
     source: https://storage.googleapis.com/cloud-tpu-checkpoints/mixnet/mixnet-l.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilefacedet-v1-mxnet/model.yml
+++ b/models/public/mobilefacedet-v1-mxnet/model.yml
@@ -20,11 +20,11 @@ task_type: detection
 files:
   - name: mobilefacedet_v1_mxnet-symbol.json
     size: 143406
-    sha384: 010114c232811b4d79cad6535ce0688a412950cc0f65788b212487ec125f8657e2aeccc51245cbcee994ed09deea4d1e
+    checksum: 010114c232811b4d79cad6535ce0688a412950cc0f65788b212487ec125f8657e2aeccc51245cbcee994ed09deea4d1e
     source: https://raw.githubusercontent.com/becauseofAI/MobileFace/128cea33b928dc9bb6d1963202b57a97f5661ccf/MobileFace_Detection/model/mobilefacedet_v1_mxnet-symbol.json
   - name: mobilefacedet_v1_mxnet-0000.params
     size: 31229887
-    sha384: 729fd402458eb997c47b1f1fdada9c3f056bfc146df5be147854bd6241fc3c99980a162297633fd8eef2a43db76e64dd
+    checksum: 729fd402458eb997c47b1f1fdada9c3f056bfc146df5be147854bd6241fc3c99980a162297633fd8eef2a43db76e64dd
     source: https://raw.githubusercontent.com/becauseofAI/MobileFace/128cea33b928dc9bb6d1963202b57a97f5661ccf/MobileFace_Detection/model/mobilefacedet_v1_mxnet-0000.params
 model_optimizer_args:
   - --input_shape=[1,256,256,3]

--- a/models/public/mobilenet-ssd/model.yml
+++ b/models/public/mobilenet-ssd/model.yml
@@ -28,11 +28,11 @@ task_type: detection
 files:
   - name: mobilenet-ssd.prototxt
     size: 29353
-    sha384: 71b465ac516f06b713807b850febe933547b741be15b3382723e7d4503a4d135ce8b13376d66b3bb1e4793cdd3338742
+    checksum: 71b465ac516f06b713807b850febe933547b741be15b3382723e7d4503a4d135ce8b13376d66b3bb1e4793cdd3338742
     source: https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/ba00fc987b3eb0ba87bb99e89bf0298a2fd10765/MobileNetSSD_deploy.prototxt
   - name: mobilenet-ssd.caffemodel
     size: 23147564
-    sha384: 21726b46b567b1d81241d8378305cf32185e03e0fc71c36ca85ccf34ad76f0ec7688494172a9e39139cd04fde50643af
+    checksum: 21726b46b567b1d81241d8378305cf32185e03e0fc71c36ca85ccf34ad76f0ec7688494172a9e39139cd04fde50643af
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/mobilenet-ssd/MobileNetSSD_deploy.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,300,300]

--- a/models/public/mobilenet-v1-0.25-128/model.yml
+++ b/models/public/mobilenet-v1-0.25-128/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet_v1_0.25_128.tgz
     size: 10800019
-    sha384: 274f37d5b52f2291d78e438a9d780b19a8f379a1bb83d649c27780ce38e33365ca331405b06f103edc1852e214235169
+    checksum: 274f37d5b52f2291d78e438a9d780b19a8f379a1bb83d649c27780ce38e33365ca331405b06f103edc1852e214235169
     source: http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_0.25_128.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v1-0.50-160/model.yml
+++ b/models/public/mobilenet-v1-0.50-160/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet_v1_0.5_160.tgz
     size: 29958343
-    sha384: 7023a17e0f7dd48ffb3607ef1d7712702b1eb110d1a2c14f80bdf41b08148a07f9521a22250b5ef214b59a0bf62ef88b
+    checksum: 7023a17e0f7dd48ffb3607ef1d7712702b1eb110d1a2c14f80bdf41b08148a07f9521a22250b5ef214b59a0bf62ef88b
     source: http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_0.5_160.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v1-0.50-224/model.yml
+++ b/models/public/mobilenet-v1-0.50-224/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet_v1_0.5_224.tgz
     size: 29969407
-    sha384: 643989e61ae03d2e956a4bc222082534c44ac1bcce06450aafd5d30537dc5080fcf2f1d16a9ebbcbc613122e55759673
+    checksum: 643989e61ae03d2e956a4bc222082534c44ac1bcce06450aafd5d30537dc5080fcf2f1d16a9ebbcbc613122e55759673
     source: http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_0.5_224.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v1-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v1-1.0-224-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet_v1_1.0_224.tgz
     size: 94321559
-    sha384: 20383a8a25a1f2dc0e9b72176a5cc93f662fd513be6e7153061045a635e88dbfe7e6b72880f60a1dfbec7cdd57f91641
+    checksum: 20383a8a25a1f2dc0e9b72176a5cc93f662fd513be6e7153061045a635e88dbfe7e6b72880f60a1dfbec7cdd57f91641
     source: http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v1-1.0-224/model.yml
+++ b/models/public/mobilenet-v1-1.0-224/model.yml
@@ -22,11 +22,11 @@ task_type: classification
 files:
   - name: mobilenet-v1-1.0-224.prototxt
     size: 28105
-    sha384: 06dab8ee44af147320578ee54217e5d428b0525df8efd8d9ffb133e16822e274e1a8e257e3894a9ad23659ce56556b46
+    checksum: 06dab8ee44af147320578ee54217e5d428b0525df8efd8d9ffb133e16822e274e1a8e257e3894a9ad23659ce56556b46
     source: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_deploy.prototxt
   - name: mobilenet-v1-1.0-224.caffemodel
     size: 17027058
-    sha384: 9a7b8bed738806e9e5a330410b301f5ce105e0a51c260499f07c6740eb6fe343cdc815673f4f62f60305a72fe1a194d1
+    checksum: 9a7b8bed738806e9e5a330410b301f5ce105e0a51c260499f07c6740eb6fe343cdc815673f4f62f60305a72fe1a194d1
     source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/mobilenet-v2-1.0-224/model.yml
+++ b/models/public/mobilenet-v2-1.0-224/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet_v2_1.0_224.tgz
     size: 78306834
-    sha384: 061da971be19c9fa185be494c7cd567ac8798bd14847f80c83afd9f4ffb2096343b4f5911fa227fe659c8d6684478822
+    checksum: 061da971be19c9fa185be494c7cd567ac8798bd14847f80c83afd9f4ffb2096343b4f5911fa227fe659c8d6684478822
     source: https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.0_224.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v2-1.4-224/model.yml
+++ b/models/public/mobilenet-v2-1.4-224/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: mobilenet-v2-1.4-224.tar.gz
     size: 135977516
-    sha384: fd257f73e8ee5280328903afa6bbd646dcf4e8ae7c090e3424cf05d973c0940fe02ee220a3a5a20ea51cb9caacbf4961
+    checksum: fd257f73e8ee5280328903afa6bbd646dcf4e8ae7c090e3424cf05d973c0940fe02ee220a3a5a20ea51cb9caacbf4961
     source: https://storage.googleapis.com/mobilenet_v2/checkpoints/mobilenet_v2_1.4_224.tgz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mobilenet-v2-pytorch/model.yml
+++ b/models/public/mobilenet-v2-pytorch/model.yml
@@ -27,7 +27,7 @@ task_type: classification
 files:
   - name: mobilenet_v2-b0353104.pth
     size: 14212972
-    sha384: ca1be3e2eb8015c2876bfa6da5f35c9db9e2167281f972adfef6de332688d11ebe649f646e88f7410d8694e554a27613
+    checksum: ca1be3e2eb8015c2876bfa6da5f35c9db9e2167281f972adfef6de332688d11ebe649f646e88f7410d8694e554a27613
     source: https://download.pytorch.org/models/mobilenet_v2-b0353104.pth
 framework: pytorch
 conversion_to_onnx_args:

--- a/models/public/mobilenet-v2/model.yml
+++ b/models/public/mobilenet-v2/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: mobilenet-v2.prototxt
     size: 51551
-    sha384: 62accf1c3389d496848ffac2fa0544f5c1311dcf5e16dba596ed517fb8e2175055f77100e64cb08314df2750e2461041
+    checksum: 62accf1c3389d496848ffac2fa0544f5c1311dcf5e16dba596ed517fb8e2175055f77100e64cb08314df2750e2461041
     source: https://raw.githubusercontent.com/shicai/MobileNet-Caffe/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2_deploy.prototxt
   - name: mobilenet-v2.caffemodel
     size: 14186496
-    sha384: da548763d0f93c8c0ac2187ae23c217038afb5ede540e4bc1853e9c806c2b5be16b8b5fadca292976c104e3e21ea00ba
+    checksum: da548763d0f93c8c0ac2187ae23c217038afb5ede540e4bc1853e9c806c2b5be16b8b5fadca292976c104e3e21ea00ba
     source: https://github.com/shicai/MobileNet-Caffe/raw/26a8b8c0afb6114a07c1c9e4f550e4e0dd8cced1/mobilenet_v2.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: weights_mobilenet_v3_large_224_1.0_float.h5
     size: 22661472
-    sha384: 4e7e0ecab69b15ecde1e3f4c494826cece07169bdc14d7da29eb07bef718c32f532d952d0b3113ffaca95c2d6d9577b5
+    checksum: 4e7e0ecab69b15ecde1e3f4c494826cece07169bdc14d7da29eb07bef718c32f532d952d0b3113ffaca95c2d6d9577b5
     source: https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v3/weights_mobilenet_v3_large_224_1.0_float.h5
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/mobilenet-v3-small-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v3-small-1.0-224-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: weights_mobilenet_v3_small_224_1.0_float.h5
     size: 10734624
-    sha384: d342c446ceecbcf76edf94f7a51bb94d26296fea8d91e0b28287143eff569118c98a950df3258f37a94c06f0adc4d31b
+    checksum: d342c446ceecbcf76edf94f7a51bb94d26296fea8d91e0b28287143eff569118c98a950df3258f37a94c06f0adc4d31b
     source: https://storage.googleapis.com/tensorflow/keras-applications/mobilenet_v3/weights_mobilenet_v3_small_224_1.0_float.h5
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/mobilenet-yolo-v4-syg/model.yml
+++ b/models/public/mobilenet-yolo-v4-syg/model.yml
@@ -21,11 +21,11 @@ task_type: detection
 files:
   - name: mobilenet-yolo-v4-syg.pb
     size: 42004202
-    sha384: 8f931bc5bc0adcfaaaa2ddbad8c13838725fe61bfef24ff5ff23ad9268b392c40b3ecb2bbe736152060c7014ced80e6b
+    checksum: 8f931bc5bc0adcfaaaa2ddbad8c13838725fe61bfef24ff5ff23ad9268b392c40b3ecb2bbe736152060c7014ced80e6b
     source: https://github.com/legendary111/mobilenet-yolo-v4-syg/releases/download/files/mobilenet-yolo-v4-syg.pb
   - name: yolo_pb2ir.json
     size: 414
-    sha384: 2c5236e29566a0d198e972630941840a98f2fcedce6d39b05dc61980166c29a7da9b55883c5dc8b568d682529c18430f
+    checksum: 2c5236e29566a0d198e972630941840a98f2fcedce6d39b05dc61980166c29a7da9b55883c5dc8b568d682529c18430f
     source: https://github.com/legendary111/mobilenet-yolo-syg/releases/download/mobilenet-yolo-v4-syg/yolo_pb2ir.json
 model_optimizer_args:
   - --input_model=$dl_dir/mobilenet-yolo-v4-syg.pb

--- a/models/public/mozilla-deepspeech-0.6.1/model.yml
+++ b/models/public/mozilla-deepspeech-0.6.1/model.yml
@@ -24,7 +24,7 @@ task_type: speech_recognition
 files:
   - name: deepspeech-0.6.1-models.tar.gz
     size: 1229020343
-    sha384: ad9ceb672c21ccb93f6c16432c172d1d08e403a9925a9466552538de9642878af7c459c863bbe721483f644385c5677d
+    checksum: ad9ceb672c21ccb93f6c16432c172d1d08e403a9925a9466552538de9642878af7c459c863bbe721483f644385c5677d
     source: https://github.com/mozilla/DeepSpeech/releases/download/v0.6.1/deepspeech-0.6.1-models.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/mozilla-deepspeech-0.8.2/model.yml
+++ b/models/public/mozilla-deepspeech-0.8.2/model.yml
@@ -24,11 +24,11 @@ task_type: speech_recognition
 files:
   - name: deepspeech-0.8.2-models.pbmm
     size: 188915984
-    sha384: 5ab0759fcace311c36c5322321463ad171458102230df4db83435c1c337f3c7deeba1344057cc9d158e23dd42268b298
+    checksum: 5ab0759fcace311c36c5322321463ad171458102230df4db83435c1c337f3c7deeba1344057cc9d158e23dd42268b298
     source: https://github.com/mozilla/DeepSpeech/releases/download/v0.8.2/deepspeech-0.8.2-models.pbmm
   - name: deepspeech-0.8.2-models.scorer
     size: 953363776
-    sha384: 2694ef52d092ab7ddf9f913a8cf2f6b958a0ae38790080a37eb3be3453961ecc96d225095d3ae505e22dd6ba41fd27d5
+    checksum: 2694ef52d092ab7ddf9f913a8cf2f6b958a0ae38790080a37eb3be3453961ecc96d225095d3ae505e22dd6ba41fd27d5
     source: https://github.com/mozilla/DeepSpeech/releases/download/v0.8.2/deepspeech-0.8.2-models.scorer
 model_optimizer_args:
   - --input_model=$conv_dir/deepspeech-0.8.2-models.pb

--- a/models/public/mtcnn/mtcnn-o/model.yml
+++ b/models/public/mtcnn/mtcnn-o/model.yml
@@ -31,11 +31,11 @@ task_type: detection
 files:
   - name: mtcnn-o.prototxt
     size: 3931
-    sha384: 403ad213827dfb0b6201ae3de7cc160be2f4d6ca59de0dbad7147d2cca1077f26ae38ba239bc8a2023cffbb0b90925b7
+    checksum: 403ad213827dfb0b6201ae3de7cc160be2f4d6ca59de0dbad7147d2cca1077f26ae38ba239bc8a2023cffbb0b90925b7
     source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.prototxt
   - name: mtcnn-o.caffemodel
     size: 1558412
-    sha384: 77bb0c7ec10017793e903e73a70b33b3f9e9bb36569c39e87eec0b8ac7ff58ec7a4ed813822467dceb8549cb1e3c03e0
+    checksum: 77bb0c7ec10017793e903e73a70b33b3f9e9bb36569c39e87eec0b8ac7ff58ec7a4ed813822467dceb8549cb1e3c03e0
     source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det3.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,48,48]

--- a/models/public/mtcnn/mtcnn-p/model.yml
+++ b/models/public/mtcnn/mtcnn-p/model.yml
@@ -31,11 +31,11 @@ task_type: detection
 files:
   - name: mtcnn-p.prototxt
     size: 2353
-    sha384: 372af5af8ba5c1820b587b64670ef957e40c5118f7775381d46e4eb88ec8f9cadb7abdeadfa3863459e17bf7b87318fd
+    checksum: 372af5af8ba5c1820b587b64670ef957e40c5118f7775381d46e4eb88ec8f9cadb7abdeadfa3863459e17bf7b87318fd
     source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.prototxt
   - name: mtcnn-p.caffemodel
     size: 28163
-    sha384: abf640a47ec5b87724564741121a235581dd15f3782cf0b9380acfa45ef665974b97d8e8122114a66d9973696ae3b35e
+    checksum: abf640a47ec5b87724564741121a235581dd15f3782cf0b9380acfa45ef665974b97d8e8122114a66d9973696ae3b35e
     source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det1.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/mtcnn/mtcnn-r/model.yml
+++ b/models/public/mtcnn/mtcnn-r/model.yml
@@ -32,11 +32,11 @@ task_type: detection
 files:
   - name: mtcnn-r.prototxt
     size: 3159
-    sha384: c75ed855e1129678d3947455ebf78c4ffa8f8757dac72eda0987650bb7c447b3a8462d797b7916f45b847d9d37040d26
+    checksum: c75ed855e1129678d3947455ebf78c4ffa8f8757dac72eda0987650bb7c447b3a8462d797b7916f45b847d9d37040d26
     source: https://raw.githubusercontent.com/DuinoDu/mtcnn/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.prototxt
   - name: mtcnn-r.caffemodel
     size: 407910
-    sha384: 87b9a7262724688cb5825e2584b623110b1df2e44308abe5be1800cbcd7a37940e44547466cd016ce9141733b62fbd8f
+    checksum: 87b9a7262724688cb5825e2584b623110b1df2e44308abe5be1800cbcd7a37940e44547466cd016ce9141733b62fbd8f
     source: https://github.com/DuinoDu/mtcnn/raw/db5bd8f02023f8d37913140fd2bf2749c2dbf266/model/det2.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,24,24]

--- a/models/public/netvlad-tf/model.yml
+++ b/models/public/netvlad-tf/model.yml
@@ -25,15 +25,15 @@ task_type: place_recognition
 files:
   - name: netvlad.zip
     size: 1108966217
-    sha384: 2aacb2110402ee5c2c1dd5ccfdade0ca3da8df94d1f5eb5441d929beb031877909a399cb7268fef95fd1a8f251ccbd85
+    checksum: 2aacb2110402ee5c2c1dd5ccfdade0ca3da8df94d1f5eb5441d929beb031877909a399cb7268fef95fd1a8f251ccbd85
     source: http://rpg.ifi.uzh.ch/datasets/netvlad/vd16_pitts30k_conv5_3_vlad_preL2_intra_white.zip
   - name: netvlad_tf/layers.py
     size: 1492
-    sha384: 0cc24ff1de4a28c5d0c93da0958043145583d2ff9dc2e0209cf405d8d033dc95ad2caa071a2b1e0e1461946480ef31ab
+    checksum: 0cc24ff1de4a28c5d0c93da0958043145583d2ff9dc2e0209cf405d8d033dc95ad2caa071a2b1e0e1461946480ef31ab
     source: https://github.com/uzh-rpg/netvlad_tf_open/raw/abe37fe9d656bf781cff32caf738efca525b7889/python/netvlad_tf/layers.py
   - name: netvlad_tf/nets.py
     size: 2613
-    sha384: 01d2aade49c07a389e3f906c7157a5bbe7c1c7685873e81dbdc7ef5d1a44c796dfc7d53808ae05445ae9d0529f70e9ef
+    checksum: 01d2aade49c07a389e3f906c7157a5bbe7c1c7685873e81dbdc7ef5d1a44c796dfc7d53808ae05445ae9d0529f70e9ef
     source: https://github.com/uzh-rpg/netvlad_tf_open/raw/abe37fe9d656bf781cff32caf738efca525b7889/python/netvlad_tf/nets.py
 postprocessing:
   - $type: unpack_archive

--- a/models/public/nfnet-f0/model.yml
+++ b/models/public/nfnet-f0/model.yml
@@ -34,11 +34,11 @@ task_type: classification
 files:
   - name: timm-0.4.5-py3-none-any.whl
     size: 287415
-    sha384: 0956e380ed9d2a00697bbb8bba8c2c741dd426671a92de220e2e46c673ec86643071f2264b411a929578609ff1d94ad1
+    checksum: 0956e380ed9d2a00697bbb8bba8c2c741dd426671a92de220e2e46c673ec86643071f2264b411a929578609ff1d94ad1
     source: https://files.pythonhosted.org/packages/9e/89/d94f59780b5dd973154bf506d8ce598f6bfe7cc44dd445d644d6d3be8c39/timm-0.4.5-py3-none-any.whl
   - name: dm_nfnet_f0-604f9c3a.pth
     size: 285993610
-    sha384: dd903d64b8b6404e9b33b5fb664ac803916d51e1d4a03ff5c9f286084dd2240d29472e2dacff5768f731780ce2102da5
+    checksum: dd903d64b8b6404e9b33b5fb664ac803916d51e1d4a03ff5c9f286084dd2240d29472e2dacff5768f731780ce2102da5
     source: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-dnf-weights/dm_nfnet_f0-604f9c3a.pth
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-densenet-121-0.125/model.yml
+++ b/models/public/octave-densenet-121-0.125/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a01_densenet-121_alpha-0.125.tar
     size: 32983040
-    sha384: 3893ca9f4dc2d352734e1d077beaed086743a83583080668870eb4436f221a3e25175a7d7e1231e0c96814e46faa79e2
+    checksum: 3893ca9f4dc2d352734e1d077beaed086743a83583080668870eb4436f221a3e25175a7d7e1231e0c96814e46faa79e2
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a01_densenet-121_alpha-0.125.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnet-101-0.125/model.yml
+++ b/models/public/octave-resnet-101-0.125/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a06_resnet-101_alpha-0.125.tar
     size: 179302400
-    sha384: 4df4304f787888b4dcf1e56b4ef8d33cf42b0c8010c18571a915bf5847178cfa807ad8a3266938a07e450f22649dbb46
+    checksum: 4df4304f787888b4dcf1e56b4ef8d33cf42b0c8010c18571a915bf5847178cfa807ad8a3266938a07e450f22649dbb46
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a06_resnet-101_alpha-0.125.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnet-200-0.125/model.yml
+++ b/models/public/octave-resnet-200-0.125/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a08_resnet-200_alpha-0.125.tar
     size: 260812800
-    sha384: d12ff6032906d051bd2c99ca1153a9a25443a60aaa8bba35dd5a5dab09091e296a3d1fda72f2afa29ca6440a5872a20f
+    checksum: d12ff6032906d051bd2c99ca1153a9a25443a60aaa8bba35dd5a5dab09091e296a3d1fda72f2afa29ca6440a5872a20f
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a08_resnet-200_alpha-0.125.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnet-26-0.25/model.yml
+++ b/models/public/octave-resnet-26-0.25/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a02_resnet-26_alpha-0.250.tar
     size: 64256000
-    sha384: ac368af08afd64c646ad3bb467b2957b687675914c6e064b18957a2744f4a75c0ba7bc07153ec2dbc24e4c207a791fb1
+    checksum: ac368af08afd64c646ad3bb467b2957b687675914c6e064b18957a2744f4a75c0ba7bc07153ec2dbc24e4c207a791fb1
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a02_resnet-26_alpha-0.250.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnet-50-0.125/model.yml
+++ b/models/public/octave-resnet-50-0.125/model.yml
@@ -31,7 +31,7 @@ task_type: classification
 files:
   - name: a03_resnet-50_alpha-0.125.tar
     size: 102748160
-    sha384: 97066f9e044af8b58430f5eace265295515a893670ac7c6629ed7574b10589fd1b6de21155266bfa5363754325dd9ad9
+    checksum: 97066f9e044af8b58430f5eace265295515a893670ac7c6629ed7574b10589fd1b6de21155266bfa5363754325dd9ad9
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a03_resnet-50_alpha-0.125.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnext-101-0.25/model.yml
+++ b/models/public/octave-resnext-101-0.25/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a07_resnext-101_32x4d_alpha-0.250.tar
     size: 177950720
-    sha384: 1ecb5bdfbeea64b21ac17b6d7fc293a93c7096e29b403e6a3287517542c0cf8fa58bc5ad624fcb8fb36058573b4bf001
+    checksum: 1ecb5bdfbeea64b21ac17b6d7fc293a93c7096e29b403e6a3287517542c0cf8fa58bc5ad624fcb8fb36058573b4bf001
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a07_resnext-101_32x4d_alpha-0.250.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-resnext-50-0.25/model.yml
+++ b/models/public/octave-resnext-50-0.25/model.yml
@@ -30,7 +30,7 @@ task_type: classification
 files:
   - name: a04_resnext-50_32x4d_alpha-0.250.tar
     size: 100700160
-    sha384: cd7de5d38afa2e8cc6e73819f1a5fc27b9742c4e21787db5713e031e8acd7ade334011c3448693fbb8b141b2ea629ced
+    checksum: cd7de5d38afa2e8cc6e73819f1a5fc27b9742c4e21787db5713e031e8acd7ade334011c3448693fbb8b141b2ea629ced
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a04_resnext-50_32x4d_alpha-0.250.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/octave-se-resnet-50-0.125/model.yml
+++ b/models/public/octave-se-resnet-50-0.125/model.yml
@@ -31,7 +31,7 @@ task_type: classification
 files:
   - name: a05_se-resnet-50_alpha-0.125.tar
     size: 112947200
-    sha384: b255678de9198207c71f81395af431cc0f86edf3ff24b471b9a57a1121d0e048fe9a027fefed8f49343403b95c656586
+    checksum: b255678de9198207c71f81395af431cc0f86edf3ff24b471b9a57a1121d0e048fe9a027fefed8f49343403b95c656586
     source: https://dl.fbaipublicfiles.com/octconv/ablation/a05_se-resnet-50_alpha-0.125.tar
 postprocessing:
   - $type: unpack_archive

--- a/models/public/open-closed-eye-0001/model.yml
+++ b/models/public/open-closed-eye-0001/model.yml
@@ -18,7 +18,7 @@ task_type: classification
 files:
   - name: open-closed-eye.onnx
     size: 46164
-    sha384: 2615bce53b55620c629db21b043057600ccc53466f053c0a8277c43577c2db21e48f330cf9b15213016d17cddb8cba27
+    checksum: 2615bce53b55620c629db21b043057600ccc53466f053c0a8277c43577c2db21e48f330cf9b15213016d17cddb8cba27
     source: https://download.01.org/opencv/openvino_training_extensions/models/open_closed_eye/open_closed_eye.onnx
 framework: onnx
 model_optimizer_args:

--- a/models/public/pelee-coco/model.yml
+++ b/models/public/pelee-coco/model.yml
@@ -21,7 +21,7 @@ task_type: detection
 files:
   - name: pelee_coco.tar.gz
     size: 22501897
-    sha384: 40b5113a6811e6f52d91c72a1b67b7a4c3117ca22e7079d7d440308c5f1b6cd9a4a6c77ad5214a449765027e16399243
+    checksum: 40b5113a6811e6f52d91c72a1b67b7a4c3117ca22e7079d7d440308c5f1b6cd9a4a6c77ad5214a449765027e16399243
     source:
       $type: google_drive
       id: 1NXfmytr_55Njg8h6MXVflo3-tvhxYdm8

--- a/models/public/pspnet-pytorch/model.yml
+++ b/models/public/pspnet-pytorch/model.yml
@@ -23,39 +23,39 @@ task_type: semantic_segmentation
 files:
   - name: pspnet_r50-d8_512x512_20k_voc12aug_20200617_101958-ed5dfbd9.pth
     size: 196212259
-    sha384: be24b179a6b45e794a03dc153dcfa854cc9f3ee5beefad70072b47902d720d9d1d0ed6dfefb1a43412ed356e2f44fa98
+    checksum: be24b179a6b45e794a03dc153dcfa854cc9f3ee5beefad70072b47902d720d9d1d0ed6dfefb1a43412ed356e2f44fa98
     source: https://download.openmmlab.com/mmsegmentation/v0.5/pspnet/pspnet_r50-d8_512x512_20k_voc12aug/pspnet_r50-d8_512x512_20k_voc12aug_20200617_101958-ed5dfbd9.pth
   - name: models/configs/pspnet/pspnet_r50-d8_512x512_20k_voc12aug.py
     size: 263
-    sha384: 08bf47369c9070d3f8685a587801335ee894a73de38e4c71f913813ad0d4b7584528d0640e06efcf904f1b3f2cd7d223
+    checksum: 08bf47369c9070d3f8685a587801335ee894a73de38e4c71f913813ad0d4b7584528d0640e06efcf904f1b3f2cd7d223
     source: https://raw.githubusercontent.com/open-mmlab/mmsegmentation/993be2523b908d1e0cb45bc68e92d210b5b2cda1/configs/pspnet/pspnet_r50-d8_512x512_20k_voc12aug.py
   - name: models/configs/_base_/models/pspnet_r50-d8.py
     size: 1261
-    sha384: ed36f85e10894f27cd6df46fb9242467e712ecc8f3f877da55e7d145660f896588b7dcedcb88be195501cae3ea5f45d8
+    checksum: ed36f85e10894f27cd6df46fb9242467e712ecc8f3f877da55e7d145660f896588b7dcedcb88be195501cae3ea5f45d8
     source: https://raw.githubusercontent.com/open-mmlab/mmsegmentation/993be2523b908d1e0cb45bc68e92d210b5b2cda1/configs/_base_/models/pspnet_r50-d8.py
   - name: models/configs/_base_/datasets/pascal_voc12_aug.py
     size: 261
-    sha384: 722791c001f6c9f4e0ce124e7903fa69bf32ceed81f6966ecf4e50506e414f39455192e412b7489048b32ba95663a485
+    checksum: 722791c001f6c9f4e0ce124e7903fa69bf32ceed81f6966ecf4e50506e414f39455192e412b7489048b32ba95663a485
     source: https://raw.githubusercontent.com/open-mmlab/mmsegmentation/993be2523b908d1e0cb45bc68e92d210b5b2cda1/configs/_base_/datasets/pascal_voc12_aug.py
   - name: models/configs/_base_/datasets/pascal_voc12.py
     size: 1930
-    sha384: e90c60f80e0893f8362ab2ee5ec0cfe69d7e9d40475fa9c52f533990778614a8661c64777e2b213886aeea37aaf847cc
+    checksum: e90c60f80e0893f8362ab2ee5ec0cfe69d7e9d40475fa9c52f533990778614a8661c64777e2b213886aeea37aaf847cc
     source: https://raw.githubusercontent.com/open-mmlab/mmsegmentation/993be2523b908d1e0cb45bc68e92d210b5b2cda1/configs/_base_/datasets/pascal_voc12.py
   - name: models/configs/_base_/default_runtime.py
     size: 321
-    sha384: 76c434ea40497b787f1aa2cc8f2ece8da3fedd17d30e26f61baf16b8b464506c7d0e7a3d9b96a5ad16acb34749f6fd6a
+    checksum: 76c434ea40497b787f1aa2cc8f2ece8da3fedd17d30e26f61baf16b8b464506c7d0e7a3d9b96a5ad16acb34749f6fd6a
     source: https://raw.githubusercontent.com/open-mmlab/mmsegmentation/993be2523b908d1e0cb45bc68e92d210b5b2cda1/configs/_base_/default_runtime.py
   - name: models/mmsegmentation-0.11.0-py3-none-any.whl
     size: 147357
-    sha384: beddc80a37db7be119e1dc94a79c7a824ffcc01c7c5ca19712ddc3b07bc217868d97bd97c4de457ea518078a0b87774c
+    checksum: beddc80a37db7be119e1dc94a79c7a824ffcc01c7c5ca19712ddc3b07bc217868d97bd97c4de457ea518078a0b87774c
     source: https://files.pythonhosted.org/packages/b4/f9/4722a9dfc9bf2d6d6f5cabb90cd61d549ae316ccbe226fc6e245b586d5f9/mmsegmentation-0.11.0-py3-none-any.whl
   - name: models/addict-2.4.0-py3-none-any.whl
     size: 3832
-    sha384: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
+    checksum: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
     source: https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl
   - name: models/mmcv-1.2.0.tar.gz
     size: 241987
-    sha384: 23b888f6b727372b2f61047bb5b068bd1a06cef9884b7c9a5e3976e6a1b542eef4d3f37cbbbad2e0bf657f320d18a529
+    checksum: 23b888f6b727372b2f61047bb5b068bd1a06cef9884b7c9a5e3976e6a1b542eef4d3f37cbbbad2e0bf657f320d18a529
     source: https://files.pythonhosted.org/packages/d4/a0/01de45397c6222a29cf088bf54d4fb5038a4a524340eef0f923335a23116/mmcv-1.2.0.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/quartznet-15x5-en/model.yml
+++ b/models/public/quartznet-15x5-en/model.yml
@@ -23,15 +23,15 @@ task_type: speech_recognition
 files:
   - name: models/ruamel.yaml-0.17.2-py3-none-any.whl
     size: 101631
-    sha384: 1f0f8622be5cb6018836ebba71b1eb137a088ff5617f5f1013c1fa0503af0c1933410915e85c76b4a1468ae22a63a115
+    checksum: 1f0f8622be5cb6018836ebba71b1eb137a088ff5617f5f1013c1fa0503af0c1933410915e85c76b4a1468ae22a63a115
     source: https://files.pythonhosted.org/packages/82/b8/d5bc68c849d0a60b1acb3ad20fec5d23534733701f5db6b2cc029076bf72/ruamel.yaml-0.17.2-py3-none-any.whl
   - name: models/nemo_toolkit-0.11.0-py3-none-any.whl
     size: 622593
-    sha384: da6f83fce1342dac73b05b09c2590bc48ba5aa8242c9cca723f5baf19441b6052eb7b5d3c4e5c02b869d5fc097ebb4cd
+    checksum: da6f83fce1342dac73b05b09c2590bc48ba5aa8242c9cca723f5baf19441b6052eb7b5d3c4e5c02b869d5fc097ebb4cd
     source: https://files.pythonhosted.org/packages/70/68/7392874cb5fcb8a0317671a03a7b7f51cf7f2648614ef2546fc0f00726bc/nemo_toolkit-0.11.0-py3-none-any.whl
   - name: models/QuartzNet15x5-En-Base.nemo
     size: 71083664
-    sha384: 74e8284e77098906afb7a15a861ef60ec14db1a4acb206fa719492fa43050ad69a91c245652c05c5f0ded38b5903ed55
+    checksum: 74e8284e77098906afb7a15a861ef60ec14db1a4acb206fa719492fa43050ad69a91c245652c05c5f0ded38b5903ed55
     source: https://api.ngc.nvidia.com/v2/models/nvidia/multidataset_quartznet15x5/versions/2/files/QuartzNet15x5-En-Base.nemo
 postprocessing:
   - $type: unpack_archive

--- a/models/public/regnetx-3.2gf/model.yml
+++ b/models/public/regnetx-3.2gf/model.yml
@@ -23,59 +23,59 @@ task_type: classification
 files:
   - name: configs/dds_baselines/regnetx/RegNetX-3.2GF_dds_8gpu.yaml
     size: 362
-    sha384: 63516817df084ebde1d6014e60f8aa108ce6cc83254ef8984413d15d2a100de89ec1e39b09b5a67f19ea664ebdc48004
+    checksum: 63516817df084ebde1d6014e60f8aa108ce6cc83254ef8984413d15d2a100de89ec1e39b09b5a67f19ea664ebdc48004
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/configs/dds_baselines/regnetx/RegNetX-3.2GF_dds_8gpu.yaml
   - name: pycls/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/__init__.py
   - name: pycls/core/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/__init__.py
   - name: pycls/core/checkpoint.py
     size: 3497
-    sha384: 8187a1e75ec52dabdfc0d8cb823fe59e4f865e9feaf3b69975a119d72a1ea651fc3fa22fab8304c1ec6c953845595dbe
+    checksum: 8187a1e75ec52dabdfc0d8cb823fe59e4f865e9feaf3b69975a119d72a1ea651fc3fa22fab8304c1ec6c953845595dbe
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/checkpoint.py
   - name: pycls/core/net.py
     size: 3924
-    sha384: f78a59516a98467783b879601f8eec777d4f01621e5acc6b7e03c02f437b598d490df7cbe25738fe40a2ab7289ac8d56
+    checksum: f78a59516a98467783b879601f8eec777d4f01621e5acc6b7e03c02f437b598d490df7cbe25738fe40a2ab7289ac8d56
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/net.py
   - name: pycls/core/distributed.py
     size: 5410
-    sha384: cec9732ace81ccc16deca956fd5ea0eb490c32b3582ff30aa0c8a6d91ffb1167de571a375124b086ac192b28ad586aec
+    checksum: cec9732ace81ccc16deca956fd5ea0eb490c32b3582ff30aa0c8a6d91ffb1167de571a375124b086ac192b28ad586aec
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/distributed.py
   - name: pycls/core/config.py
     size: 10502
-    sha384: c1eab6f5e3bd91d38b0264cb6da2ef78f3ba0213d0716cc85982b5438f4768eb14a9bc42bfe27b255813b61957eaad2d
+    checksum: c1eab6f5e3bd91d38b0264cb6da2ef78f3ba0213d0716cc85982b5438f4768eb14a9bc42bfe27b255813b61957eaad2d
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/config.py
   - name: pycls/core/io.py
     size: 2603
-    sha384: 4a854e5a9a7e3b2bdbd84172d3a5d46c58df0a1459936997b7a49d95782d3be8afe6517b82ed1b3703200ee4e255b4df
+    checksum: 4a854e5a9a7e3b2bdbd84172d3a5d46c58df0a1459936997b7a49d95782d3be8afe6517b82ed1b3703200ee4e255b4df
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/core/io.py
   - name: pycls/models/__init__.py
     size: 317
-    sha384: ebac105e1fb95d363ea917090295ac833e46cf1a4fabb30fe9009dd569990dd40695cc4d708ea1ca56e446980bc3f5f8
+    checksum: ebac105e1fb95d363ea917090295ac833e46cf1a4fabb30fe9009dd569990dd40695cc4d708ea1ca56e446980bc3f5f8
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/models/__init__.py
   - name: pycls/models/blocks.py
     size: 6752
-    sha384: fbf2f518dde241316e3920a289a6b8a1f7796e25544342981dd2f63ef1f4217f5f93a1525e7882792ffbfb7bae317594
+    checksum: fbf2f518dde241316e3920a289a6b8a1f7796e25544342981dd2f63ef1f4217f5f93a1525e7882792ffbfb7bae317594
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/models/blocks.py
   - name: pycls/models/anynet.py
     size: 11457
-    sha384: 3be01cc1376256b9795356aa7e484b8e06673ef6ec323e7c68d9b5ca41e9ed625c549fe3b9f11af232877b86fea48e32
+    checksum: 3be01cc1376256b9795356aa7e484b8e06673ef6ec323e7c68d9b5ca41e9ed625c549fe3b9f11af232877b86fea48e32
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/models/anynet.py
   - name: pycls/models/regnet.py
     size: 2602
-    sha384: 2ffbd0689ba2efabd906f1c4685055db70e83f6f777fc3e41e2610ee625b94d99973f21a9bb865d6ef0ebb77a00ce880
+    checksum: 2ffbd0689ba2efabd906f1c4685055db70e83f6f777fc3e41e2610ee625b94d99973f21a9bb865d6ef0ebb77a00ce880
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/models/regnet.py
   - name: pycls/models/model_zoo.py
     size: 8982
-    sha384: a4529d529aeed36a2f90bb91e3e5d8ba820ba5ca6078f0188dd4c454b55e667e1fd586e4819ff8194cb2134c916d05dc
+    checksum: a4529d529aeed36a2f90bb91e3e5d8ba820ba5ca6078f0188dd4c454b55e667e1fd586e4819ff8194cb2134c916d05dc
     source: https://raw.githubusercontent.com/facebookresearch/pycls/ca89a79161e437deca8f39f31ceaef3b05873f30/pycls/models/model_zoo.py
   - name: ckpt/regnetx-3.2gf.pyth
     size: 122749825
-    sha384: 5757be265470b77fa83a26b256d7ee0f49dea765f97b1e6254e87951a2d77079f34b750a5bc4df1f156cf658bc07c6fe
+    checksum: 5757be265470b77fa83a26b256d7ee0f49dea765f97b1e6254e87951a2d77079f34b750a5bc4df1f156cf658bc07c6fe
     source: https://dl.fbaipublicfiles.com/pycls/dds_baselines/160906139/RegNetX-3.2GF_dds_8gpu.pyth
 postprocessing:
   - $type: regex_replace

--- a/models/public/repvgg-a0/model.yml
+++ b/models/public/repvgg-a0/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: repvgg.py
     size: 12745
-    sha384: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
+    checksum: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
     source: https://raw.githubusercontent.com/DingXiaoH/RepVGG/faba6fb5cbc27a3956e2e0522e27e065b824c757/repvgg.py
   - name: RepVGG-A0-train.pth
     size: 36588855
-    sha384: 7efb6b28b0376d80753c86b43687b38f2a7ae94f3ef58552b602a55767b4187dbb7b1fe8770b16133427c93e6cf137d7
+    checksum: 7efb6b28b0376d80753c86b43687b38f2a7ae94f3ef58552b602a55767b4187dbb7b1fe8770b16133427c93e6cf137d7
     source:
       $type: google_drive
       id: 13Gn8rq1PztoMEgK7rCOPMUYHjGzk-w11

--- a/models/public/repvgg-b1/model.yml
+++ b/models/public/repvgg-b1/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: repvgg.py
     size: 12745
-    sha384: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
+    checksum: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
     source: https://raw.githubusercontent.com/DingXiaoH/RepVGG/faba6fb5cbc27a3956e2e0522e27e065b824c757/repvgg.py
   - name: RepVGG-B1-train.pth
     size: 230009223
-    sha384: 23d9bea60e7bf0c184e0ec273ac228cda6ee8afcd4abe734cd1b02ca48253143000b41e299124601252a4498fe6ba379
+    checksum: 23d9bea60e7bf0c184e0ec273ac228cda6ee8afcd4abe734cd1b02ca48253143000b41e299124601252a4498fe6ba379
     source:
       $type: google_drive
       id: 1VlCfXXiaJjNjzQBy3q7C3H2JcxoL0fms

--- a/models/public/repvgg-b3/model.yml
+++ b/models/public/repvgg-b3/model.yml
@@ -32,11 +32,11 @@ task_type: classification
 files:
   - name: repvgg.py
     size: 12745
-    sha384: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
+    checksum: 3d41d82d256eb4bb8b0216e177bcf84458cf4cb0dcd15809fee1e4c30d304bce7f3136caedc717e863c7e67b97c0d87d
     source: https://raw.githubusercontent.com/DingXiaoH/RepVGG/faba6fb5cbc27a3956e2e0522e27e065b824c757/repvgg.py
   - name: RepVGG-B3-200epochs-train.pth
     size: 492817293
-    sha384: 647371bdfad380c1001d16c2dae0cd244974b11b2464933f7508c1ae3e82976eab2e0f940a5192a3a75db7363d0e8db4
+    checksum: 647371bdfad380c1001d16c2dae0cd244974b11b2464933f7508c1ae3e82976eab2e0f940a5192a3a75db7363d0e8db4
     source:
       $type: google_drive
       id: 1wBpq5317iPKk3-qblBHnx35bY_WumAlU

--- a/models/public/resnest-50-pytorch/model.yml
+++ b/models/public/resnest-50-pytorch/model.yml
@@ -28,20 +28,20 @@ description: >-
 task_type: classification
 files:
   - name: resnest50-528c19ca.pth
-    sha384: c08c80b6c826ea76eda8f638b1c06535aed947cf8ccc26c027dbda917fb1afad72191f753a7a6029d6126360973f0a06
+    checksum: c08c80b6c826ea76eda8f638b1c06535aed947cf8ccc26c027dbda917fb1afad72191f753a7a6029d6126360973f0a06
     size: 110273258
     source: https://github.com/zhanghang1989/ResNeSt/releases/download/weights_step1/resnest50-528c19ca.pth
   - name: model/resnest.py
     size: 2908
-    sha384: 00a948bbe8a8aeb671724cc2ddca21de34ede1d9908b5f22ac05681518b7f929eb89eddcd23694aaea7999a0e9808477
+    checksum: 00a948bbe8a8aeb671724cc2ddca21de34ede1d9908b5f22ac05681518b7f929eb89eddcd23694aaea7999a0e9808477
     source: https://raw.githubusercontent.com/zhanghang1989/ResNeSt/c4ea0c083fe4308eda92bd7d4140a248914bead5/resnest/torch/resnest.py
   - name: model/resnet.py
     size: 13205
-    sha384: 1191368d697bb05970ace761740bfe4e3c8b3d15ab487260f56169db7321ea8b505f33779817eb96bdb51f9c07548f0d
+    checksum: 1191368d697bb05970ace761740bfe4e3c8b3d15ab487260f56169db7321ea8b505f33779817eb96bdb51f9c07548f0d
     source: https://raw.githubusercontent.com/zhanghang1989/ResNeSt/c4ea0c083fe4308eda92bd7d4140a248914bead5/resnest/torch/resnet.py
   - name: model/splat.py
     size: 3620
-    sha384: f3fdd36cab53e2f3ff1819391246ab9738426758ee5f6af01d5e8c22a8f662a49164e738be6574a4cae03fac76d47259
+    checksum: f3fdd36cab53e2f3ff1819391246ab9738426758ee5f6af01d5e8c22a8f662a49164e738be6574a4cae03fac76d47259
     source: https://raw.githubusercontent.com/zhanghang1989/ResNeSt/c4ea0c083fe4308eda92bd7d4140a248914bead5/resnest/torch/splat.py
 framework: pytorch
 conversion_to_onnx_args:

--- a/models/public/resnet-18-pytorch/model.yml
+++ b/models/public/resnet-18-pytorch/model.yml
@@ -26,7 +26,7 @@ description: >-
 task_type: classification
 files:
   - name: resnet18-5c106cde.pth
-    sha384: 5d513c0e73ad03072938d37c0f973ef96719db2ceee80d827b89b74a30a499b1b86f0e0e47d20f3965889577c1d854dd
+    checksum: 5d513c0e73ad03072938d37c0f973ef96719db2ceee80d827b89b74a30a499b1b86f0e0e47d20f3965889577c1d854dd
     size: 46827520
     source: https://download.pytorch.org/models/resnet18-5c106cde.pth
 framework: pytorch

--- a/models/public/resnet-34-pytorch/model.yml
+++ b/models/public/resnet-34-pytorch/model.yml
@@ -26,7 +26,7 @@ description: >-
 task_type: classification
 files:
   - name: resnet34-333f7ec4.pth
-    sha384: 857b461359759d30b1eed4a5bd6e0db499b8c6e6eaff38b456ee980c834b62035c4ac53b6005ecef7150b15b23828c71
+    checksum: 857b461359759d30b1eed4a5bd6e0db499b8c6e6eaff38b456ee980c834b62035c4ac53b6005ecef7150b15b23828c71
     size: 87306240
     source: https://download.pytorch.org/models/resnet34-333f7ec4.pth
 framework: pytorch

--- a/models/public/resnet-50-caffe2/model.yml
+++ b/models/public/resnet-50-caffe2/model.yml
@@ -20,11 +20,11 @@ task_type: classification
 files:
   - name: predict_net.pb
     size: 31649
-    sha384: 5d21f314c72263f17734e0ebab5fdb0d6f0d6107a2b7ea40842193e8f1fc430db4935b3f4cfc1e26794260edb420168d
+    checksum: 5d21f314c72263f17734e0ebab5fdb0d6f0d6107a2b7ea40842193e8f1fc430db4935b3f4cfc1e26794260edb420168d
     source: https://s3.amazonaws.com/download.caffe2.ai/models/resnet50/predict_net.pb
   - name: init_net.pb
     size: 128070759
-    sha384: 3f0dff89a72b22a460fb55b3e42699f2a40e89b525a21443282532422fa7f4c7e5ae7e82761117382e01b4d8b0afce81
+    checksum: 3f0dff89a72b22a460fb55b3e42699f2a40e89b525a21443282532422fa7f4c7e5ae7e82761117382e01b4d8b0afce81
     source: https://s3.amazonaws.com/download.caffe2.ai/models/resnet50/init_net.pb
 framework: caffe2
 quantizable: yes

--- a/models/public/resnet-50-pytorch/model.yml
+++ b/models/public/resnet-50-pytorch/model.yml
@@ -26,7 +26,7 @@ description: >-
 task_type: classification
 files:
   - name: resnet50-19c8e357.pth
-    sha384: de63f5f0157c6781341f7b8e6cca587b462a0d80425b51b7a333d3f38a9be0ff198df25bf6ce107112c0136ce5b9ee50
+    checksum: de63f5f0157c6781341f7b8e6cca587b462a0d80425b51b7a333d3f38a9be0ff198df25bf6ce107112c0136ce5b9ee50
     size: 102502400
     source: https://download.pytorch.org/models/resnet50-19c8e357.pth
 framework: pytorch

--- a/models/public/resnet-50-tf/model.yml
+++ b/models/public/resnet-50-tf/model.yml
@@ -21,7 +21,7 @@ task_type: classification
 files:
   - name: resnet_v1-50.pb
     size: 102170160
-    sha384: d1097f41df917e56e927b38867bc0748a7b136b8a3441ce7d2002bbb6894b2bc167835146d0a9fc10b5c94b9d7f6f156
+    checksum: d1097f41df917e56e927b38867bc0748a7b136b8a3441ce7d2002bbb6894b2bc167835146d0a9fc10b5c94b9d7f6f156
     source: https://download.01.org/opencv/public_models/012020/resnet-50-tf/resnet_v1-50.pb
 model_optimizer_args:
   - --input_shape=[1,224,224,3]

--- a/models/public/retinaface-resnet50-pytorch/model.yml
+++ b/models/public/retinaface-resnet50-pytorch/model.yml
@@ -21,19 +21,19 @@ task_type: detection
 files:
   - name: models/retinaface.py
     size: 4865
-    sha384: def46f34640a3f597838f48a6defe1a08e2eb624251dde189cac46a3148bf9f1159bf259308fb74b0ba8a8a4f24a02e4
+    checksum: def46f34640a3f597838f48a6defe1a08e2eb624251dde189cac46a3148bf9f1159bf259308fb74b0ba8a8a4f24a02e4
     source: https://raw.githubusercontent.com/biubug6/Pytorch_Retinaface/b984b4b775b2c4dced95c1eadd195a5c7d32a60b/models/retinaface.py
   - name: models/net.py
     size: 4598
-    sha384: 6d7791ce8526ddc9068552dff37023a048ef39b25c491e67ee91b0ef780ddba86d895cf88cae5ffc4a181e4849e8383a
+    checksum: 6d7791ce8526ddc9068552dff37023a048ef39b25c491e67ee91b0ef780ddba86d895cf88cae5ffc4a181e4849e8383a
     source: https://raw.githubusercontent.com/biubug6/Pytorch_Retinaface/b984b4b775b2c4dced95c1eadd195a5c7d32a60b/models/net.py
   - name: data/config.py
     size: 928
-    sha384: 2c139b1b41adf97f09437959fdc24490c7febfa886d4eeb017e63b8f08bda0407735e54de4c8c1ce14be12a18304cd3d
+    checksum: 2c139b1b41adf97f09437959fdc24490c7febfa886d4eeb017e63b8f08bda0407735e54de4c8c1ce14be12a18304cd3d
     source: https://raw.githubusercontent.com/biubug6/Pytorch_Retinaface/b984b4b775b2c4dced95c1eadd195a5c7d32a60b/data/config.py
   - name: Resnet50_Final.pth
     size: 109497761
-    sha384: 80453e582f22ff7786b1392fb0ffb54e0e220ffb71a1381ca05de77673b0da3afeae70540076776a448b0972976c7a3c
+    checksum: 80453e582f22ff7786b1392fb0ffb54e0e220ffb71a1381ca05de77673b0da3afeae70540076776a448b0972976c7a3c
     source:
       $type: google_drive
       id: 14KX6VqF69MdSPk3Tr9PlDYbq7ArpdNUW

--- a/models/public/retinanet-tf/model.yml
+++ b/models/public/retinanet-tf/model.yml
@@ -20,7 +20,7 @@ task_type: detection
 files:
   - name: retinanet_resnet50_coco_best_v2.1.0.pb
     size: 152890076
-    sha384: 0f51df51f4a58c5e0fe65e9ed69f7bb07819e73ebf975c86783e7a176634357b15c212a839c80a31f99a751c88d21683
+    checksum: 0f51df51f4a58c5e0fe65e9ed69f7bb07819e73ebf975c86783e7a176634357b15c212a839c80a31f99a751c88d21683
     source: https://download.01.org/opencv/public_models/052020/retinanet-tf/retinanet_resnet50_coco_best_v2.1.0.pb
 model_optimizer_args:
   - --input_shape=[1,1333,1333,3]

--- a/models/public/rexnet-v1-x1.0/model.yml
+++ b/models/public/rexnet-v1-x1.0/model.yml
@@ -28,13 +28,13 @@ task_type: classification
 files:
   - name: rexnetv1_1.0x.pth
     size: 19428695
-    sha384: 5ffbf929993b597825907077194d24f9bac496d0e652d6f11a8ef75ae8e1a583c66acedf67767085dcafc437355e63be
+    checksum: 5ffbf929993b597825907077194d24f9bac496d0e652d6f11a8ef75ae8e1a583c66acedf67767085dcafc437355e63be
     source:
       $type: google_drive
       id: 1xeIJ3wb83uOowU008ykYj6wDX2dsncA9
   - name: rexnetv1.py
     size: 6335
-    sha384: e53d67fae9ac700e0d8ff412f0e2397fb9f63fd49cb6e34233f11596dee25e6911965c2988784b40f7c2ea97fd7a098c
+    checksum: e53d67fae9ac700e0d8ff412f0e2397fb9f63fd49cb6e34233f11596dee25e6911965c2988784b40f7c2ea97fd7a098c
     source: https://raw.githubusercontent.com/clovaai/rexnet/104f2184754d97b8050f24bdf39f650b3e80cad8/rexnetv1.py
 postprocessing:
   - $type: regex_replace

--- a/models/public/rfcn-resnet101-coco-tf/model.yml
+++ b/models/public/rfcn-resnet101-coco-tf/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: rfcn_resnet101_coco_2018_01_28.tar.gz
     size: 652955004
-    sha384: 23641344acd2eacc6da60af24e62271b6e3b878b8a085d25321e40b64141e295c37cd7559ff47b1695850acbb48d4a24
+    checksum: 23641344acd2eacc6da60af24e62271b6e3b878b8a085d25321e40b64141e295c37cd7559ff47b1695850acbb48d4a24
     source: http://download.tensorflow.org/models/object_detection/rfcn_resnet101_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/se-inception/model.yml
+++ b/models/public/se-inception/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-inception.prototxt
     size: 66438
-    sha384: 7c98df55b4d53dc435a792f624442b5276cb61947937775ef3ee31a8362980ebfe90af05d133511f22cf24f8a1e45963
+    checksum: 7c98df55b4d53dc435a792f624442b5276cb61947937775ef3ee31a8362980ebfe90af05d133511f22cf24f8a1e45963
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-BN-Inception.prototxt
   - name: se-inception.caffemodel
     size: 47855246
-    sha384: b5d3a92296b83cb5c706140a1d2855903906c6c2176766bdd58303643c28a6aa9950cec2f318cb4f97778705c394d5d1
+    checksum: b5d3a92296b83cb5c706140a1d2855903906c6c2176766bdd58303643c28a6aa9950cec2f318cb4f97778705c394d5d1
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-inception/SE-BN-Inception.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/se-resnet-101/model.yml
+++ b/models/public/se-resnet-101/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-resnet-101.prototxt
     size: 98677
-    sha384: c661a0960ce1fb36121ce0edd636e3fc080f973b0a5f07f72b4a9809df2c9adacad2ac04b16ab7cb2612c0875c09d8a9
+    checksum: c661a0960ce1fb36121ce0edd636e3fc080f973b0a5f07f72b4a9809df2c9adacad2ac04b16ab7cb2612c0875c09d8a9
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-101.prototxt
   - name: se-resnet-101.caffemodel
     size: 197806200
-    sha384: 76e8d87cf23deb013ba8c03c05e66919477ecd1a1bf2ebe2d43e4539947d12f4eb22593b8bc4bc3cc00e9783071a52db
+    checksum: 76e8d87cf23deb013ba8c03c05e66919477ecd1a1bf2ebe2d43e4539947d12f4eb22593b8bc4bc3cc00e9783071a52db
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-resnet-101/SE-ResNet-101.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/se-resnet-152/model.yml
+++ b/models/public/se-resnet-152/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-resnet-152.prototxt
     size: 148017
-    sha384: 5d958315940c93ef26d9902798d5e58ace08089c43e7e83e58f2e0c8ef435a2b6d1f6a13a90d9e44692ff36df611cbe1
+    checksum: 5d958315940c93ef26d9902798d5e58ace08089c43e7e83e58f2e0c8ef435a2b6d1f6a13a90d9e44692ff36df611cbe1
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-152.prototxt
   - name: se-resnet-152.caffemodel
     size: 268009578
-    sha384: 0b5a987c1f07119a50610b20405c02b83eb09db0bc86cdd63719f306717be72922c131eba1cb30ce609c9c1eeed9f55d
+    checksum: 0b5a987c1f07119a50610b20405c02b83eb09db0bc86cdd63719f306717be72922c131eba1cb30ce609c9c1eeed9f55d
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-resnet-152/SE-ResNet-152.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/se-resnet-50/model.yml
+++ b/models/public/se-resnet-50/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-resnet-50.prototxt
     size: 49272
-    sha384: 7110ff9a57008b8487f05e678ee3510bbf9b550f461f714c0a829dfb6a3503fc5935d676078d7e353668561d23ec213a
+    checksum: 7110ff9a57008b8487f05e678ee3510bbf9b550f461f714c0a829dfb6a3503fc5935d676078d7e353668561d23ec213a
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNet-50.prototxt
   - name: se-resnet-50.caffemodel
     size: 112602669
-    sha384: 3f093acba237185b50fb354e3841b4d01f50328d9f381937af5e836e808b4ce2671b0b44ca808df8911dba81a3e9d97c
+    checksum: 3f093acba237185b50fb354e3841b4d01f50328d9f381937af5e836e808b4ce2671b0b44ca808df8911dba81a3e9d97c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-resnet-50/SE-ResNet-50.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/se-resnext-101/model.yml
+++ b/models/public/se-resnext-101/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-resnext-101.prototxt
     size: 99162
-    sha384: 4b3e9c8992e2b9c5b691e32181f9c79b3e466e7322f455117d53317e5a6c422cb106a8bd6bcb0f23e928bc2135b7cf20
+    checksum: 4b3e9c8992e2b9c5b691e32181f9c79b3e466e7322f455117d53317e5a6c422cb106a8bd6bcb0f23e928bc2135b7cf20
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-101.prototxt
   - name: se-resnext-101.caffemodel
     size: 196447403
-    sha384: 7c3000c0b24236b75a2eee4222ac971185229614d49eb896e340409392f31b539ae62fde2df1d0b1024184b829316f28
+    checksum: 7c3000c0b24236b75a2eee4222ac971185229614d49eb896e340409392f31b539ae62fde2df1d0b1024184b829316f28
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-resnext-101/SE-ResNeXt-101.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/se-resnext-50/model.yml
+++ b/models/public/se-resnext-50/model.yml
@@ -18,11 +18,11 @@ task_type: classification
 files:
   - name: se-resnext-50.prototxt
     size: 49519
-    sha384: 5a87782d5f79f2b12df90bd6f61310a552aa4f2fa8df2573e7ab654f01dda44137620cebfc08717f57e76a17909a7844
+    checksum: 5a87782d5f79f2b12df90bd6f61310a552aa4f2fa8df2573e7ab654f01dda44137620cebfc08717f57e76a17909a7844
     source: https://raw.githubusercontent.com/hujie-frank/SENet/369374b0678907a0e45c6f267256c7c34203177e/models/SE-ResNeXt-50.prototxt
   - name: se-resnext-50.caffemodel
     size: 110550637
-    sha384: cbc0b1da5a2a21ba1398fa1e79b143f637c5dc0248262ab6cf936ef783a3a1cd23943bf5f19f03f19000d7e7d3baf700
+    checksum: cbc0b1da5a2a21ba1398fa1e79b143f637c5dc0248262ab6cf936ef783a3a1cd23943bf5f19f03f19000d7e7d3baf700
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/se-resnext-50/SE-ResNeXt-50.caffemodel
 model_optimizer_args:
   - --input_shape=[1,3,224,224]

--- a/models/public/shufflenet-v2-x0.5/model.yml
+++ b/models/public/shufflenet-v2-x0.5/model.yml
@@ -29,11 +29,11 @@ task_type: classification
 files:
   - name: shufflenet-v2-x0.5.prototxt
     size: 68502
-    sha384: a22e8fec3f60b313b4853d4beff651dfc856786974f3b888db967ddd1e943e42d7576a50b7bee7e14288498ff8f7155b
+    checksum: a22e8fec3f60b313b4853d4beff651dfc856786974f3b888db967ddd1e943e42d7576a50b7bee7e14288498ff8f7155b
     source: https://github.com/miaow1988/ShuffleNet_V2_pytorch_caffe/releases/download/v0.1.1/shufflenet_v2_x0.5.prototxt
   - name: shufflenet-v2-x0.5.caffemodel
     size: 5529092
-    sha384: b19fbc18030a80580c9fc1e67626486368b0090c283456e00f4e98cd5cdd66ebf942fec591a465b248b50e18e24d81a9
+    checksum: b19fbc18030a80580c9fc1e67626486368b0090c283456e00f4e98cd5cdd66ebf942fec591a465b248b50e18e24d81a9
     source: https://github.com/miaow1988/ShuffleNet_V2_pytorch_caffe/releases/download/v0.1.1/shufflenet_v2_x0.5.caffemodel
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/shufflenet-v2-x1.0/model.yml
+++ b/models/public/shufflenet-v2-x1.0/model.yml
@@ -27,7 +27,7 @@ description: >-
 task_type: classification
 files:
   - name: shufflenetv2_x1-5666bf0f80.pth
-    sha384: 95dbe93b68849d149e4964cfc2cef9d847da6da6f6d2618c661eaddaebc29772a9becad45a455d80cf59aab1d35b411e
+    checksum: 95dbe93b68849d149e4964cfc2cef9d847da6da6f6d2618c661eaddaebc29772a9becad45a455d80cf59aab1d35b411e
     size: 9218294
     source: https://download.pytorch.org/models/shufflenetv2_x1-5666bf0f80.pth
 framework: pytorch

--- a/models/public/single-human-pose-estimation-0001/model.yml
+++ b/models/public/single-human-pose-estimation-0001/model.yml
@@ -17,7 +17,7 @@ description: >-
 task_type: human_pose_estimation
 files:
   - name: single-human-pose-estimation-0001.tar.gz
-    sha384: 440a3e299edf8f474bd974f124416dcd2f6b3121993b6b176bfb0da52a615b0f69d7b22b56ccc912fa04c2ccf96ca632
+    checksum: 440a3e299edf8f474bd974f124416dcd2f6b3121993b6b176bfb0da52a615b0f69d7b22b56ccc912fa04c2ccf96ca632
     size: 151979155
     source: https://download.01.org/opencv/openvino_training_extensions/models/human_pose_estimation/single-human-pose-estimation-0001.tar.gz
 postprocessing:

--- a/models/public/squeezenet1.0/model.yml
+++ b/models/public/squeezenet1.0/model.yml
@@ -28,11 +28,11 @@ task_type: classification
 files:
   - name: squeezenet1.0.prototxt
     size: 9640
-    sha384: 4091e21776a51767811cfb469017af5ee1ee4d1b42cdac0902b6cab41367f01864e72cd2df371f8472694ca521196fc0
+    checksum: 4091e21776a51767811cfb469017af5ee1ee4d1b42cdac0902b6cab41367f01864e72cd2df371f8472694ca521196fc0
     source: https://raw.githubusercontent.com/forresti/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/deploy.prototxt
   - name: squeezenet1.0.caffemodel
     size: 5001403
-    sha384: b8dc96393e093b4f23390b70f01fe37330d629759db59c1da3c15f846d0b1b1751b6ad841570c2e303c86829c750a745
+    checksum: b8dc96393e093b4f23390b70f01fe37330d629759db59c1da3c15f846d0b1b1751b6ad841570c2e303c86829c750a745
     source: https://github.com/forresti/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.0/squeezenet_v1.0.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/squeezenet1.1-caffe2/model.yml
+++ b/models/public/squeezenet1.1-caffe2/model.yml
@@ -20,11 +20,11 @@ task_type: classification
 files:
   - name: predict_net.pb
     size: 6175
-    sha384: 39d0085c126407c20d5e4823c6fa9294442fc714142c21b3d8e2bf4b23a83a933d78b62b5d4318f51b757389e15c6b1e
+    checksum: 39d0085c126407c20d5e4823c6fa9294442fc714142c21b3d8e2bf4b23a83a933d78b62b5d4318f51b757389e15c6b1e
     source: https://s3.amazonaws.com/download.caffe2.ai/models/squeezenet/predict_net.pb
   - name: init_net.pb
     size: 6181001
-    sha384: 5a4324a7778480b3c57e41a5c6c5cf03b9b6a2c08d7e995358a4d2192619eebeb041f6f925874f9a790fd2c53138e863
+    checksum: 5a4324a7778480b3c57e41a5c6c5cf03b9b6a2c08d7e995358a4d2192619eebeb041f6f925874f9a790fd2c53138e863
     source: https://s3.amazonaws.com/download.caffe2.ai/models/squeezenet/init_net.pb
 framework: caffe2
 conversion_to_onnx_args:

--- a/models/public/squeezenet1.1/model.yml
+++ b/models/public/squeezenet1.1/model.yml
@@ -29,11 +29,11 @@ task_type: classification
 files:
   - name: squeezenet1.1.prototxt
     size: 9678
-    sha384: 04e07f1f70210300959388d675b613ebc002464a4508dbcee7784f3bb1b55542f9ee1d191b79838d82dcf14ddac27485
+    checksum: 04e07f1f70210300959388d675b613ebc002464a4508dbcee7784f3bb1b55542f9ee1d191b79838d82dcf14ddac27485
     source: https://raw.githubusercontent.com/forresti/SqueezeNet/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/deploy.prototxt
   - name: squeezenet1.1.caffemodel
     size: 4950080
-    sha384: 1ffe0f38d605c2c83b51cfea5fa34a4d60744ebeac5655d317146a0ce5ccf39fc40daa1a7798e3c6dc4f67c11ddb9245
+    checksum: 1ffe0f38d605c2c83b51cfea5fa34a4d60744ebeac5655d317146a0ce5ccf39fc40daa1a7798e3c6dc4f67c11ddb9245
     source: https://github.com/forresti/SqueezeNet/raw/a47b6f13d30985279789d08053d37013d67d131b/SqueezeNet_v1.1/squeezenet_v1.1.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/ssd-resnet34-1200-onnx/model.yml
+++ b/models/public/ssd-resnet34-1200-onnx/model.yml
@@ -22,7 +22,7 @@ task_type: detection
 files:
   - name: resnet34-ssd1200.onnx
     size: 80363696
-    sha384: 754dd59fdb244e6a93f6173efe26c45bce804305f71b1d0a8a3eb555b3a120894658a0b97475840b93f3c2a30c5efd99
+    checksum: 754dd59fdb244e6a93f6173efe26c45bce804305f71b1d0a8a3eb555b3a120894658a0b97475840b93f3c2a30c5efd99
     source: https://zenodo.org/record/3228411/files/resnet34-ssd1200.onnx
 model_optimizer_args:
   - --reverse_input_channels

--- a/models/public/ssd300/model.yml
+++ b/models/public/ssd300/model.yml
@@ -37,7 +37,7 @@ task_type: detection
 files:
   - name: ssd300.tar.gz
     size: 97789219
-    sha384: 2c96cb2aeb08044b1475b5e80523f956317e764ceea8d603d12adebe00951ec25d38f5c060c1bf6d215792a355559c3c
+    checksum: 2c96cb2aeb08044b1475b5e80523f956317e764ceea8d603d12adebe00951ec25d38f5c060c1bf6d215792a355559c3c
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/ssd300/models_VGGNet_VOC0712Plus_SSD_300x300_ft.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssd512/model.yml
+++ b/models/public/ssd512/model.yml
@@ -37,7 +37,7 @@ task_type: detection
 files:
   - name: ssd512.tar.gz
     size: 100991061
-    sha384: 569b25de77ebd11c19fd9934dff148251505414cd3eec0f7419c60f5efc27666b20fc64df1131bc755f61d77335ad0e0
+    checksum: 569b25de77ebd11c19fd9934dff148251505414cd3eec0f7419c60f5efc27666b20fc64df1131bc755f61d77335ad0e0
     source: https://storage.openvinotoolkit.org/repositories/open_model_zoo/public/2021.4/ssd512/models_VGGNet_VOC0712Plus_SSD_512x512.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssd_mobilenet_v1_coco/model.yml
+++ b/models/public/ssd_mobilenet_v1_coco/model.yml
@@ -21,7 +21,7 @@ task_type: detection
 files:
   - name: ssd_mobilenet_v1_coco.tar.gz
     size: 76541073
-    sha384: 95d7ad978aef6fa7fded5fac04f2cdc286f82ee8e59e2ed638de6d0000dbed051c409ed276b56672d17b5b79fe6ba78c
+    checksum: 95d7ad978aef6fa7fded5fac04f2cdc286f82ee8e59e2ed638de6d0000dbed051c409ed276b56672d17b5b79fe6ba78c
     source: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssd_mobilenet_v1_fpn_coco/model.yml
+++ b/models/public/ssd_mobilenet_v1_fpn_coco/model.yml
@@ -18,7 +18,7 @@ task_type: detection
 files:
   - name: ssd_mobilenet_v1_fpn_shared_box_predictor_640x640_coco14_sync_2018_07_03.tar.gz
     size: 135664441
-    sha384: e89adbaf822f508c30e77b9aa6e9a0a566493466617064c3ee7203d9210756f6d5cd5740140ce2c0df46514d37bb5023
+    checksum: e89adbaf822f508c30e77b9aa6e9a0a566493466617064c3ee7203d9210756f6d5cd5740140ce2c0df46514d37bb5023
     source: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_fpn_shared_box_predictor_640x640_coco14_sync_2018_07_03.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssd_mobilenet_v2_coco/model.yml
+++ b/models/public/ssd_mobilenet_v2_coco/model.yml
@@ -27,7 +27,7 @@ task_type: detection
 files:
   - name: ssd_mobilenet_v2_coco.tar.gz
     size: 187925923
-    sha384: 86ecb3ed519ba4d766ad84b2ff4586b83b81f999169a45cfede500a5ad22f8f9c8e93a2d2d6e772c515daa0af61154ee
+    checksum: 86ecb3ed519ba4d766ad84b2ff4586b83b81f999169a45cfede500a5ad22f8f9c8e93a2d2d6e772c515daa0af61154ee
     source: http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v2_coco_2018_03_29.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssd_resnet50_v1_fpn_coco/model.yml
+++ b/models/public/ssd_resnet50_v1_fpn_coco/model.yml
@@ -21,7 +21,7 @@ task_type: detection
 files:
   - name: ssd_resnet50_v1_fpn_coco.tar.gz
     size: 366947246
-    sha384: 74abd247b05b1d3beaba831f088f479cc886fcdd30c636a417ed19a79adace3b65fcc02e019fa40364e48bee172adc0b
+    checksum: 74abd247b05b1d3beaba831f088f479cc886fcdd30c636a417ed19a79adace3b65fcc02e019fa40364e48bee172adc0b
     source: http://download.tensorflow.org/models/object_detection/ssd_resnet50_v1_fpn_shared_box_predictor_640x640_coco14_sync_2018_07_03.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/ssdlite_mobilenet_v2/model.yml
+++ b/models/public/ssdlite_mobilenet_v2/model.yml
@@ -20,7 +20,7 @@ task_type: detection
 files:
   - name: ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz
     size: 51025348
-    sha384: 8e205630237f1913ac0ed623d48798f1fa03a9e95c467bd149eb5f6107e704a8131cdb0a72fcf6517dafa0ff47d32a4e
+    checksum: 8e205630237f1913ac0ed623d48798f1fa03a9e95c467bd149eb5f6107e704a8131cdb0a72fcf6517dafa0ff47d32a4e
     source: http://download.tensorflow.org/models/object_detection/ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/swin-tiny-patch4-window7-224/model.yml
+++ b/models/public/swin-tiny-patch4-window7-224/model.yml
@@ -27,11 +27,11 @@ task_type: classification
 files:
   - name: timm-0.4.12-py3-none-any.whl
     size: 376973
-    sha384: e5030b792501314113ca804b3b00d35d89c40d0a92d53aa0c41e2a83697d11ef5ea8c73ed1c0bec28c4791047c9dd1b3
+    checksum: e5030b792501314113ca804b3b00d35d89c40d0a92d53aa0c41e2a83697d11ef5ea8c73ed1c0bec28c4791047c9dd1b3
     source: https://files.pythonhosted.org/packages/90/fc/606bc5cf46acac3aa9bd179b3954433c026aaf88ea98d6b19f5d14c336da/timm-0.4.12-py3-none-any.whl
   - name: swin_tiny_patch4_window7_224.pth
     size: 114342173
-    sha384: 210021216e1f205617d885836b1ac59d725b8c41dbff8dc4c513e838911436b0b75e06529737e472d3167519a7c1a6ad
+    checksum: 210021216e1f205617d885836b1ac59d725b8c41dbff8dc4c513e838911436b0b75e06529737e472d3167519a7c1a6ad
     source: https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_tiny_patch4_window7_224.pth
 postprocessing:
   - $type: unpack_archive

--- a/models/public/text-recognition-resnet-fc/model.yml
+++ b/models/public/text-recognition-resnet-fc/model.yml
@@ -21,197 +21,197 @@ task_type: optical_character_recognition
 files:
   - name: vedastr/models/__init__.py
     size: 88
-    sha384: 825c2e21b6b2cbf346c7d34fad9f5342ef302ee582183af33ebaddcfaec8857925dcf518a74ae23becef8c289caa0009
+    checksum: 825c2e21b6b2cbf346c7d34fad9f5342ef302ee582183af33ebaddcfaec8857925dcf518a74ae23becef8c289caa0009
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/__init__.py
   - name: vedastr/models/builder.py
     size: 179
-    sha384: 959e9d7da38edaba0282d2d50d63b489a1d57618f6d18270ab3c91a08c43c2b41036d72257a13f49f0dc082a263630f7
+    checksum: 959e9d7da38edaba0282d2d50d63b489a1d57618f6d18270ab3c91a08c43c2b41036d72257a13f49f0dc082a263630f7
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/builder.py
   - name: vedastr/models/model.py
     size: 644
-    sha384: d22fa2c8c3ad3daf0210e2da0737cf3ef197100edcefaca4d42e28caa8c9c6fb7ab82db7b3700e10aeb2adb8138f57d2
+    checksum: d22fa2c8c3ad3daf0210e2da0737cf3ef197100edcefaca4d42e28caa8c9c6fb7ab82db7b3700e10aeb2adb8138f57d2
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/model.py
   - name: vedastr/models/weight_init.py
     size: 3445
-    sha384: f6f2ae7183bffb9382ad378c45bbc9d3b87de5a37b236722bd41cf6b2f021f834403b94081ccd248f5bf13cc4f3bf138
+    checksum: f6f2ae7183bffb9382ad378c45bbc9d3b87de5a37b236722bd41cf6b2f021f834403b94081ccd248f5bf13cc4f3bf138
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/weight_init.py
   - name: vedastr/models/registry.py
     size: 57
-    sha384: 5b10880eb49b899469306459acee721e64c2a7ab8ac2f5934a6778d9b7ad0cdfc3ee1f6e0658203bd98973184cf6fd5d
+    checksum: 5b10880eb49b899469306459acee721e64c2a7ab8ac2f5934a6778d9b7ad0cdfc3ee1f6e0658203bd98973184cf6fd5d
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/registry.py
   - name: vedastr/models/heads/__init__.py
     size: 189
-    sha384: a29856d56efd6da99f7d63647a9cc81506844caa1e5e48cd4f6eebf55e3210f68076b9cb9ef0d8bb335b113fef15b343
+    checksum: a29856d56efd6da99f7d63647a9cc81506844caa1e5e48cd4f6eebf55e3210f68076b9cb9ef0d8bb335b113fef15b343
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/heads/__init__.py
   - name: vedastr/models/heads/builder.py
     size: 179
-    sha384: ed99623bddee8359523edec9c1616cb894c0ec301e1d86c9eed7b57e92c25b70a0ae4418e6c0c7be9d509c45f10dbe00
+    checksum: ed99623bddee8359523edec9c1616cb894c0ec301e1d86c9eed7b57e92c25b70a0ae4418e6c0c7be9d509c45f10dbe00
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/heads/builder.py
   - name: vedastr/models/heads/fc_head.py
     size: 1801
-    sha384: 05136410ed697d7d61d063b2457bb8277d6fe7d57da76e486d52d3f84aae9c94cec03ea81240eafb970a994ae6dee9f2
+    checksum: 05136410ed697d7d61d063b2457bb8277d6fe7d57da76e486d52d3f84aae9c94cec03ea81240eafb970a994ae6dee9f2
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/heads/fc_head.py
   - name: vedastr/models/heads/registry.py
     size: 70
-    sha384: 52439fa05b738bdb170b64ebcf3fd705ca9125be1357a0887bfa15325ffe4a7d0dd5bdc5b00eadc33c5503222af382bc
+    checksum: 52439fa05b738bdb170b64ebcf3fd705ca9125be1357a0887bfa15325ffe4a7d0dd5bdc5b00eadc33c5503222af382bc
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/heads/registry.py
   - name: vedastr/models/bodies/__init__.py
     size: 357
-    sha384: c935e6d7859bc27029ad3374ceed26b8238b082cfcb9e58b48fffe7b90e52f885b24dc66944527a0bfcfeb8aa6e11ac4
+    checksum: c935e6d7859bc27029ad3374ceed26b8238b082cfcb9e58b48fffe7b90e52f885b24dc66944527a0bfcfeb8aa6e11ac4
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/__init__.py
   - name: vedastr/models/bodies/builder.py
     size: 324
-    sha384: 6f5998f70a27efb04122df68b18945f02437d1a45b10f228f817d6e1a7c4ccc223a7798d3e426e0d6558d925fb0e2783
+    checksum: 6f5998f70a27efb04122df68b18945f02437d1a45b10f228f817d6e1a7c4ccc223a7798d3e426e0d6558d925fb0e2783
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/builder.py
   - name: vedastr/models/bodies/registry.py
     size: 96
-    sha384: 9ebec8b3c481611b95aca0f037516950cc90959887b2f65f416af4cfd4430f97ba7f4fbc26f29622be5b139b91010073
+    checksum: 9ebec8b3c481611b95aca0f037516950cc90959887b2f65f416af4cfd4430f97ba7f4fbc26f29622be5b139b91010073
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/registry.py
   - name: vedastr/models/bodies/body.py
     size: 1207
-    sha384: dae2ff54a52dff55a9a372734b83046f4e35d0c376bde36746e26f40e216a4cfa6fb963133b2c9dce5166c5199383bbe
+    checksum: dae2ff54a52dff55a9a372734b83046f4e35d0c376bde36746e26f40e216a4cfa6fb963133b2c9dce5166c5199383bbe
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/body.py
   - name: vedastr/models/bodies/component.py
     size: 1421
-    sha384: 0cf81b22eff798932a51e4335af9dd6cafb591167cffce9e0eaeafe26b4946ab2a06d7164bc9b1cc99a0b0de89459a6e
+    checksum: 0cf81b22eff798932a51e4335af9dd6cafb591167cffce9e0eaeafe26b4946ab2a06d7164bc9b1cc99a0b0de89459a6e
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/component.py
   - name: vedastr/models/bodies/sequences/__init__.py
     size: 142
-    sha384: 9b3e08021436c6fbe2538f7a7368f8f80c87f4ef6f29c180f91175eeaf557d619e80ff47a4db4ea489fb98aaf5359e9a
+    checksum: 9b3e08021436c6fbe2538f7a7368f8f80c87f4ef6f29c180f91175eeaf557d619e80ff47a4db4ea489fb98aaf5359e9a
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/sequences/__init__.py
   - name: vedastr/models/bodies/sequences/builder.py
     size: 418
-    sha384: 71f08b22dabcb4033a1e722473c282ed0b2467f4196c98337be7909f359a99b51c9fc03ccd50f1ad12e233a2f3b4dde7
+    checksum: 71f08b22dabcb4033a1e722473c282ed0b2467f4196c98337be7909f359a99b51c9fc03ccd50f1ad12e233a2f3b4dde7
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/sequences/builder.py
   - name: vedastr/models/bodies/sequences/registry.py
     size: 134
-    sha384: 23d5732c4dea15424e0ee5dc15a7c0e7d7ffdcd32237d21b247e851da3f037ac73fa632538bf071a6a992ef0bdd1756e
+    checksum: 23d5732c4dea15424e0ee5dc15a7c0e7d7ffdcd32237d21b247e851da3f037ac73fa632538bf071a6a992ef0bdd1756e
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/sequences/registry.py
   - name: vedastr/models/bodies/feature_extractors/__init__.py
     size: 182
-    sha384: a285af4b7aa62e1eb00fdc848b8e684d0764f5953c9d04d40f01ddd94484569e37ec829ef9f9c45597cc893e7ca16e10
+    checksum: a285af4b7aa62e1eb00fdc848b8e684d0764f5953c9d04d40f01ddd94484569e37ec829ef9f9c45597cc893e7ca16e10
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/__init__.py
   - name: vedastr/models/bodies/feature_extractors/builder.py
     size: 717
-    sha384: 29bb67edf9f83953f87fdebd46a99314f7dcbf96c7c4dc97df1d92edbb556750460e8c1e796775bde82305aa5e9ef1d3
+    checksum: 29bb67edf9f83953f87fdebd46a99314f7dcbf96c7c4dc97df1d92edbb556750460e8c1e796775bde82305aa5e9ef1d3
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/builder.py
   - name: vedastr/models/bodies/feature_extractors/decoders/__init__.py
     size: 104
-    sha384: ca0a256a4307ebcf156c2762fece70f8ca09d413c23939da64ec1fd7c463d7f1d4be082fab6de5a951367faf333bfffc
+    checksum: ca0a256a4307ebcf156c2762fece70f8ca09d413c23939da64ec1fd7c463d7f1d4be082fab6de5a951367faf333bfffc
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/__init__.py
   - name: vedastr/models/bodies/feature_extractors/decoders/builder.py
     size: 194
-    sha384: 412a7be4a76e23c9e7a5380a4b6829dd6b51a661eac944471c92d80ccdc46a228c04505989ee0d2ff636b19becd7f841
+    checksum: 412a7be4a76e23c9e7a5380a4b6829dd6b51a661eac944471c92d80ccdc46a228c04505989ee0d2ff636b19becd7f841
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/builder.py
   - name: vedastr/models/bodies/feature_extractors/decoders/registry.py
     size: 67
-    sha384: 68a3816e984c561f62a2efc88a36c777828ac26a0fb3a9b453b9fadb0d65c118a3a874cf0e7445398bf265d9e609db81
+    checksum: 68a3816e984c561f62a2efc88a36c777828ac26a0fb3a9b453b9fadb0d65c118a3a874cf0e7445398bf265d9e609db81
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/registry.py
   - name: vedastr/models/bodies/feature_extractors/decoders/bricks/__init__.py
     size: 154
-    sha384: f66787789b1de49dafe59315a14001c73e73ad81c0d2e1b483e1536beadefa4993c5f5f7f48a16404a12a8405336feec
+    checksum: f66787789b1de49dafe59315a14001c73e73ad81c0d2e1b483e1536beadefa4993c5f5f7f48a16404a12a8405336feec
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/bricks/__init__.py
   - name: vedastr/models/bodies/feature_extractors/decoders/bricks/bricks.py
     size: 6933
-    sha384: a13fe3ac2e365e6d09e58f9437dc3e3e2c62aa06c24c539f39287a4167cb73f4b7e7af5187516675043c195262a385f0
+    checksum: a13fe3ac2e365e6d09e58f9437dc3e3e2c62aa06c24c539f39287a4167cb73f4b7e7af5187516675043c195262a385f0
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/bricks/bricks.py
   - name: vedastr/models/bodies/feature_extractors/decoders/bricks/builder.py
     size: 353
-    sha384: 1b50ca0f1411ad3207b14d9196bfae6bdfd5e44b54c84e6fa8a10d52d8fe5b10219a227b4044ddc34902986ec778ccd3
+    checksum: 1b50ca0f1411ad3207b14d9196bfae6bdfd5e44b54c84e6fa8a10d52d8fe5b10219a227b4044ddc34902986ec778ccd3
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/bricks/builder.py
   - name: vedastr/models/bodies/feature_extractors/decoders/bricks/registry.py
     size: 63
-    sha384: b2bf466aaa2ca81c57b0542ae7192324019223b081a7efb3ea22baa950669486d4fdde75cf07f34e0898c5b5e8cd6e59
+    checksum: b2bf466aaa2ca81c57b0542ae7192324019223b081a7efb3ea22baa950669486d4fdde75cf07f34e0898c5b5e8cd6e59
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/decoders/bricks/registry.py
   - name: vedastr/models/bodies/feature_extractors/encoders/__init__.py
     size: 123
-    sha384: be4f67f4d58333fa6af14bfd8582f2f5ea14e3c8248d1bb34ee34b7fd08a288044252d609cf4d4fec15383200acff7ab
+    checksum: be4f67f4d58333fa6af14bfd8582f2f5ea14e3c8248d1bb34ee34b7fd08a288044252d609cf4d4fec15383200acff7ab
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/__init__.py
   - name: vedastr/models/bodies/feature_extractors/encoders/builder.py
     size: 435
-    sha384: fa291a26fa93a7649e046ef11e19c3bf013e4f1e969bfa903b7b66c882a232f27dea0231b1bd8fcd243283d4050ff634
+    checksum: fa291a26fa93a7649e046ef11e19c3bf013e4f1e969bfa903b7b66c882a232f27dea0231b1bd8fcd243283d4050ff634
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/builder.py
   - name: vedastr/models/bodies/feature_extractors/encoders/backbones/__init__.py
     size: 94
-    sha384: ebff8db1aede61eec6b1770842e179f5963f7d21193cc65aa8e5319ae52e6e52ac7b4bce1b5e21adf485eddc5060ec98
+    checksum: ebff8db1aede61eec6b1770842e179f5963f7d21193cc65aa8e5319ae52e6e52ac7b4bce1b5e21adf485eddc5060ec98
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/backbones/__init__.py
   - name: vedastr/models/bodies/feature_extractors/encoders/backbones/builder.py
     size: 200
-    sha384: e739ecebb0a62ad19333adc2bfe028e7f6b2e6e841ef9f6459de51e28808fa043afc5343794978831e68d828bfea8e30
+    checksum: e739ecebb0a62ad19333adc2bfe028e7f6b2e6e841ef9f6459de51e28808fa043afc5343794978831e68d828bfea8e30
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/backbones/builder.py
   - name: vedastr/models/bodies/feature_extractors/encoders/backbones/registry.py
     size: 69
-    sha384: 922150d8af98734d4dd6057f6c0baed67ee02696d07cb53a81e4ac1bcc427a6d94fcd5c2b3f41bba9b9add037e7f120e
+    checksum: 922150d8af98734d4dd6057f6c0baed67ee02696d07cb53a81e4ac1bcc427a6d94fcd5c2b3f41bba9b9add037e7f120e
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/backbones/registry.py
   - name: vedastr/models/bodies/feature_extractors/encoders/backbones/resnet.py
     size: 9147
-    sha384: 8a81940db53bc762a75b94794d80f46e9b34a3076386614b201060b7b1f35c04ffb6d8c28f8d73ffef7c41cc0743c5d7
+    checksum: 8a81940db53bc762a75b94794d80f46e9b34a3076386614b201060b7b1f35c04ffb6d8c28f8d73ffef7c41cc0743c5d7
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/backbones/resnet.py
   - name: vedastr/models/bodies/feature_extractors/encoders/enhance_modules/__init__.py
     size: 86
-    sha384: 87cc8901a0fe0ae44f8d37a3fc04c9a9ac364b1f20babe2807783c7f98618b1c9f24c10d2415d79f18e39e518112b953
+    checksum: 87cc8901a0fe0ae44f8d37a3fc04c9a9ac364b1f20babe2807783c7f98618b1c9f24c10d2415d79f18e39e518112b953
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/enhance_modules/__init__.py
   - name: vedastr/models/bodies/feature_extractors/encoders/enhance_modules/builder.py
     size: 230
-    sha384: 4d7574643c3df5364c25e120a97e21d6baedcbe20ecaf546e2d00b7411db517025eab74353db3c3547bccc893e966fb0
+    checksum: 4d7574643c3df5364c25e120a97e21d6baedcbe20ecaf546e2d00b7411db517025eab74353db3c3547bccc893e966fb0
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/enhance_modules/builder.py
   - name: vedastr/models/bodies/feature_extractors/encoders/enhance_modules/registry.py
     size: 81
-    sha384: df139c3acbc88a8dd2d9cadbb314469624e3d17dd0d8d069185fa5cbaa4b0d265f285f9b7fd11a4375cc9edf8a8a6142
+    checksum: df139c3acbc88a8dd2d9cadbb314469624e3d17dd0d8d069185fa5cbaa4b0d265f285f9b7fd11a4375cc9edf8a8a6142
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/bodies/feature_extractors/encoders/enhance_modules/registry.py
   - name: vedastr/models/utils/__init__.py
     size: 208
-    sha384: cfec04ffec33171fbc9cd5bcc4a3852f659ebe0411c8e031e24423138e1b6dcae04e425ed665f4de80d69e14f66ac292
+    checksum: cfec04ffec33171fbc9cd5bcc4a3852f659ebe0411c8e031e24423138e1b6dcae04e425ed665f4de80d69e14f66ac292
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/__init__.py
   - name: vedastr/models/utils/builder.py
     size: 329
-    sha384: 812796d176490712d3e6b0b3f29fe57db3528c7422dd64841c3fe3b9c54d9f4d157ce23123b8b18c88653b4f06ea2d2d
+    checksum: 812796d176490712d3e6b0b3f29fe57db3528c7422dd64841c3fe3b9c54d9f4d157ce23123b8b18c88653b4f06ea2d2d
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/builder.py
   - name: vedastr/models/utils/conv_module.py
     size: 7325
-    sha384: 3fba038a67857c3dd7587f958d17bdafdebcd622843d60af24f8d59dfc0f1b9d6f17c14750dfe8d3fd1c179d1377cc79
+    checksum: 3fba038a67857c3dd7587f958d17bdafdebcd622843d60af24f8d59dfc0f1b9d6f17c14750dfe8d3fd1c179d1377cc79
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/conv_module.py
   - name: vedastr/models/utils/fc_module.py
     size: 2650
-    sha384: 7ee9dc75269987659a4de418784efd8549fbcfa78b801a75e4e365bf10c833c20a8a03f83584a2e99182ac7531d87018
+    checksum: 7ee9dc75269987659a4de418784efd8549fbcfa78b801a75e4e365bf10c833c20a8a03f83584a2e99182ac7531d87018
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/fc_module.py
   - name: vedastr/models/utils/norm.py
     size: 1688
-    sha384: 3bb4e47aacf3e850ea728365fb42e6c0d5f62661e3ca4da97fe1e20a25eacd2bc20f97cc652071a533ae7735569e2d82
+    checksum: 3bb4e47aacf3e850ea728365fb42e6c0d5f62661e3ca4da97fe1e20a25eacd2bc20f97cc652071a533ae7735569e2d82
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/norm.py
   - name: vedastr/models/utils/registry.py
     size: 62
-    sha384: f40331526d0c838c7d858259d3d7e4a13f040d316dc3ed5ae6cf618f60e42675a8cbcb68ddac31952bf366baf0c21999
+    checksum: f40331526d0c838c7d858259d3d7e4a13f040d316dc3ed5ae6cf618f60e42675a8cbcb68ddac31952bf366baf0c21999
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/models/utils/registry.py
   - name: vedastr/utils/__init__.py
     size: 255
-    sha384: 5688acebc5e6389c6eb726769ae99421c43ead7d616693f66b0e824deed01f0d314ef33eb3a008f053639a8144c56500
+    checksum: 5688acebc5e6389c6eb726769ae99421c43ead7d616693f66b0e824deed01f0d314ef33eb3a008f053639a8144c56500
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/utils/__init__.py
   - name: vedastr/utils/common.py
     size: 3255
-    sha384: 4b517fc8d3e90b236acd7898f2dcf476e2737541e7df3881146d2006376ad467eca5f66441ce254ac010b75dc7e64c8c
+    checksum: 4b517fc8d3e90b236acd7898f2dcf476e2737541e7df3881146d2006376ad467eca5f66441ce254ac010b75dc7e64c8c
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/utils/common.py
   - name: vedastr/utils/registry.py
     size: 1226
-    sha384: ddf95b80d2f1bc0250635f65b37b8ac20bb477995c249ec5cea26c422cd6ece66a117b269b0bff62161729381f60c0ef
+    checksum: ddf95b80d2f1bc0250635f65b37b8ac20bb477995c249ec5cea26c422cd6ece66a117b269b0bff62161729381f60c0ef
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/utils/registry.py
   - name: vedastr/utils/config.py
     size: 5232
-    sha384: f1a4d00bdc6cde100ae7203644ffa56701aec0e431ff0b2008c20954230e6e94272d695feab52d604e3ae602c3d1ac8d
+    checksum: f1a4d00bdc6cde100ae7203644ffa56701aec0e431ff0b2008c20954230e6e94272d695feab52d604e3ae602c3d1ac8d
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/vedastr/utils/config.py
   - name: vedastr/configs/resnet_fc.py
     size: 8247
-    sha384: d42ae06175fca6a117fc3e51cb94d04bf2b062ba49611366c4f6eca1500ad07a769ee631927cab1414f86d4b29cc7b30
+    checksum: d42ae06175fca6a117fc3e51cb94d04bf2b062ba49611366c4f6eca1500ad07a769ee631927cab1414f86d4b29cc7b30
     source: https://raw.githubusercontent.com/Media-Smart/vedastr/0fd2a0bd7819ae4daa2a161501e9f1c2ac67e96a/configs/resnet_fc.py
   - name: vedastr/ckpt/resnet_fc.pth
     size: 712199075
-    sha384: 731cfa8125b4176f3ee668dd78d8f4dc964dc2e60bd1959e07931804a59292c10c94bee6548ee50b8626b09b8f442d07
+    checksum: 731cfa8125b4176f3ee668dd78d8f4dc964dc2e60bd1959e07931804a59292c10c94bee6548ee50b8626b09b8f442d07
     source:
       $type: google_drive
       id: 1OnUGdv9RFhFbQGXUUkWMcxUZg0mPV0kK
   - name: vedastr/addict-2.4.0-py3-none-any.whl
     size: 3832
-    sha384: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
+    checksum: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
     source: https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl
 postprocessing:
   - $type: regex_replace

--- a/models/public/ultra-lightweight-face-detection-rfb-320/model.yml
+++ b/models/public/ultra-lightweight-face-detection-rfb-320/model.yml
@@ -23,7 +23,7 @@ task_type: detection
 files:
   - name: ultra-lightweight-face-detection-rfb-320.onnx
     size: 1270727
-    sha384: c3f6a4f672d157dbed29d1757e8f72c8b66c357f2b321b7869b92b983d47d1f0af448e7ea1b6eefd4c41c2780377d153
+    checksum: c3f6a4f672d157dbed29d1757e8f72c8b66c357f2b321b7869b92b983d47d1f0af448e7ea1b6eefd4c41c2780377d153
     source: https://raw.githubusercontent.com/Linzaer/Ultra-Light-Fast-Generic-Face-Detector-1MB/3cb8d7f9a9e418ab594b5b0bb349756a49699517/models/onnx/version-RFB-320.onnx
 model_optimizer_args:
   - --input_shape=[1,3,240,320]

--- a/models/public/ultra-lightweight-face-detection-slim-320/model.yml
+++ b/models/public/ultra-lightweight-face-detection-slim-320/model.yml
@@ -23,7 +23,7 @@ task_type: detection
 files:
   - name: ultra-lightweight-face-detection-slim-320.onnx
     size: 1195330
-    sha384: c6d986113c002b0b8758ba717cff298f7731220e142dd7301bc2349028820fb8dd8942386ab70668b0999bf17d8b818c
+    checksum: c6d986113c002b0b8758ba717cff298f7731220e142dd7301bc2349028820fb8dd8942386ab70668b0999bf17d8b818c
     source: https://raw.githubusercontent.com/Linzaer/Ultra-Light-Fast-Generic-Face-Detector-1MB/3cb8d7f9a9e418ab594b5b0bb349756a49699517/models/onnx/version-slim-320.onnx
 model_optimizer_args:
   - --input_shape=[1,3,240,320]

--- a/models/public/vehicle-license-plate-detection-barrier-0123/model.yml
+++ b/models/public/vehicle-license-plate-detection-barrier-0123/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: ssd-mobilenet-v2-0.35.1-barrier-256x256-0123.tar.gz
     size: 4387714
-    sha384: 71a1b74e9612204e4533d44a8eff105490bb3248043d22ef894c19d5da4fb135a989946307b86191ba4ec2ce391b34bf
+    checksum: 71a1b74e9612204e4533d44a8eff105490bb3248043d22ef894c19d5da4fb135a989946307b86191ba4ec2ce391b34bf
     source: https://download.01.org/opencv/openvino_training_extensions/models/ssd_detector/ssd-mobilenet-v2-0.35.1-barrier-256x256-0123.tar.gz
 postprocessing:
   - $type: unpack_archive

--- a/models/public/vehicle-reid-0001/model.yml
+++ b/models/public/vehicle-reid-0001/model.yml
@@ -22,7 +22,7 @@ task_type: object_attributes
 files:
   - name: osnet_ain_x1_0_vehicle_reid.onnx
     size: 8836743
-    sha384: 0515ce72f653c39780d5b87dfed7255d396dd2b1e8b6e91fbaacdfad1da189166343157273c02f3b0fede3050ef7abb7
+    checksum: 0515ce72f653c39780d5b87dfed7255d396dd2b1e8b6e91fbaacdfad1da189166343157273c02f3b0fede3050ef7abb7
     source:
       $type: google_drive
       id: 1MEtaIr_9mWuntGD9edydFl_T5waloNRm

--- a/models/public/vgg16/model.yml
+++ b/models/public/vgg16/model.yml
@@ -26,11 +26,11 @@ task_type: classification
 files:
   - name: vgg16.prototxt
     size: 4776
-    sha384: 02ecff319e3fab8e68232ad5a8a5a4d91f2f49b00f15b868674cd59ef33a4b0c216d751ae60c07411fa3fdf3af795faa
+    checksum: 02ecff319e3fab8e68232ad5a8a5a4d91f2f49b00f15b868674cd59ef33a4b0c216d751ae60c07411fa3fdf3af795faa
     source: https://gist.githubusercontent.com/ksimonyan/211839e770f7b538e2d8/raw/0067c9b32f60362c74f4c445a080beed06b07eb3/VGG_ILSVRC_16_layers_deploy.prototxt
   - name: vgg16.caffemodel
     size: 553432081
-    sha384: 8ed7890af721fa22a9a356c00ec8360984f572b37991d1a5d70993ece85a0d25d675f02ff27c443523be1b61b9bb3d15
+    checksum: 8ed7890af721fa22a9a356c00ec8360984f572b37991d1a5d70993ece85a0d25d675f02ff27c443523be1b61b9bb3d15
     source: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/vgg19-caffe2/model.yml
+++ b/models/public/vgg19-caffe2/model.yml
@@ -20,11 +20,11 @@ task_type: classification
 files:
   - name: predict_net.pb
     size: 2862
-    sha384: c7f106946b34ddfa05cb71b0a8d46dbc608b07796e1b0182e1f0acd5fa5607338c552115381e78cebaf8fcd0d188dbc6
+    checksum: c7f106946b34ddfa05cb71b0a8d46dbc608b07796e1b0182e1f0acd5fa5607338c552115381e78cebaf8fcd0d188dbc6
     source: https://s3.amazonaws.com/download.caffe2.ai/models/vgg19/predict_net.pb
   - name: init_net.pb
     size: 718338501
-    sha384: f68fded92d0c949a881a581bb0f697fc2c51936065444811aaf69047adb5cfbf473cb246fbce86239d38a7786eeb917c
+    checksum: f68fded92d0c949a881a581bb0f697fc2c51936065444811aaf69047adb5cfbf473cb246fbce86239d38a7786eeb917c
     source: https://s3.amazonaws.com/download.caffe2.ai/models/vgg19/init_net.pb
 framework: caffe2
 quantizable: yes

--- a/models/public/vgg19/model.yml
+++ b/models/public/vgg19/model.yml
@@ -26,11 +26,11 @@ task_type: classification
 files:
   - name: vgg19.prototxt
     size: 5499
-    sha384: f3c8a34cbaba8c92fbd7744f4a26d244555e1b9a541fef3294622483b316465dad2363bdbab548dfd6733da66213a2d3
+    checksum: f3c8a34cbaba8c92fbd7744f4a26d244555e1b9a541fef3294622483b316465dad2363bdbab548dfd6733da66213a2d3
     source: https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/f02f8769e64494bcd3d7e97d5d747ac275825721/VGG_ILSVRC_19_layers_deploy.prototxt
   - name: vgg19.caffemodel
     size: 574671192
-    sha384: 86b83739d448a81ddc927922d4d7581e06113478106b59480097b02cc63ff51c9da7c3cd8a865b08946d07d0281d5b2e
+    checksum: 86b83739d448a81ddc927922d4d7581e06113478106b59480097b02cc63ff51c9da7c3cd8a865b08946d07d0281d5b2e
     source: http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel
 postprocessing:
   - $type: regex_replace

--- a/models/public/vitstr-small-patch16-224/model.yml
+++ b/models/public/vitstr-small-patch16-224/model.yml
@@ -25,15 +25,15 @@ task_type: optical_character_recognition
 files:
   - name: timm-0.4.12-py3-none-any.whl
     size: 376973
-    sha384: e5030b792501314113ca804b3b00d35d89c40d0a92d53aa0c41e2a83697d11ef5ea8c73ed1c0bec28c4791047c9dd1b3
+    checksum: e5030b792501314113ca804b3b00d35d89c40d0a92d53aa0c41e2a83697d11ef5ea8c73ed1c0bec28c4791047c9dd1b3
     source: https://files.pythonhosted.org/packages/90/fc/606bc5cf46acac3aa9bd179b3954433c026aaf88ea98d6b19f5d14c336da/timm-0.4.12-py3-none-any.whl
   - name: modules/vitstr.py
     size: 8363
-    sha384: 90e14135b5a23aad667fbde7581f0142a572b096d3ef6fb4d969f6b6069ce1369eebad916b24e11a1b57768b197d7244
+    checksum: 90e14135b5a23aad667fbde7581f0142a572b096d3ef6fb4d969f6b6069ce1369eebad916b24e11a1b57768b197d7244
     source: https://raw.githubusercontent.com/roatienza/deep-text-recognition-benchmark/c937d69388dbaa1c4a776badb2670344b39d0942/modules/vitstr.py
   - name: vitstr_small_patch16_224.pth
     size: 86086343
-    sha384: 529c216830a23a2b9d7f6782515deca4a2f99aa42a22440e1997182d092b8db5a64718dda0df47cdc6ca3d51ecec5a97
+    checksum: 529c216830a23a2b9d7f6782515deca4a2f99aa42a22440e1997182d092b8db5a64718dda0df47cdc6ca3d51ecec5a97
     source: https://github.com/roatienza/deep-text-recognition-benchmark/releases/download/v0.1.0/vitstr_small_patch16_224.pth
 postprocessing:
   - $type: unpack_archive

--- a/models/public/wav2vec2-base/model.yml
+++ b/models/public/wav2vec2-base/model.yml
@@ -28,23 +28,23 @@ task_type: named_entity_recognition
 files:
   - name: transformers-4.8.2-py3-none-any.whl
     size: 2499371
-    sha384: 91713fbb6bf46b5a216c3336260cc03e7d2c7cbd031e810d22feeed0865f9e0f5d7a87c45f7d60669587cbc9548c30c1
+    checksum: 91713fbb6bf46b5a216c3336260cc03e7d2c7cbd031e810d22feeed0865f9e0f5d7a87c45f7d60669587cbc9548c30c1
     source: https://files.pythonhosted.org/packages/fd/1a/41c644c963249fd7f3836d926afa1e3f1cc234a1c40d80c5f03ad8f6f1b2/transformers-4.8.2-py3-none-any.whl
   - name: wav2vec2-base-960h/pytorch_model.bin
     size: 377667514
-    sha384: 647658a0fc4376ddccb8430207fd50f22a59f607f821ddb6e7dfec7bf2f41d3bbe4d6e62c2779530f1a2e20ec75acf9b
+    checksum: 647658a0fc4376ddccb8430207fd50f22a59f607f821ddb6e7dfec7bf2f41d3bbe4d6e62c2779530f1a2e20ec75acf9b
     source: https://huggingface.co/facebook/wav2vec2-base-960h/resolve/main/pytorch_model.bin
   - name: wav2vec2-base-960h/config.json
     size: 1596
-    sha384: 1c28d7ba60f46b0212c73afde1ff9a77a0bc2801c3dc6bcac77835ed147e0df49a28bc627c0a76b1f6b8959170e7627b
+    checksum: 1c28d7ba60f46b0212c73afde1ff9a77a0bc2801c3dc6bcac77835ed147e0df49a28bc627c0a76b1f6b8959170e7627b
     source: https://huggingface.co/facebook/wav2vec2-base-960h/resolve/main/config.json
   - name: wav2vec2-base-960h/vocab.json
     size: 291
-    sha384: 87dc62dd416ca1d37674e5169d701d443b0644f23c0584d52b5813d025ebb5cecf9ea64850c4c09fe10766e7b2e8435c
+    checksum: 87dc62dd416ca1d37674e5169d701d443b0644f23c0584d52b5813d025ebb5cecf9ea64850c4c09fe10766e7b2e8435c
     source: https://huggingface.co/facebook/wav2vec2-base-960h/resolve/main/vocab.json
   - name: packaging-20.9-py2.py3-none-any.whl
     size: 40870
-    sha384: 422fac4cb009bed3eae42e9688b1712ee15dde1799c888f33c802792e925373dee046602d1d31c460d9d2af3ff6b93a1
+    checksum: 422fac4cb009bed3eae42e9688b1712ee15dde1799c888f33c802792e925373dee046602d1d31c460d9d2af3ff6b93a1
     source: https://files.pythonhosted.org/packages/3e/89/7ea760b4daa42653ece2380531c90f64788d979110a2ab51049d92f408af/packaging-20.9-py2.py3-none-any.whl
 postprocessing:
   - $type: unpack_archive

--- a/models/public/wavernn/wavernn-rnn/model.yml
+++ b/models/public/wavernn/wavernn-rnn/model.yml
@@ -18,7 +18,7 @@ task_type: text_to_speech
 files:
   - name: wavernn-rnn.zip
     size: 14297518
-    sha384: 77186c83348d404c547d5706af7541d9a5cb430ed4236595d4f5b5f5e034d01ee5a74e3d39307324d5cdac5007cd013a
+    checksum: 77186c83348d404c547d5706af7541d9a5cb430ed4236595d4f5b5f5e034d01ee5a74e3d39307324d5cdac5007cd013a
     source: https://download.01.org/opencv/public_models/102020/wavernn/wavernn-rnn.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/wavernn/wavernn-upsampler/model.yml
+++ b/models/public/wavernn/wavernn-upsampler/model.yml
@@ -18,7 +18,7 @@ task_type: text_to_speech
 files:
   - name: wavernn-upsampler.zip
     size: 1496559
-    sha384: 7d27cf5e68dd9e66a5a6cf800a4f6114819eb1cd8e103cea4b9cf15e1dd0b163ce382f76aaa19e24033fa09e347ba2ef
+    checksum: 7d27cf5e68dd9e66a5a6cf800a4f6114819eb1cd8e103cea4b9cf15e1dd0b163ce382f76aaa19e24033fa09e347ba2ef
     source: https://download.01.org/opencv/public_models/102020/wavernn/wavernn-upsampler.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/yolact-resnet50-fpn-pytorch/model.yml
+++ b/models/public/yolact-resnet50-fpn-pytorch/model.yml
@@ -23,31 +23,31 @@ task_type: instance_segmentation
 files:
   - name: yolact/yolact.py
     size: 31516
-    sha384: 8e3b27af4ba4d68600fa37dc9c3716890f41306904c92da4a6f5ff1ee9447d1301835d62d33710a6833d7e8e02c744a1
+    checksum: 8e3b27af4ba4d68600fa37dc9c3716890f41306904c92da4a6f5ff1ee9447d1301835d62d33710a6833d7e8e02c744a1
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/yolact.py
   - name: yolact/backbone.py
     size: 17286
-    sha384: 9f507122dfe8c164343d7f302668afc671f3d730e14a454d859e7ccff77e92a77ecf027cccce6eba9ae76f4a3f98594c
+    checksum: 9f507122dfe8c164343d7f302668afc671f3d730e14a454d859e7ccff77e92a77ecf027cccce6eba9ae76f4a3f98594c
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/backbone.py
   - name: yolact/data/config.py
     size: 31172
-    sha384: f7f77e46e09d6b2912dee1b9f4bde3a16e79b769eba43b0cac0c53070345bcf3d169752ae60159f134ee44d7a5d70670
+    checksum: f7f77e46e09d6b2912dee1b9f4bde3a16e79b769eba43b0cac0c53070345bcf3d169752ae60159f134ee44d7a5d70670
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/data/config.py
   - name: yolact/utils/timer.py
     size: 3508
-    sha384: 4b2161e5216da3be3089b3d391da206ad3f69b596c9d55353e399de99fa69f17e42803b6a65ac1cbebd62910e6a90dc5
+    checksum: 4b2161e5216da3be3089b3d391da206ad3f69b596c9d55353e399de99fa69f17e42803b6a65ac1cbebd62910e6a90dc5
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/utils/timer.py
   - name: yolact/utils/functions.py
     size: 6503
-    sha384: 1940ef89ddc62704f1508673c81ed289689644f5c58b23bd1ccbbc2f29fddafd105c0f0f84c6ca2182a1c7343ae99def
+    checksum: 1940ef89ddc62704f1508673c81ed289689644f5c58b23bd1ccbbc2f29fddafd105c0f0f84c6ca2182a1c7343ae99def
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/utils/functions.py
   - name: yolact/layers/interpolate.py
     size: 412
-    sha384: f8780a33988fb04c0408f22735f72eb0780295ebc5f5c3a316fabdc1985e957b007deeb525f2980169c46c7e0bfcf407
+    checksum: f8780a33988fb04c0408f22735f72eb0780295ebc5f5c3a316fabdc1985e957b007deeb525f2980169c46c7e0bfcf407
     source: https://raw.githubusercontent.com/dbolya/yolact/57b8f2d95e62e2e649b382f516ab41f949b57239/layers/interpolate.py
   - name: yolact/yolact_resnet50_54_800000.pth
     size: 127300392
-    sha384: 7ef5b5367fd30871c77814500bbecbaf32f0a9e5721bba0a1cc4479e78e4d6ed25363ebfe6982b94189a11da1e45cf78
+    checksum: 7ef5b5367fd30871c77814500bbecbaf32f0a9e5721bba0a1cc4479e78e4d6ed25363ebfe6982b94189a11da1e45cf78
     source:
       $type: google_drive
       id: 1yp7ZbbDwvMiFJEq4ptVKTYTI2VeRDXl0

--- a/models/public/yolo-v1-tiny-tf/model.yml
+++ b/models/public/yolo-v1-tiny-tf/model.yml
@@ -19,7 +19,7 @@ task_type: detection
 files:
   - name: yolo-v1-tiny.pb
     size: 63501195
-    sha384: b25e5dfb0c140e06d97ac8c0cf8c44f167a6287f1d4a883d41897973643628efd41621389fb1a27dda7cb404400688e9
+    checksum: b25e5dfb0c140e06d97ac8c0cf8c44f167a6287f1d4a883d41897973643628efd41621389fb1a27dda7cb404400688e9
     source: https://download.01.org/opencv/public_models/022020/tiny_yolo_v1/saved_model.pb
 model_optimizer_args:
   - --input_shape=[1,416,416,3]

--- a/models/public/yolo-v2-tf/model.yml
+++ b/models/public/yolo-v2-tf/model.yml
@@ -21,7 +21,7 @@ task_type: detection
 files:
   - name: yolo-v2.pb
     size: 203970473
-    sha384: d97d0e4736a210879c1e3db84e19a7b9cf8dd138350d66ef65715514a1ce361ec822133789020b6adca9bd25f0d73817
+    checksum: d97d0e4736a210879c1e3db84e19a7b9cf8dd138350d66ef65715514a1ce361ec822133789020b6adca9bd25f0d73817
     source: https://download.01.org/opencv/public_models/102020/yolo-v2-tf/yolo-v2.pb
 model_optimizer_args:
   - --input_shape=[1,608,608,3]

--- a/models/public/yolo-v2-tiny-tf/model.yml
+++ b/models/public/yolo-v2-tiny-tf/model.yml
@@ -21,23 +21,23 @@ task_type: detection
 files:
   - name: yolov2-tiny.weights
     size: 44948600
-    sha384: 48109100a3414fce39d57c8dd1feaee8714423e473f9d4dfd2cf8e1aa23f7e0e5920b9362ad7e3c804f24522e06fe536
+    checksum: 48109100a3414fce39d57c8dd1feaee8714423e473f9d4dfd2cf8e1aa23f7e0e5920b9362ad7e3c804f24522e06fe536
     source: https://pjreddie.com/media/files/yolov2-tiny.weights
   - name: keras-YOLOv3-model-set/tools/model_converter/convert.py
     size: 12937
-    sha384: fd6d1550e3843bc4ae27d1cf53ade56606a01c2162d149bc58ed8d654dfbbe59754a2bfd8e8ca508ecee663b38f6e7bf
+    checksum: fd6d1550e3843bc4ae27d1cf53ade56606a01c2162d149bc58ed8d654dfbbe59754a2bfd8e8ca508ecee663b38f6e7bf
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/tools/model_converter/convert.py
   - name: keras-YOLOv3-model-set/tools/model_converter/keras_to_tensorflow.py
     size: 8370
-    sha384: 1be7f22eafa2c9fd54457938bebbe4d572b7b2abdfed9a1fd720bbb52cdc96151839726957aa8c7dde9cd3abb332807e
+    checksum: 1be7f22eafa2c9fd54457938bebbe4d572b7b2abdfed9a1fd720bbb52cdc96151839726957aa8c7dde9cd3abb332807e
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/tools/model_converter/keras_to_tensorflow.py
   - name: keras-YOLOv3-model-set/common/utils.py
     size: 5002
-    sha384: 7acd0f55fb4c1a0f00df46c2383309bc12715d66c09adb9bcb22d6aea2555ef0478d2d7147fe5cd8de770a23008e4958
+    checksum: 7acd0f55fb4c1a0f00df46c2383309bc12715d66c09adb9bcb22d6aea2555ef0478d2d7147fe5cd8de770a23008e4958
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/common/utils.py
   - name: keras-YOLOv3-model-set/cfg/yolov2-tiny.cfg
     size: 1488
-    sha384: bb52511d6b3c33a066bcd2e41a86d300c854e73b74b9064bb5bfe510ef8801315228abc5e5a89e7dacb3e0c330ed07cd
+    checksum: bb52511d6b3c33a066bcd2e41a86d300c854e73b74b9064bb5bfe510ef8801315228abc5e5a89e7dacb3e0c330ed07cd
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/cfg/yolov2-tiny.cfg
 postprocessing:
   # disable imports that aren't needed for this model and code that uses them

--- a/models/public/yolo-v3-onnx/model.yml
+++ b/models/public/yolo-v3-onnx/model.yml
@@ -22,7 +22,7 @@ description: >-
 task_type: detection
 files:
   - name: yolov3-10.onnx
-    sha384: 832bb4c2be2f9a0eb3e69c426ceaadf472ef260802995fc694b5e8e36a63f0bdfe005058d16e18f091bfdefde3489746
+    checksum: 832bb4c2be2f9a0eb3e69c426ceaadf472ef260802995fc694b5e8e36a63f0bdfe005058d16e18f091bfdefde3489746
     size: 247908721
     source: https://media.githubusercontent.com/media/onnx/models/41ccf18ba5a815dab714899ac234e9b1e4293c20/vision/object_detection_segmentation/yolov3/model/yolov3-10.onnx
 model_optimizer_args:

--- a/models/public/yolo-v3-tf/model.yml
+++ b/models/public/yolo-v3-tf/model.yml
@@ -21,11 +21,11 @@ task_type: detection
 files:
   - name: yolo-v3.pb
     size: 248128731
-    sha384: 169977adef481096e57b73d0602ec9f0a85bd692ad90bd46afcf97d1d808ccfa3d1beb719d91cfd22e6e463e0b27a2bd
+    checksum: 169977adef481096e57b73d0602ec9f0a85bd692ad90bd46afcf97d1d808ccfa3d1beb719d91cfd22e6e463e0b27a2bd
     source: https://download.01.org/opencv/public_models/022020/yolo_v3/yolov3.pb
   - name: yolo-v3.json
     size: 384
-    sha384: 9367c59fbd1208675cfa40fc6ebe1c73c1d316e14d59fc7226d2773ed6d0e9d83b276a294db705ace92f60c7a83e1ad6
+    checksum: 9367c59fbd1208675cfa40fc6ebe1c73c1d316e14d59fc7226d2773ed6d0e9d83b276a294db705ace92f60c7a83e1ad6
     source: https://download.01.org/opencv/public_models/022020/yolo_v3/yolo_v3_new.json
 model_optimizer_args:
   - --input_shape=[1,416,416,3]

--- a/models/public/yolo-v3-tiny-onnx/model.yml
+++ b/models/public/yolo-v3-tiny-onnx/model.yml
@@ -22,7 +22,7 @@ description: >-
 task_type: detection
 files:
   - name: tiny-yolov3-11.onnx
-    sha384: 997714d4731fd00d6bc8c5deb3b9f6ce5b43a21b3eade03bc636f9347c6daa6df9a6e27cc3ff22cbc5d0572eab57314e
+    checksum: 997714d4731fd00d6bc8c5deb3b9f6ce5b43a21b3eade03bc636f9347c6daa6df9a6e27cc3ff22cbc5d0572eab57314e
     size: 35511756
     source: https://media.githubusercontent.com/media/onnx/models/41ccf18ba5a815dab714899ac234e9b1e4293c20/vision/object_detection_segmentation/tiny-yolov3/model/tiny-yolov3-11.onnx
 model_optimizer_args:

--- a/models/public/yolo-v3-tiny-tf/model.yml
+++ b/models/public/yolo-v3-tiny-tf/model.yml
@@ -21,7 +21,7 @@ task_type: detection
 files:
   - name: yolo-v3-tiny-tf.zip
     size: 32836256
-    sha384: 675da89d10e73f2f5150b914ebb840fb9ef6901c08505ef02d141d64dd98c1a0d1ddc5ecd4ede6e1f9a8573ce1abee9f
+    checksum: 675da89d10e73f2f5150b914ebb840fb9ef6901c08505ef02d141d64dd98c1a0d1ddc5ecd4ede6e1f9a8573ce1abee9f
     source: https://download.01.org/opencv/public_models/082020/yolo-v3-tiny-tf/yolo-v3-tiny-tf.zip
 postprocessing:
   - $type: unpack_archive

--- a/models/public/yolo-v4-tf/model.yml
+++ b/models/public/yolo-v4-tf/model.yml
@@ -23,19 +23,19 @@ task_type: detection
 files:
   - name: yolov4.weights
     size: 257717640
-    sha384: bb55bc319c21cde4546f86cee1ad7a74e1056bbe38edcd1da74e754b9a9081d0bd8834e15f7e4f7b46a3e38ce336ada9
+    checksum: bb55bc319c21cde4546f86cee1ad7a74e1056bbe38edcd1da74e754b9a9081d0bd8834e15f7e4f7b46a3e38ce336ada9
     source: https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v3_optimal/yolov4.weights
   - name: keras-YOLOv3-model-set/tools/model_converter/convert.py
     size: 16704
-    sha384: 176b20235fbe2d55faf78e6437693c194a3a989b8c11ad78afe2313926edbabadef1323bc5bbb2bf4c6fb81ff2ba6ccd
+    checksum: 176b20235fbe2d55faf78e6437693c194a3a989b8c11ad78afe2313926edbabadef1323bc5bbb2bf4c6fb81ff2ba6ccd
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/6c9aff7bb0c1660704ad07c85739e95885676e5b/tools/model_converter/convert.py
   - name: keras-YOLOv3-model-set/yolo4/models/layers.py
     size: 15535
-    sha384: f8d67ea5f2d293c00a967b7aa85efb03100e2420d0dc702cb38cd49c31d1b6e367469bd455c1870828184268d94007b7
+    checksum: f8d67ea5f2d293c00a967b7aa85efb03100e2420d0dc702cb38cd49c31d1b6e367469bd455c1870828184268d94007b7
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/6c9aff7bb0c1660704ad07c85739e95885676e5b/yolo4/models/layers.py
   - name: keras-YOLOv3-model-set/cfg/yolov4.cfg
     size: 12208
-    sha384: ccd87e37a99bf98582ceb39af3cd3b9ddb550c382f433f177c86f896fc1ad621ef0e5e51da6318415c853bf2311e5b9b
+    checksum: ccd87e37a99bf98582ceb39af3cd3b9ddb550c382f433f177c86f896fc1ad621ef0e5e51da6318415c853bf2311e5b9b
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/6c9aff7bb0c1660704ad07c85739e95885676e5b/cfg/yolov4.cfg
 postprocessing:
   # disable imports that aren't needed for this model and code that uses them

--- a/models/public/yolo-v4-tiny-tf/model.yml
+++ b/models/public/yolo-v4-tiny-tf/model.yml
@@ -23,27 +23,27 @@ task_type: detection
 files:
   - name: yolov4-tiny.weights
     size: 24251276
-    sha384: ee417b9217aa806b93110e8c688c06f7d75778645372667712f989fc961175244162d9a74f402dfedc64b80b3a21e58d
+    checksum: ee417b9217aa806b93110e8c688c06f7d75778645372667712f989fc961175244162d9a74f402dfedc64b80b3a21e58d
     source: https://github.com/AlexeyAB/darknet/releases/download/darknet_yolo_v4_pre/yolov4-tiny.weights
   - name: keras-YOLOv3-model-set/tools/model_converter/convert.py
     size: 16060
-    sha384: 6a72c81fce395d3d7f16b713fa70e539aabe53403baac7f6f1e7a51ad11e50cc37a708b96d9b239c89d1a1210d8edd7d
+    checksum: 6a72c81fce395d3d7f16b713fa70e539aabe53403baac7f6f1e7a51ad11e50cc37a708b96d9b239c89d1a1210d8edd7d
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/6b4a0ee63771262363e8224b0ee915cad6c5e93e/tools/model_converter/convert.py
   - name: keras-YOLOv3-model-set/tools/model_converter/keras_to_tensorflow.py
     size: 8370
-    sha384: 1be7f22eafa2c9fd54457938bebbe4d572b7b2abdfed9a1fd720bbb52cdc96151839726957aa8c7dde9cd3abb332807e
+    checksum: 1be7f22eafa2c9fd54457938bebbe4d572b7b2abdfed9a1fd720bbb52cdc96151839726957aa8c7dde9cd3abb332807e
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/tools/model_converter/keras_to_tensorflow.py
   - name: keras-YOLOv3-model-set/common/utils.py
     size: 5002
-    sha384: 7acd0f55fb4c1a0f00df46c2383309bc12715d66c09adb9bcb22d6aea2555ef0478d2d7147fe5cd8de770a23008e4958
+    checksum: 7acd0f55fb4c1a0f00df46c2383309bc12715d66c09adb9bcb22d6aea2555ef0478d2d7147fe5cd8de770a23008e4958
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/common/utils.py
   - name: keras-YOLOv3-model-set/yolo4/models/layers.py
     size: 15171
-    sha384: b949a66aeac84fe0ff6990961c8b39d1dc6585e4ce206c2fbafa5ee5f1063f7a55424beeacf55932bf8afe621c308a3e
+    checksum: b949a66aeac84fe0ff6990961c8b39d1dc6585e4ce206c2fbafa5ee5f1063f7a55424beeacf55932bf8afe621c308a3e
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/d38c3d865f7190ee9b19a30e91f2b750a31320c1/yolo4/models/layers.py
   - name: keras-YOLOv3-model-set/cfg/yolov4-tiny.cfg
     size: 3028
-    sha384: 387ffb240df5f9c81355145a72a5d6bba085db3118b0f61ad214d3d3491e957f3b3ab9498eb8b873c098404fa5235cb7
+    checksum: 387ffb240df5f9c81355145a72a5d6bba085db3118b0f61ad214d3d3491e957f3b3ab9498eb8b873c098404fa5235cb7
     source: https://github.com/david8862/keras-YOLOv3-model-set/raw/6b4a0ee63771262363e8224b0ee915cad6c5e93e/cfg/yolov4-tiny.cfg
 postprocessing:
   # disable imports that aren't needed for this model and code that uses them

--- a/models/public/yolof/model.yml
+++ b/models/public/yolof/model.yml
@@ -24,86 +24,86 @@ files:
   # cvpods
   - name: cvpods/__init__.py
     size: 274
-    sha384: 89d7d3a6a8a220f9c6eb3420bfe93ee29f486051ee65cb0957fc9eb7422179f1a1d3574638e26a6006041ff3a8f6bab8
+    checksum: 89d7d3a6a8a220f9c6eb3420bfe93ee29f486051ee65cb0957fc9eb7422179f1a1d3574638e26a6006041ff3a8f6bab8
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/__init__.py
   #  layers
   - name: cvpods/layers/__init__.py
     size: 1276
-    sha384: b5b34410c514a1e7b4e7c203b4b183b30b3a35fc18e6516da7b54b83ae236c6bdaea6b439f2c563171dc015c48287ce4
+    checksum: b5b34410c514a1e7b4e7c203b4b183b30b3a35fc18e6516da7b54b83ae236c6bdaea6b439f2c563171dc015c48287ce4
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/layers/__init__.py
   - name: cvpods/layers/batch_norm.py
     size: 9872
-    sha384: b331702dfac0c680870e1c164442ab647be88e54258f6a4e3c7f777e471a4719ffa8ebd8fcdc7e4e8f8a1f15a726c005
+    checksum: b331702dfac0c680870e1c164442ab647be88e54258f6a4e3c7f777e471a4719ffa8ebd8fcdc7e4e8f8a1f15a726c005
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/layers/batch_norm.py
   - name: cvpods/layers/shape_spec.py
     size: 672
-    sha384: ac251409d116121ee0acd10cd86a6c367d003169fd581e4f9c562bb20359e69642d8a720cf39bfd16cc2909782108172
+    checksum: ac251409d116121ee0acd10cd86a6c367d003169fd581e4f9c562bb20359e69642d8a720cf39bfd16cc2909782108172
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/layers/shape_spec.py
   - name: cvpods/layers/wrappers.py
     size: 15619
-    sha384: f6caf877a6c1c593f911240eaf28e71880ab220b80653796455effa0d7d38d5241bcfd0357171fddd0431d65364b6920
+    checksum: f6caf877a6c1c593f911240eaf28e71880ab220b80653796455effa0d7d38d5241bcfd0357171fddd0431d65364b6920
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/layers/wrappers.py
   #  modeling
   - name: cvpods/modeling/anchor_generator.py
     size: 15718
-    sha384: e55872f196946705bc66b82234a91d8b893810fe8f94bc72ef1be211334772904ed81aa0e3d89275dd3f93524dfe2b5e
+    checksum: e55872f196946705bc66b82234a91d8b893810fe8f94bc72ef1be211334772904ed81aa0e3d89275dd3f93524dfe2b5e
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/modeling/anchor_generator.py
   - name: cvpods/modeling/backbone/__init__.py
     size: 905
-    sha384: d95a02c8a1bf4549892b3082ea0199902cdd9a614107c9042d48ed150b33eeecab8a199a7e40da337c42dff874efde2c
+    checksum: d95a02c8a1bf4549892b3082ea0199902cdd9a614107c9042d48ed150b33eeecab8a199a7e40da337c42dff874efde2c
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/modeling/backbone/__init__.py
   - name: cvpods/modeling/backbone/backbone.py
     size: 1632
-    sha384: ade8d08b8f1d53a3c0f5ccbe40da905fc4f9222eab9955fa05246fc3bba309b40a17b9f63e7a199683f73aa5c1f433ea
+    checksum: ade8d08b8f1d53a3c0f5ccbe40da905fc4f9222eab9955fa05246fc3bba309b40a17b9f63e7a199683f73aa5c1f433ea
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/modeling/backbone/backbone.py
   - name: cvpods/modeling/nn_utils/__init__.py
     size: 0
-    sha384: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+    checksum: 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/modeling/nn_utils/__init__.py
   - name: cvpods/modeling/nn_utils/weight_init.py
     size: 3756
-    sha384: 6b6982835f798c5e48077b3cc5cbda8ce1232742d2b360ef0b967dbb509e6f0dd5f496b4bd57c89f03b7d4477553dca0
+    checksum: 6b6982835f798c5e48077b3cc5cbda8ce1232742d2b360ef0b967dbb509e6f0dd5f496b4bd57c89f03b7d4477553dca0
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/modeling/nn_utils/weight_init.py
   #  structures
   - name: cvpods/structures/__init__.py
     size: 520
-    sha384: 1fa10738d59a77e09c3df06ed2ed2c3f5943122daaf020a8d24db3754bf855e3c1a3687bc6ffc3320e2d18152dcefc97
+    checksum: 1fa10738d59a77e09c3df06ed2ed2c3f5943122daaf020a8d24db3754bf855e3c1a3687bc6ffc3320e2d18152dcefc97
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/structures/__init__.py
   - name: cvpods/structures/boxes.py
     size: 15620
-    sha384: faa7e2927da6eafee119acfa14b0b72ba312d9114dd7235388fbd86d900bbb1ac29595fe7038017588ae43986778e78e
+    checksum: faa7e2927da6eafee119acfa14b0b72ba312d9114dd7235388fbd86d900bbb1ac29595fe7038017588ae43986778e78e
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/cvpods/structures/boxes.py
   # models
   - name: models/cspdarknet.py
     size: 11889
-    sha384: 8cf272cdcf6296bfc06271e0d113908b086a4242a50c777d6acfcfcbdf827351cae347983aa44d876461f613ab344da9
+    checksum: 8cf272cdcf6296bfc06271e0d113908b086a4242a50c777d6acfcfcbdf827351cae347983aa44d876461f613ab344da9
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/playground/detection/coco/yolof/yolof.cspdarknet53.DC5.9x.stage2.3x/cspdarknet.py
   # yolof_base
   - name: yolof_base/__init__.py
     size: 156
-    sha384: f9a49cf1ba3eb106ba5d71f9c425e41410fb72e35b69cf38a1d0573b04926f9ee2af073bb548ba11f4fa422e0698894c
+    checksum: f9a49cf1ba3eb106ba5d71f9c425e41410fb72e35b69cf38a1d0573b04926f9ee2af073bb548ba11f4fa422e0698894c
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/playground/detection/coco/yolof/yolof_base/__init__.py
   - name: yolof_base/decoder.py
     size: 4473
-    sha384: c0c5c894887812b088919f2194bfc7a096c674760095afdff30a624f482073d7f1801930f12fae626fb96f3ea5976126
+    checksum: c0c5c894887812b088919f2194bfc7a096c674760095afdff30a624f482073d7f1801930f12fae626fb96f3ea5976126
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/playground/detection/coco/yolof/yolof_base/decoder.py
   - name: yolof_base/encoder.py
     size: 4588
-    sha384: a2ed22ceefac9c93e07e8a18936248b389856d0b7bbc8b048368eb2313726934b0c74656efd18049b89cb7a510d27e41
+    checksum: a2ed22ceefac9c93e07e8a18936248b389856d0b7bbc8b048368eb2313726934b0c74656efd18049b89cb7a510d27e41
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/playground/detection/coco/yolof/yolof_base/encoder.py
   - name: yolof_base/utils.py
     size: 1615
-    sha384: 5b21efa0002bd3b44f3af8cd85f021037110ef32ff5cd8e6418a512da57d2c2f7b9e381288acac086ed68293f164cadd
+    checksum: 5b21efa0002bd3b44f3af8cd85f021037110ef32ff5cd8e6418a512da57d2c2f7b9e381288acac086ed68293f164cadd
     source: https://raw.githubusercontent.com/megvii-model/YOLOF/d09c5a64ff354e6f4141c26d68574f9f9f0b84a2/playground/detection/coco/yolof/yolof_base/utils.py
   # ckpt
   - name: ckpt/YOLOF_CSP_D_53_DC5_9x.pth
     size: 385559524
-    sha384: 8bc639e0ce4825b0891e9ea50c4e7898c9eb7548de725490a135a2368162e637dc43658eb696e27f1d4a1649c2108e03
+    checksum: 8bc639e0ce4825b0891e9ea50c4e7898c9eb7548de725490a135a2368162e637dc43658eb696e27f1d4a1649c2108e03
     source: https://upzqqa.bn.files.1drv.com/y4mwk1QklsZktMCS8X9bmTcxB8cqyMbouGOKV_8fjN0-nISdWdiRAoZwkzOqKHSq7bOmFchzhWz52mHMRvXC6sa-rjEPwP_QqVxjc9dePvpE-7X3Lr5sDyV0zlLky_MClBOSfcpWPd_Fro-BKaE9KDC20_eukQJRREXf5uWp8w0CHHMZ2JN9wv38W17KkSy-EspmHSLvPrkw2BysFTeOTJJ6A
   # addict
   - name: lib/addict-2.4.0-py3-none-any.whl
     size: 3832
-    sha384: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
+    checksum: 0b3d7c226551078ffcd70e4d512194f2cb67c6c06dc8c7a7b8001752b842b934990817f9236f73fb7c38cba5573205ab
     source: https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl
 postprocessing:
   # unpack

--- a/models/public/yolox-tiny/model.yml
+++ b/models/public/yolox-tiny/model.yml
@@ -24,35 +24,35 @@ task_type: detection
 files:
   - name: models/yolox.py
     size: 1374
-    sha384: eb0fe479a6b65b1292644955e7c3717dab1271d5854a4ec5b3d671f18805848cbddd8541b779394daeb96acb7e3fba06
+    checksum: eb0fe479a6b65b1292644955e7c3717dab1271d5854a4ec5b3d671f18805848cbddd8541b779394daeb96acb7e3fba06
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/yolox.py
   - name: models/yolo_head.py
     size: 23223
-    sha384: d48caa0874839ca3d45e5209db339733ecdafeb02af7216278544c995539beda6a07549a317cca0055ecba13c2b0ee50
+    checksum: d48caa0874839ca3d45e5209db339733ecdafeb02af7216278544c995539beda6a07549a317cca0055ecba13c2b0ee50
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/yolo_head.py
   - name: models/yolo_pafpn.py
     size: 3540
-    sha384: 9037b1ec330b8071e9e8984410ebfc54119385a47fde1f02b9831a50f0383d5701b4e778a49be37d5252da029e956322
+    checksum: 9037b1ec330b8071e9e8984410ebfc54119385a47fde1f02b9831a50f0383d5701b4e778a49be37d5252da029e956322
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/yolo_pafpn.py
   - name: models/darknet.py
     size: 6028
-    sha384: 77cb6df3b46d6d9d98c4bdccaba8faeab817110a8133b2a57595e3028697076ecea604724c71a983d1d37b930d5ab671
+    checksum: 77cb6df3b46d6d9d98c4bdccaba8faeab817110a8133b2a57595e3028697076ecea604724c71a983d1d37b930d5ab671
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/darknet.py
   - name: models/network_blocks.py
     size: 6102
-    sha384: 96f7f932abae06f57589c30e2e460a0c10064ca095c6a4a687271a19f0d38977dab1897db8f902c6883ba65477e6463d
+    checksum: 96f7f932abae06f57589c30e2e460a0c10064ca095c6a4a687271a19f0d38977dab1897db8f902c6883ba65477e6463d
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/network_blocks.py
   - name: models/losses.py
     size: 1663
-    sha384: 0c1373e269a1e99f9c77eb88cb9fc279f72cd4d0146d01ff108c10f3fd999a2fe15c1e56e31deeae92d26e5190d0c24c
+    checksum: 0c1373e269a1e99f9c77eb88cb9fc279f72cd4d0146d01ff108c10f3fd999a2fe15c1e56e31deeae92d26e5190d0c24c
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/models/losses.py
   - name: utils/boxes.py
     size: 4481
-    sha384: 6f92071f17c19f8bcac4cf7d38901b4d48e40cbba81ca53c455bd2e17895b3c98c03de6dbb8be9bd12f2ab34cfa7fa0c
+    checksum: 6f92071f17c19f8bcac4cf7d38901b4d48e40cbba81ca53c455bd2e17895b3c98c03de6dbb8be9bd12f2ab34cfa7fa0c
     source: https://raw.githubusercontent.com/Megvii-BaseDetection/YOLOX/69f1173a569f1e0cc41025146a32b5d5fa06dd26/yolox/utils/boxes.py
   - name: yolox_tiny.pth
     size: 40726661
-    sha384: 9083e8c9e2388c0c1ddde44a97f0304a10f8ffc2219943a4b5280d9791b96d9998129c8ba34b5dd2902cfd715fcd8138
+    checksum: 9083e8c9e2388c0c1ddde44a97f0304a10f8ffc2219943a4b5280d9791b96d9998129c8ba34b5dd2902cfd715fcd8138
     source: https://github.com/Megvii-BaseDetection/storage/releases/download/0.0.1/yolox_tiny.pth
 postprocessing:
   - $type: regex_replace

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/base.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/base.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from openvino.model_zoo.download_engine import validation
+
+
+class TaggedBase:
+    @classmethod
+    def deserialize(cls, value):
+        try:
+            return cls.types[value['$type']].deserialize(value)
+        except KeyError:
+            raise validation.DeserializationError('Unknown "$type": "{}"'.format(value['$type']))

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
@@ -26,8 +26,8 @@ CHUNK_SIZE = 1 << 15 if sys.stdout.isatty() else 1 << 20
 
 
 class NullCache:
-    def has(self, hash, hash_len): return False
-    def get(self, model_file, path, reporter, hash_len): return False
+    def has(self, hash): return False
+    def get(self, model_file, path, reporter): return False
     def put(self, hash, path): pass
 
 
@@ -41,16 +41,15 @@ class DirCache:
         self._staging_dir = self._cache_dir / 'staging'
         self._staging_dir.mkdir(exist_ok=True)
 
-    def _hash_path(self, hash, hash_len):
-        assert len(hash) == hash_len
+    def _hash_path(self, hash):
         hash_str = hash.hex().lower()
         return self._cache_dir / hash_str[:2] / hash_str[2:]
 
-    def has(self, hash, hash_len):
-        return self._hash_path(hash, hash_len).exists()
+    def has(self, hash):
+        return self._hash_path(hash).exists()
 
-    def get(self, model_file, path, reporter, hash_len):
-        cache_path = self._hash_path(model_file.checksum.value, hash_len)
+    def get(self, model_file, path, reporter):
+        cache_path = self._hash_path(model_file.checksum.value)
         cache_sha = model_file.checksum.type
         cache_size = 0
 

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
@@ -108,11 +108,11 @@ class Downloader:
 
     def _try_retrieve_from_cache(self, reporter, model_file, destination):
         try:
-            if self.cache.has(model_file.checksum.value, model_file.checksum.type.digest_size):
+            if self.cache.has(model_file.checksum.value):
                 reporter.job_context.check_interrupted()
 
                 reporter.print_section_heading('Retrieving {} from the cache', destination)
-                if not self.cache.get(model_file, destination, reporter, model_file.checksum.type.digest_size):
+                if not self.cache.get(model_file, destination, reporter):
                     reporter.print('Will retry from the original source.')
                     reporter.print()
                     return False

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/file_source.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/file_source.py
@@ -15,18 +15,10 @@
 import re
 import requests
 
-from openvino.model_zoo.download_engine import validation
+from openvino.model_zoo.download_engine import base, validation
 
 
-class TaggedBase:
-    @classmethod
-    def deserialize(cls, value):
-        try:
-            return cls.types[value['$type']].deserialize(value)
-        except KeyError:
-            raise validation.DeserializationError('Unknown "$type": "{}"'.format(value['$type']))
-
-class FileSource(TaggedBase):
+class FileSource(base.TaggedBase):
     RE_CONTENT_RANGE_VALUE = re.compile(r'bytes (\d+)-\d+/(?:\d+|\*)')
 
     types = {}

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/postprocessing.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/postprocessing.py
@@ -15,9 +15,9 @@
 import re
 import shutil
 
-from openvino.model_zoo.download_engine import file_source, validation
+from openvino.model_zoo.download_engine import base, validation
 
-class Postproc(file_source.TaggedBase):
+class Postproc(base.TaggedBase):
     types = {}
 
 class PostprocRegexReplace(Postproc):

--- a/tools/model_tools/src/openvino/model_zoo/schema.yml
+++ b/tools/model_tools/src/openvino/model_zoo/schema.yml
@@ -23,7 +23,14 @@ required:
       required:
         name: "//str"
         size: "//int"
-        sha384: "//str"
+        checksum:
+          type: "//any"
+          of:
+            - "//str"
+            - type: "//rec"
+              required:
+                $type: "//str"
+                value: "//str"
         source:
           type: "//any"
           of:


### PR DESCRIPTION
Support extension of download engine with different hash algorithms

New checksum format for model.yml
by default for sha384:
```
checksum: str
```
for other algorithms extensions:
```
checksum:
  $type: str (sha256|sha384|md5sum|…)
  value: str
```