### PR TITLE
Fix kenlm version on the latest stable

### DIFF
--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -129,5 +129,5 @@ setup(
     tests_require=[read("requirements-test.in")],
     cmdclass={'test': PyTest, 'install_core': CoreInstall},
     extras_require={'extra': ['pycocotools>=2.0.2', 'torch>=0.4.0', 'torchvision>=0.2.1', 'lpips',
-                              'kenlm @ git+https://github.com/kpu/kenlm.git#egg=kenlm@f01e12d83c7fd03ebe6656e0ad6d73a3e022bd50']}
+                              'kenlm @ git+https://github.com/kpu/kenlm.git@f01e12d83c7fd03ebe6656e0ad6d73a3e022bd50#egg=kenlm']}
 )

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -129,5 +129,5 @@ setup(
     tests_require=[read("requirements-test.in")],
     cmdclass={'test': PyTest, 'install_core': CoreInstall},
     extras_require={'extra': ['pycocotools>=2.0.2', 'torch>=0.4.0', 'torchvision>=0.2.1', 'lpips',
-                              'kenlm @ git+https://github.com/kpu/kenlm.git#egg=kenlm']}
+                              'kenlm @ git+https://github.com/kpu/kenlm.git#egg=kenlm@f01e12d83c7fd03ebe6656e0ad6d73a3e022bd50']}
 )


### PR DESCRIPTION
Looks like https://github.com/kpu/kenlm/commit/5cea457db26950a73d638425c183b368c06ed7c6 commit broken the ability to build kenlm module on Windows: https://openvino-ci.intel.com/job/private-ci/job/ie/job/accuracy-windows-acc_test/3989/

PR to check this fix in OpenVINO validation: https://github.com/intel-innersource/frameworks.ai.openvino.ci.product-configs/pull/664 

The issue submitted on kenlm: https://github.com/kpu/kenlm/issues/364 