### PR TITLE
Demos: adopt yolo demo for new IR format

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
@@ -25,6 +25,7 @@ class Metadata:
     precision: str = ''
     type: str = ''
     meta: Dict = field(default_factory=dict)
+    index: int = -1
 
 
 class ModelAdapter(metaclass=abc.ABCMeta):

--- a/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
@@ -131,10 +131,24 @@ class OpenvinoAdapter(ModelAdapter):
 
     def _get_meta_from_ngraph(self, layers_info):
         ng_func = ngraph.function_from_cnn(self.net)
-        for node in ng_func.get_ordered_ops():
+        for idx, node in enumerate(ng_func.get_ordered_ops()):
             layer_name = node.get_friendly_name()
             if layer_name not in layers_info.keys():
                 continue
-            layers_info[layer_name].meta = node._get_attributes()
+            layers_info[layer_name].meta = node.get_attributes()
             layers_info[layer_name].type = node.get_type_name()
+            layers_info[layer_name].index = idx
         return layers_info
+
+    def operations_by_type(self, operation_type):
+        layers_info = {}
+        ng_func = ngraph.function_from_cnn(self.net)
+        for idx, node in enumerate(ng_func.get_ordered_ops()):
+            if node.get_type_name() == operation_type:
+                layer_name = node.get_friendly_name()
+                layers_info[layer_name] = Metadata()
+                layers_info[layer_name].meta = node.get_attributes()
+                layers_info[layer_name].type = node.get_type_name()
+                layers_info[layer_name].index = idx
+        return layers_info
+

--- a/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
@@ -151,4 +151,3 @@ class OpenvinoAdapter(ModelAdapter):
                 layers_info[layer_name].type = node.get_type_name()
                 layers_info[layer_name].index = idx
         return layers_info
-

--- a/demos/common/python/openvino/model_zoo/model_api/models/yolo.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/yolo.py
@@ -117,7 +117,6 @@ class YOLO(DetectionModel):
                         closest_name = reg
                 if closest_name is not None:
                     meta = yolo_regions[closest_name].meta
-                    print(meta, closest_name, yolo_regions[closest_name].index, name, info.index)
             params = self.Params(meta, shape[2:4])
             output_info[name] = (shape, params)
         return output_info


### PR DESCRIPTION
due to alignment of layouts with original frameworks, yolo models get additional Transpose operation after YoloRegion. it breaks our logic for getting attributes. This PR fix it in python demo