### PR TITLE
Changed framework from dlsdk to openvino in AC configs, added deprecation warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ This example uses validation configuration file for [DenseNet-121](models/public
 models:
   - name: densenet-121-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/intel/action-recognition-0001/accuracy-check.yml
+++ b/models/intel/action-recognition-0001/accuracy-check.yml
@@ -10,7 +10,7 @@ evaluations:
           adapter: classification
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: kinetics-400

--- a/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
+++ b/models/intel/age-gender-recognition-retail-0013/accuracy-check.yml
@@ -2,11 +2,11 @@ models:
   - name: age-gender-recognition-retail-0013
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: age_gender
           gender_out: prob
-          age_out: age_conv3
+          age_out: fc3_a
 
     datasets:
       - name: age_gender

--- a/models/intel/asl-recognition-0004/accuracy-check.yml
+++ b/models/intel/asl-recognition-0004/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: asl-recognition-0004
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
         inputs:
           - type: INPUT

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-large-uncased-whole-word-masking-squad-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: bert_question_answering
           start_token_logits_output: "output_s"

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-emb-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-large-uncased-whole-word-masking-squad-emb-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: bert_question_answering_embedding

--- a/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/accuracy-check.yml
+++ b/models/intel/bert-large-uncased-whole-word-masking-squad-int8-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-large-uncased-whole-word-masking-squad-int8-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: bert_question_answering
           start_token_logits_output: "output_s"

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0001/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-small-uncased-whole-word-masking-squad-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: bert_question_answering
           start_token_logits_output: "output_s"

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-0002/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-small-uncased-whole-word-masking-squad-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: bert_question_answering
           start_token_logits_output: "output_s"

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-emb-int8-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-small-uncased-whole-word-masking-squad-emb-int8-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: bert_question_answering_embedding

--- a/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/accuracy-check.yml
+++ b/models/intel/bert-small-uncased-whole-word-masking-squad-int8-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-small-uncased-whole-word-masking-squad-int8-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: bert_question_answering
           start_token_logits_output: "output_s"

--- a/models/intel/common-sign-language-0002/accuracy-check.yml
+++ b/models/intel/common-sign-language-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: common-sign-language-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
         inputs:
           - type: INPUT

--- a/models/intel/driver-action-recognition-adas-0002/accuracy-check.yml
+++ b/models/intel/driver-action-recognition-adas-0002/accuracy-check.yml
@@ -10,7 +10,7 @@ evaluations:
           adapter: classification
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: driver_action_recognition_dataset

--- a/models/intel/emotions-recognition-retail-0003/accuracy-check.yml
+++ b/models/intel/emotions-recognition-retail-0003/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: emotions-recognition-retail-0003
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/intel/face-detection-0200/accuracy-check.yml
+++ b/models/intel/face-detection-0200/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-0200
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-detection-0202/accuracy-check.yml
+++ b/models/intel/face-detection-0202/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-0202
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-detection-0204/accuracy-check.yml
+++ b/models/intel/face-detection-0204/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-0204
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-detection-0205/accuracy-check.yml
+++ b/models/intel/face-detection-0205/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-0205
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: class_agnostic_detection
           scale: 0.00240384615

--- a/models/intel/face-detection-0206/accuracy-check.yml
+++ b/models/intel/face-detection-0206/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-0206
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: class_agnostic_detection
           scale: 0.0015625

--- a/models/intel/face-detection-adas-0001/accuracy-check.yml
+++ b/models/intel/face-detection-adas-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-adas-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-detection-retail-0004/accuracy-check.yml
+++ b/models/intel/face-detection-retail-0004/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-retail-0004
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-detection-retail-0005/accuracy-check.yml
+++ b/models/intel/face-detection-retail-0005/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-detection-retail-0005
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/face-reidentification-retail-0095/accuracy-check.yml
+++ b/models/intel/face-reidentification-retail-0095/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: face-reidentification-retail-0095
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/facial-landmarks-35-adas-0002/accuracy-check.yml
+++ b/models/intel/facial-landmarks-35-adas-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: facial-landmarks-35-adas-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: landmarks_regression
 
     datasets:

--- a/models/intel/facial-landmarks-98-detection-0001/accuracy-check.yml
+++ b/models/intel/facial-landmarks-98-detection-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: facial-landmarks-98-detection-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: facial_landmarks_detection
           output_blob: 3851

--- a/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: faster-rcnn-resnet101-coco-sparse-60-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ssd
         inputs:

--- a/models/intel/formula-recognition-medium-scan-0001/accuracy-check.yml
+++ b/models/intel/formula-recognition-medium-scan-0001/accuracy-check.yml
@@ -8,7 +8,7 @@ evaluations:
       max_seq_len: '192'
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: im2latex_medium_photographed

--- a/models/intel/formula-recognition-polynomials-handwritten-0001/accuracy-check.yml
+++ b/models/intel/formula-recognition-polynomials-handwritten-0001/accuracy-check.yml
@@ -8,7 +8,7 @@ evaluations:
       max_seq_len: "192"
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: im2latex_polynomials_handwritten

--- a/models/intel/gaze-estimation-adas-0002/accuracy-check.yml
+++ b/models/intel/gaze-estimation-adas-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: gaze-estimation-adas-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         inputs:
           - name: left_eye_image
             type: INPUT

--- a/models/intel/handwritten-english-recognition-0001/accuracy-check.yml
+++ b/models/intel/handwritten-english-recognition-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: handwritten-english-recognition-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctc_greedy_search_decoder
           logits_output: output

--- a/models/intel/handwritten-japanese-recognition-0001/accuracy-check.yml
+++ b/models/intel/handwritten-japanese-recognition-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: handwritten-japanese-recognition-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ctc_greedy_search_decoder
 
     datasets:

--- a/models/intel/handwritten-score-recognition-0003/accuracy-check.yml
+++ b/models/intel/handwritten-score-recognition-0003/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: handwritten-score-recognition-0003
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: beam_search_decoder
 
     datasets:

--- a/models/intel/handwritten-simplified-chinese-recognition-0001/accuracy-check.yml
+++ b/models/intel/handwritten-simplified-chinese-recognition-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: handwritten-simplified-chinese-recognition-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ctc_greedy_search_decoder
 
     datasets:

--- a/models/intel/head-pose-estimation-adas-0001/accuracy-check.yml
+++ b/models/intel/head-pose-estimation-adas-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: head-pose-estimation-adas-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: head_pose
           angle_yaw: angle_y_fc

--- a/models/intel/horizontal-text-detection-0001/accuracy-check.yml
+++ b/models/intel/horizontal-text-detection-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: horizontal-text-detection-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: class_agnostic_detection
           scale: 0.0014204

--- a/models/intel/human-pose-estimation-0001/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: human-pose-estimation-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation

--- a/models/intel/human-pose-estimation-0005/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0005/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: human-pose-estimation-0005
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation_ae

--- a/models/intel/human-pose-estimation-0006/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0006/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: human-pose-estimation-0006
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation_ae

--- a/models/intel/human-pose-estimation-0007/accuracy-check.yml
+++ b/models/intel/human-pose-estimation-0007/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: human-pose-estimation-0007
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation_ae

--- a/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: icnet-camvid-ava-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
     datasets:
       - name: CamVid

--- a/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-30-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: icnet-camvid-ava-sparse-30-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
     datasets:
       - name: CamVid

--- a/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/icnet-camvid-ava-sparse-60-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: icnet-camvid-ava-sparse-60-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
     datasets:
       - name: CamVid

--- a/models/intel/image-retrieval-0001/accuracy-check.yml
+++ b/models/intel/image-retrieval-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: image-retrieval-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/instance-segmentation-person-0007/accuracy-check.yml
+++ b/models/intel/instance-segmentation-person-0007/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-person-0007
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/instance-segmentation-security-0002/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-security-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/instance-segmentation-security-0091/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0091/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-security-0091
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/instance-segmentation-security-0228/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-0228/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-security-0228
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/instance-segmentation-security-1039/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-1039/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-security-1039
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/instance-segmentation-security-1040/accuracy-check.yml
+++ b/models/intel/instance-segmentation-security-1040/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: instance-segmentation-security-1040
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           classes_out: labels

--- a/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
+++ b/models/intel/landmarks-regression-retail-0009/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: landmarks-regression-retail-0009
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: landmarks_regression
 
     datasets:

--- a/models/intel/license-plate-recognition-barrier-0001/accuracy-check.yml
+++ b/models/intel/license-plate-recognition-barrier-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: license-plate-recognition-barrier-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: lpr
         inputs:
           - name: seq_ind

--- a/models/intel/machine-translation-nar-de-en-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-de-en-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-de-en-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: machine-translation-nar-de-en-0002/tokenizer_tgt/vocab.json

--- a/models/intel/machine-translation-nar-en-de-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-en-de-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-en-de-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: machine-translation-nar-en-de-0002/tokenizer_tgt/vocab.json

--- a/models/intel/machine-translation-nar-en-ru-0001/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-en-ru-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-en-ru-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: tokenizer_tgt/vocab.json

--- a/models/intel/machine-translation-nar-en-ru-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-en-ru-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-en-ru-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: tokenizer_tgt/vocab.json

--- a/models/intel/machine-translation-nar-ru-en-0001/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-ru-en-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-ru-en-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: tokenizer_tgt/vocab.json

--- a/models/intel/machine-translation-nar-ru-en-0002/accuracy-check.yml
+++ b/models/intel/machine-translation-nar-ru-en-0002/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: machine-translation-nar-ru-en-0002
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: narnmt
           vocabulary_file: tokenizer_tgt/vocab.json

--- a/models/intel/noise-suppression-denseunet-ll-0001/accuracy-check.yml
+++ b/models/intel/noise-suppression-denseunet-ll-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: noise-suppression-denseunet-ll-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: noise_suppression
           output_blob: output

--- a/models/intel/noise-suppression-poconetlike-0001/accuracy-check.yml
+++ b/models/intel/noise-suppression-poconetlike-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: noise-suppression-poconetlike-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: noise_suppression
           output_blob: output

--- a/models/intel/pedestrian-and-vehicle-detector-adas-0001/accuracy-check.yml
+++ b/models/intel/pedestrian-and-vehicle-detector-adas-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: pedestrian-and-vehicle-detector-adas-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/pedestrian-detection-adas-0002/accuracy-check.yml
+++ b/models/intel/pedestrian-detection-adas-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: pedestrian-detection-adas-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-attributes-recognition-crossroad-0230/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0230/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-attributes-recognition-crossroad-0230
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: person_attributes
           attributes_recognition_out: "453"

--- a/models/intel/person-attributes-recognition-crossroad-0234/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0234/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-attributes-recognition-crossroad-0234
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: person_attributes
           attributes_recognition_out: "attributes"

--- a/models/intel/person-attributes-recognition-crossroad-0238/accuracy-check.yml
+++ b/models/intel/person-attributes-recognition-crossroad-0238/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-attributes-recognition-crossroad-0238
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: person_attributes
           attributes_recognition_out: "attributes"

--- a/models/intel/person-detection-0106/accuracy-check.yml
+++ b/models/intel/person-detection-0106/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0106
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           boxes_out: boxes

--- a/models/intel/person-detection-0200/accuracy-check.yml
+++ b/models/intel/person-detection-0200/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0200
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-detection-0201/accuracy-check.yml
+++ b/models/intel/person-detection-0201/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0201
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-detection-0202/accuracy-check.yml
+++ b/models/intel/person-detection-0202/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0202
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-detection-0203/accuracy-check.yml
+++ b/models/intel/person-detection-0203/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0203
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
 
           type: class_agnostic_detection

--- a/models/intel/person-detection-0301/accuracy-check.yml
+++ b/models/intel/person-detection-0301/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0301
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
 
           type: class_agnostic_detection

--- a/models/intel/person-detection-0302/accuracy-check.yml
+++ b/models/intel/person-detection-0302/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0302
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
 
           type: class_agnostic_detection

--- a/models/intel/person-detection-0303/accuracy-check.yml
+++ b/models/intel/person-detection-0303/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-0303
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
 
           type: class_agnostic_detection

--- a/models/intel/person-detection-action-recognition-0005/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-0005/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-action-recognition-0005
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: action_detection
           priorbox_out: mbox/priorbox

--- a/models/intel/person-detection-action-recognition-0006/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-0006/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: person-detection-action-recognition-0006
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: action_detection
           multihead_net: True

--- a/models/intel/person-detection-action-recognition-teacher-0002/accuracy-check.yml
+++ b/models/intel/person-detection-action-recognition-teacher-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-action-recognition-teacher-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: action_detection
           priorbox_out: mbox/priorbox

--- a/models/intel/person-detection-asl-0001/accuracy-check.yml
+++ b/models/intel/person-detection-asl-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-asl-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: class_agnostic_detection
           scale: 0.003125

--- a/models/intel/person-detection-raisinghand-recognition-0001/accuracy-check.yml
+++ b/models/intel/person-detection-raisinghand-recognition-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-raisinghand-recognition-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: action_detection
           priorbox_out: mbox/priorbox

--- a/models/intel/person-detection-retail-0002/accuracy-check.yml
+++ b/models/intel/person-detection-retail-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-retail-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
         inputs:
           - name: im_info

--- a/models/intel/person-detection-retail-0013/accuracy-check.yml
+++ b/models/intel/person-detection-retail-0013/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-detection-retail-0013
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-reidentification-retail-0277/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0277/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-reidentification-retail-0277
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/person-reidentification-retail-0286/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0286/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-reidentification-retail-0286
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/person-reidentification-retail-0287/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0287/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-reidentification-retail-0287
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/person-reidentification-retail-0288/accuracy-check.yml
+++ b/models/intel/person-reidentification-retail-0288/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-reidentification-retail-0288
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-2000/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2000/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-2000
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-2001/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-2001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-2002/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-2002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-2003/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2003/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-2003
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: faster_rcnn_onnx
           labels_out: 'labels'

--- a/models/intel/person-vehicle-bike-detection-2004/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-2004/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-2004
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: faster_rcnn_onnx
           labels_out: 'labels'

--- a/models/intel/person-vehicle-bike-detection-crossroad-0078/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-0078/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-crossroad-0078
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-crossroad-1016/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-1016/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: person-vehicle-bike-detection-crossroad-1016
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/accuracy-check.yml
+++ b/models/intel/person-vehicle-bike-detection-crossroad-yolov3-1020/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: person-vehicle-bike-detection-crossroad-yolov3-1020
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           anchors: "10,13,  16,30,  33,23,  30,61,  62,45,  59,119,  116,90,  156,198,  373,326"

--- a/models/intel/product-detection-0001/accuracy-check.yml
+++ b/models/intel/product-detection-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: product-detection-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
+++ b/models/intel/resnet18-xnor-binary-onnx-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: resnet18-xnor-binary-onnx-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/intel/resnet50-binary-0001/accuracy-check.yml
+++ b/models/intel/resnet50-binary-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: resnet50-binary-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/intel/road-segmentation-adas-0001/accuracy-check.yml
+++ b/models/intel/road-segmentation-adas-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: road-segmentation-adas-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
 
     datasets:

--- a/models/intel/semantic-segmentation-adas-0001/accuracy-check.yml
+++ b/models/intel/semantic-segmentation-adas-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: semantic-segmentation-adas-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
         inputs:
           - name: data

--- a/models/intel/single-image-super-resolution-1032/accuracy-check.yml
+++ b/models/intel/single-image-super-resolution-1032/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: single-image-super-resolution-1032
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: super_resolution
           reverse_channels: True

--- a/models/intel/single-image-super-resolution-1033/accuracy-check.yml
+++ b/models/intel/single-image-super-resolution-1033/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: single-image-super-resolution-1033
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: super_resolution
           reverse_channels: True

--- a/models/intel/smartlab-sequence-modelling-0001/accuracy-check.yml
+++ b/models/intel/smartlab-sequence-modelling-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: smartlab-sequence-modelling-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: multi_output_regression
           ignore_batch: True

--- a/models/intel/text-detection-0003/accuracy-check.yml
+++ b/models/intel/text-detection-0003/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-detection-0003
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: pixel_link_text_detection
           pixel_link_out: model/link_logits_/add

--- a/models/intel/text-detection-0004/accuracy-check.yml
+++ b/models/intel/text-detection-0004/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-detection-0004
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: pixel_link_text_detection
           pixel_link_out: model/link_logits_/add

--- a/models/intel/text-image-super-resolution-0001/accuracy-check.yml
+++ b/models/intel/text-image-super-resolution-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-image-super-resolution-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: super_resolution
 

--- a/models/intel/text-recognition-0012/accuracy-check.yml
+++ b/models/intel/text-recognition-0012/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-recognition-0012
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: beam_search_decoder
 
     datasets:

--- a/models/intel/text-recognition-0014/accuracy-check.yml
+++ b/models/intel/text-recognition-0014/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-recognition-0014
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctc_greedy_search_decoder
           logits_output: logits

--- a/models/intel/text-recognition-0015/accuracy-check.yml
+++ b/models/intel/text-recognition-0015/accuracy-check.yml
@@ -77,7 +77,7 @@ evaluations:
         65: "Z"
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: SVT_recognition

--- a/models/intel/text-recognition-0016/accuracy-check.yml
+++ b/models/intel/text-recognition-0016/accuracy-check.yml
@@ -51,7 +51,7 @@ evaluations:
         39: "z"
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: SVT_recognition

--- a/models/intel/text-spotting-0005/accuracy-check.yml
+++ b/models/intel/text-spotting-0005/accuracy-check.yml
@@ -30,7 +30,7 @@ evaluations:
         confidence_threshold: 0.65
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: ICDAR2015_word_spotting

--- a/models/intel/text-to-speech-en-0001/accuracy-check.yml
+++ b/models/intel/text-to-speech-en-0001/accuracy-check.yml
@@ -22,7 +22,7 @@ evaluations:
         keep_shape: True
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: forward_tacotron_melgan_io

--- a/models/intel/text-to-speech-en-multi-0001/accuracy-check.yml
+++ b/models/intel/text-to-speech-en-multi-0001/accuracy-check.yml
@@ -23,7 +23,7 @@ evaluations:
         keep_shape: True
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: forward_tacotron_melgan_multispeaker_io

--- a/models/intel/time-series-forecasting-electricity-0001/accuracy-check.yml
+++ b/models/intel/time-series-forecasting-electricity-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: time-series-forecasting-electricity-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         inputs:
           - name: timestamps
             type: INPUT

--- a/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
+++ b/models/intel/unet-camvid-onnx-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: unet-camvid-onnx-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
 
     datasets:

--- a/models/intel/vehicle-attributes-recognition-barrier-0039/accuracy-check.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0039/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-attributes-recognition-barrier-0039
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: vehicle_attributes
           color_out: color

--- a/models/intel/vehicle-attributes-recognition-barrier-0042/accuracy-check.yml
+++ b/models/intel/vehicle-attributes-recognition-barrier-0042/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-attributes-recognition-barrier-0042
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: vehicle_attributes
           color_out: color

--- a/models/intel/vehicle-detection-0200/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0200/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-detection-0200
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/vehicle-detection-0201/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0201/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-detection-0201
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/vehicle-detection-0202/accuracy-check.yml
+++ b/models/intel/vehicle-detection-0202/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-detection-0202
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/vehicle-detection-adas-0002/accuracy-check.yml
+++ b/models/intel/vehicle-detection-adas-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-detection-adas-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/vehicle-license-plate-detection-barrier-0106/accuracy-check.yml
+++ b/models/intel/vehicle-license-plate-detection-barrier-0106/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-license-plate-detection-barrier-0106
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/intel/weld-porosity-detection-0001/accuracy-check.yml
+++ b/models/intel/weld-porosity-detection-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: weld-porosity-detection-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/intel/yolo-v2-ava-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-ava-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: yolo_v2

--- a/models/intel/yolo-v2-ava-sparse-35-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-sparse-35-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-ava-sparse-35-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: yolo_v2

--- a/models/intel/yolo-v2-ava-sparse-70-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-ava-sparse-70-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-ava-sparse-70-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: yolo_v2

--- a/models/intel/yolo-v2-tiny-ava-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-tiny-ava-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: tiny_yolo_v2

--- a/models/intel/yolo-v2-tiny-ava-sparse-30-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-30-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-tiny-ava-sparse-30-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: tiny_yolo_v2

--- a/models/intel/yolo-v2-tiny-ava-sparse-60-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-ava-sparse-60-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: yolo-v2-tiny-ava-sparse-60-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: tiny_yolo_v2

--- a/models/intel/yolo-v2-tiny-vehicle-detection-0001/accuracy-check.yml
+++ b/models/intel/yolo-v2-tiny-vehicle-detection-0001/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: yolo-v2-tiny-vehicle-detection-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: "0.57273, 0.677385, 1.87446, 2.06253, 3.33843, 5.47434, 7.88282, 3.52778, 9.77052, 9.16828"

--- a/models/public/Sphereface/accuracy-check.yml
+++ b/models/public/Sphereface/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: Sphereface
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/public/aclnet-int8/accuracy-check.yml
+++ b/models/public/aclnet-int8/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: aclnet-int8
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/aclnet/accuracy-check.yml
+++ b/models/public/aclnet/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: aclnet
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/alexnet/accuracy-check.yml
+++ b/models/public/alexnet/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: alexnet
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/anti-spoof-mn3/accuracy-check.yml
+++ b/models/public/anti-spoof-mn3/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: anti-spoof-mn3
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/bert-base-ner/accuracy-check.yml
+++ b/models/public/bert-base-ner/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: bert-base-ner
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: bert_ner
         inputs:
           - name: "input_ids"

--- a/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: brain-tumor-segmentation-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: brain_tumor_segmentation
           make_argmax: True

--- a/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
+++ b/models/public/brain-tumor-segmentation-0002/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: brain-tumor-segmentation-0002
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: brain_tumor_segmentation
 

--- a/models/public/caffenet/accuracy-check.yml
+++ b/models/public/caffenet/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: caffenet
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/cocosnet/accuracy-check-pipelined.yml
+++ b/models/public/cocosnet/accuracy-check-pipelined.yml
@@ -14,7 +14,7 @@ evaluations:
           additional_layers: ["InceptionV3/Logits/AvgPool_1a_8x8/AvgPool"]
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
           inputs:
             - name: "input_seg_map"
               type: INPUT

--- a/models/public/cocosnet/accuracy-check.yml
+++ b/models/public/cocosnet/accuracy-check.yml
@@ -10,7 +10,7 @@ evaluations:
             std: 127.5
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
           inputs:
             - name: "input_seg_map"
               type: INPUT

--- a/models/public/colorization-siggraph/accuracy-check-pipelined.yml
+++ b/models/public/colorization-siggraph/accuracy-check-pipelined.yml
@@ -9,7 +9,7 @@ evaluations:
           adapter: classification
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: imagenet_1000_classes

--- a/models/public/colorization-siggraph/accuracy-check.yml
+++ b/models/public/colorization-siggraph/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: colorization-siggraph
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: image_processing
           std: 1

--- a/models/public/colorization-v2/accuracy-check-pipelined.yml
+++ b/models/public/colorization-v2/accuracy-check-pipelined.yml
@@ -9,7 +9,7 @@ evaluations:
           adapter: classification
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: imagenet_1000_classes

--- a/models/public/colorization-v2/accuracy-check.yml
+++ b/models/public/colorization-v2/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: colorization-v2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: image_processing
           std: 1

--- a/models/public/common-sign-language-0001/accuracy-check.yml
+++ b/models/public/common-sign-language-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: common-sign-language-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
         inputs:
           - type: INPUT

--- a/models/public/ctdet_coco_dlav0_512/accuracy-check.yml
+++ b/models/public/ctdet_coco_dlav0_512/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: ctdet_coco_dlav0_512
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctdet
           center_heatmap_out: center_heatmap

--- a/models/public/ctpn/accuracy-check.yml
+++ b/models/public/ctpn/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: ctpn
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctpn_text_detection
           cls_prob_out: 'Reshape_2'

--- a/models/public/deblurgan-v2/accuracy-check.yml
+++ b/models/public/deblurgan-v2/accuracy-check.yml
@@ -37,7 +37,7 @@ models:
   - name: deblurgan-v2
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: image_processing
           reverse_channels: True

--- a/models/public/deeplabv3/accuracy-check.yml
+++ b/models/public/deeplabv3/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: deeplabv3
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
 
     datasets:

--- a/models/public/densenet-121-tf/accuracy-check.yml
+++ b/models/public/densenet-121-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: densenet-121-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/densenet-121/accuracy-check.yml
+++ b/models/public/densenet-121/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: densenet-121
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/detr-resnet50/accuracy-check.yml
+++ b/models/public/detr-resnet50/accuracy-check.yml
@@ -28,7 +28,7 @@ models:
 
   - name: detr-resnet50
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: detr
           scores_out: "scores"

--- a/models/public/dla-34/accuracy-check.yml
+++ b/models/public/dla-34/accuracy-check.yml
@@ -39,7 +39,7 @@ models:
   - name: dla-34
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/drn-d-38/accuracy-check.yml
+++ b/models/public/drn-d-38/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: drn-d-38
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: segmentation
           make_argmax: true

--- a/models/public/efficientdet-d0-tf/accuracy-check.yml
+++ b/models/public/efficientdet-d0-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: efficientdet-d0-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
     datasets:
       - name: ms_coco_detection_90_class_without_background

--- a/models/public/efficientdet-d1-tf/accuracy-check.yml
+++ b/models/public/efficientdet-d1-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: efficientdet-d1-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
     datasets:
       - name: ms_coco_detection_90_class_without_background

--- a/models/public/efficientnet-b0-pytorch/accuracy-check.yml
+++ b/models/public/efficientnet-b0-pytorch/accuracy-check.yml
@@ -42,7 +42,7 @@ models:
   - name: efficientnet-b0-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/efficientnet-b0/accuracy-check.yml
+++ b/models/public/efficientnet-b0/accuracy-check.yml
@@ -35,7 +35,7 @@ models:
   - name: efficientnet-b0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/efficientnet-v2-b0/accuracy-check.yml
+++ b/models/public/efficientnet-v2-b0/accuracy-check.yml
@@ -38,7 +38,7 @@ models:
   - name: efficientnet-v2-b0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/efficientnet-v2-s/accuracy-check.yml
+++ b/models/public/efficientnet-v2-s/accuracy-check.yml
@@ -38,7 +38,7 @@ models:
   - name: efficientnet-v2-s
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/f3net/accuracy-check.yml
+++ b/models/public/f3net/accuracy-check.yml
@@ -25,7 +25,7 @@ models:
 
   - name: f3net
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: salient_object_detection
     datasets:
       - name: PASCAL-S

--- a/models/public/face-detection-retail-0044/accuracy-check.yml
+++ b/models/public/face-detection-retail-0044/accuracy-check.yml
@@ -7,7 +7,7 @@ models:
         weights: face-detection-retail-0044.caffemodel
         adapter: ssd
 
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/face-recognition-resnet100-arcface-onnx/accuracy-check.yml
+++ b/models/public/face-recognition-resnet100-arcface-onnx/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: face-recognition-resnet100-arcface-onnx
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/public/faceboxes-pytorch/accuracy-check.yml
+++ b/models/public/faceboxes-pytorch/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: faceboxes-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: faceboxes
           boxes_out: "boxes"

--- a/models/public/facenet-20180408-102900/accuracy-check.yml
+++ b/models/public/facenet-20180408-102900/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: facenet-20180408-102900
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: reid
           joining_method: concatenation

--- a/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
+++ b/models/public/fast-neural-style-mosaic-onnx/accuracy-check.yml
@@ -6,7 +6,7 @@ models:
         adapter:
           type: style_transfer
 
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: style_transfer
 

--- a/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: faster_rcnn_inception_resnet_v2_atrous_coco
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
         inputs:
           - name: image_info

--- a/models/public/faster_rcnn_resnet50_coco/accuracy-check.yml
+++ b/models/public/faster_rcnn_resnet50_coco/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  faster_rcnn_resnet50_coco
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
         inputs:
           - name: image_info

--- a/models/public/fastseg-large/accuracy-check.yml
+++ b/models/public/fastseg-large/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: fastseg-large
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: segmentation
           make_argmax: True

--- a/models/public/fastseg-small/accuracy-check.yml
+++ b/models/public/fastseg-small/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: fastseg-small
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: segmentation
           make_argmax: True

--- a/models/public/fbcnn/accuracy-check.yml
+++ b/models/public/fbcnn/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: fbcnn
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: image_processing
           reverse_channels: True

--- a/models/public/fcrn-dp-nyu-depth-v2-tf/accuracy-check.yml
+++ b/models/public/fcrn-dp-nyu-depth-v2-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: fcrn-dp-nyu-depth-v2-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: mono_depth
     datasets:
       - name: NYU_Depth_V2

--- a/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-duration-prediction/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: forward-tacotron-duration-prediction
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: multi_output_regression
           outputs:

--- a/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
+++ b/models/public/forward-tacotron/forward-tacotron-regression/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: forward-tacotron-regression
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: multi_output_regression
           outputs:

--- a/models/public/gmcnn-places2-tf/accuracy-check.yml
+++ b/models/public/gmcnn-places2-tf/accuracy-check.yml
@@ -31,7 +31,7 @@ models:
   - name: gmcnn-places2-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: inpainting
         inputs:
           - name: "Placeholder"

--- a/models/public/googlenet-v1-tf/accuracy-check.yml
+++ b/models/public/googlenet-v1-tf/accuracy-check.yml
@@ -28,7 +28,7 @@ models:
 
   - name: googlenet-v1-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v1/accuracy-check.yml
+++ b/models/public/googlenet-v1/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: googlenet-v1
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v2-tf/accuracy-check.yml
+++ b/models/public/googlenet-v2-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: googlenet-v2-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v2/accuracy-check.yml
+++ b/models/public/googlenet-v2/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: googlenet-v2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v3-pytorch/accuracy-check.yml
+++ b/models/public/googlenet-v3-pytorch/accuracy-check.yml
@@ -41,7 +41,7 @@ models:
 
     # list of launchers
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v3/accuracy-check.yml
+++ b/models/public/googlenet-v3/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
 
   - name: googlenet-v3
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/googlenet-v4-tf/accuracy-check.yml
+++ b/models/public/googlenet-v4-tf/accuracy-check.yml
@@ -28,7 +28,7 @@ models:
 
   - name: googlenet-v4-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/gpt-2/accuracy-check.yml
+++ b/models/public/gpt-2/accuracy-check.yml
@@ -25,7 +25,7 @@ models:
 
   - name: gpt-2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: common_language_modeling
           logits_output: "output"

--- a/models/public/hbonet-0.25/accuracy-check.yml
+++ b/models/public/hbonet-0.25/accuracy-check.yml
@@ -45,7 +45,7 @@ models:
   - name: hbonet-0.25
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: classification
 

--- a/models/public/hbonet-1.0/accuracy-check.yml
+++ b/models/public/hbonet-1.0/accuracy-check.yml
@@ -45,7 +45,7 @@ models:
   - name: hbonet-1.0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: classification
 

--- a/models/public/higher-hrnet-w32-human-pose-estimation/accuracy-check.yml
+++ b/models/public/higher-hrnet-w32-human-pose-estimation/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: higher-hrnet-w32-human-pose-estimation
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation_hrnet

--- a/models/public/hrnet-v2-c1-segmentation/accuracy-check.yml
+++ b/models/public/hrnet-v2-c1-segmentation/accuracy-check.yml
@@ -36,7 +36,7 @@ models:
   - name: hrnet-v2-c1-segmentation
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
 
     datasets:

--- a/models/public/human-pose-estimation-3d-0001/accuracy-check.yml
+++ b/models/public/human-pose-estimation-3d-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: human-pose-estimation-3d-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: human_pose_estimation_3d

--- a/models/public/hybrid-cs-model-mri/accuracy-check.yml
+++ b/models/public/hybrid-cs-model-mri/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: hybrid-cs-model-mri
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: image_processing
           std: 1

--- a/models/public/i3d-rgb-tf/accuracy-check.yml
+++ b/models/public/i3d-rgb-tf/accuracy-check.yml
@@ -1,12 +1,12 @@
 models:
   - name: i3d-rgb-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
         inputs:
           - name: Placeholder
             type: INPUT
-            layout: NCDHW
+            layout: NDHWC
 
     datasets:
       - name: kinetics-400-frames-79-400

--- a/models/public/inception-resnet-v2-tf/accuracy-check.yml
+++ b/models/public/inception-resnet-v2-tf/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
 
   - name: inception-resnet-v2-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/license-plate-recognition-barrier-0007/accuracy-check.yml
+++ b/models/public/license-plate-recognition-barrier-0007/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: license-plate-recognition-barrier-0007
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: lpr
 
     datasets:

--- a/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_inception_resnet_v2_atrous_coco/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: mask_rcnn_inception_resnet_v2_atrous_coco
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           detection_out: reshape_do_2d

--- a/models/public/mask_rcnn_resnet50_atrous_coco/accuracy-check.yml
+++ b/models/public/mask_rcnn_resnet50_atrous_coco/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: mask_rcnn_resnet50_atrous_coco
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: mask_rcnn
           detection_out: reshape_do_2d

--- a/models/public/midasnet/accuracy-check.yml
+++ b/models/public/midasnet/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: midasnet
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: mono_depth
     datasets:
       - name: ReDWeb_V1

--- a/models/public/mixnet-l/accuracy-check.yml
+++ b/models/public/mixnet-l/accuracy-check.yml
@@ -35,7 +35,7 @@ models:
   - name: mixnet-l
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilefacedet-v1-mxnet/accuracy-check.yml
+++ b/models/public/mobilefacedet-v1-mxnet/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: mobilefacedet-v1-mxnet
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           classes: 1

--- a/models/public/mobilenet-ssd/accuracy-check.yml
+++ b/models/public/mobilenet-ssd/accuracy-check.yml
@@ -24,7 +24,7 @@ models:
 
   - name: mobilenet-ssd
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/mobilenet-v1-0.25-128/accuracy-check.yml
+++ b/models/public/mobilenet-v1-0.25-128/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
 
   - name: mobilenet-v1-0.25-128
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v1-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v1-1.0-224-tf/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
 
   - name: mobilenet-v1-1.0-224-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v1-1.0-224/accuracy-check.yml
+++ b/models/public/mobilenet-v1-1.0-224/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: mobilenet-v1-1.0-224
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v2-1.0-224/accuracy-check.yml
+++ b/models/public/mobilenet-v2-1.0-224/accuracy-check.yml
@@ -30,7 +30,7 @@ models:
 
   - name: mobilenet-v2-1.0-224
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v2-1.4-224/accuracy-check.yml
+++ b/models/public/mobilenet-v2-1.4-224/accuracy-check.yml
@@ -29,7 +29,7 @@ models:
 
   - name: mobilenet-v2-1.4-224
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v2-pytorch/accuracy-check.yml
+++ b/models/public/mobilenet-v2-pytorch/accuracy-check.yml
@@ -51,7 +51,7 @@ models:
 
     # list of launchers for MobileNetV2.
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v2/accuracy-check.yml
+++ b/models/public/mobilenet-v2/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: mobilenet-v2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v3-large-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: mobilenet-v3-large-1.0-224-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-v3-small-1.0-224-tf/accuracy-check.yml
+++ b/models/public/mobilenet-v3-small-1.0-224-tf/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: mobilenet-v3-small-1.0-224-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/mobilenet-yolo-v4-syg/accuracy-check.yml
+++ b/models/public/mobilenet-yolo-v4-syg/accuracy-check.yml
@@ -54,7 +54,7 @@ models:
 
   - name: mobilenet-yolo-v4-syg
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           classes: 4

--- a/models/public/mozilla-deepspeech-0.6.1/accuracy-check-fast.yml
+++ b/models/public/mozilla-deepspeech-0.6.1/accuracy-check-fast.yml
@@ -5,7 +5,7 @@
 models:
   - name: mozilla-deepspeech-0.6.1-with-lm
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: fast_ctc_beam_search_decoder_with_lm
           probability_out: logits
@@ -21,10 +21,10 @@ models:
             layout: NHWC
           - name: previous_state_c
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0'
           - name: previous_state_h
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0'
     datasets:
       - name: librispeech-test-clean
         reader:

--- a/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml
+++ b/models/public/mozilla-deepspeech-0.6.1/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: mozilla-deepspeech-0.6.1
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctc_beam_search_decoder_with_lm
           probability_out: logits
@@ -20,10 +20,10 @@ models:
             layout: NHWC
           - name: previous_state_c
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0'
           - name: previous_state_h
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0'
     datasets:
       - name: librispeech-test-clean
         reader:

--- a/models/public/mozilla-deepspeech-0.8.2/accuracy-check-fast.yml
+++ b/models/public/mozilla-deepspeech-0.8.2/accuracy-check-fast.yml
@@ -5,7 +5,7 @@
 models:
   - name: mozilla-deepspeech-0.8.2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: fast_ctc_beam_search_decoder_with_lm
           probability_out: logits
@@ -22,10 +22,10 @@ models:
             layout: NHWC
           - name: previous_state_c
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0'
           - name: previous_state_h
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0'
     datasets:
       - name: librispeech-test-clean
         reader:

--- a/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml
+++ b/models/public/mozilla-deepspeech-0.8.2/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: mozilla-deepspeech-0.8.2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ctc_beam_search_decoder_with_lm
           probability_out: logits
@@ -20,10 +20,10 @@ models:
             layout: NHWC
           - name: previous_state_c
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.2'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0'
           - name: previous_state_h
             type: LSTM_INPUT
-            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/BlockLSTM/TensorIterator.1'
+            value: 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0'
     datasets:
       - name: librispeech-test-clean
         reader:

--- a/models/public/mtcnn/accuracy-check.yml
+++ b/models/public/mtcnn/accuracy-check.yml
@@ -124,7 +124,7 @@ evaluations:
             - type: bgr_to_rgb
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: wider

--- a/models/public/netvlad-tf/accuracy-check.yml
+++ b/models/public/netvlad-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: netvlad-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
     datasets:
       - name: pitts30k_val

--- a/models/public/nfnet-f0/accuracy-check.yml
+++ b/models/public/nfnet-f0/accuracy-check.yml
@@ -36,7 +36,7 @@ models:
   - name: nfnet-f0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/ocrnet-hrnet-w48-paddle/accuracy-check.yml
+++ b/models/public/ocrnet-hrnet-w48-paddle/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: ocrnet-hrnet-w48-paddle
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: segmentation
 

--- a/models/public/octave-resnet-26-0.25/accuracy-check.yml
+++ b/models/public/octave-resnet-26-0.25/accuracy-check.yml
@@ -41,11 +41,11 @@ models:
             top_k: 5
             reference: 0.92584
 
-  # DLSDK inference
+  # OpenVINO inference
   - name: octave-resnet-26-0.25
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/open-closed-eye-0001/accuracy-check.yml
+++ b/models/public/open-closed-eye-0001/accuracy-check.yml
@@ -18,7 +18,7 @@ models:
 
   - name: open-closed-eye-0001
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
     datasets:
       - name: mrlEyes_2018_01

--- a/models/public/pelee-coco/accuracy-check.yml
+++ b/models/public/pelee-coco/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: pelee-coco
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/pspnet-pytorch/accuracy-check.yml
+++ b/models/public/pspnet-pytorch/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: pspnet-pytorch
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: segmentation
     datasets:
       - name: VOC2012_Segmentation

--- a/models/public/quartznet-15x5-en/accuracy-check.yml
+++ b/models/public/quartznet-15x5-en/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: quartznet-15x5-en
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: True
         adapter:
           type: ctc_greedy_decoder

--- a/models/public/regnetx-3.2gf/accuracy-check.yml
+++ b/models/public/regnetx-3.2gf/accuracy-check.yml
@@ -37,7 +37,7 @@ models:
   - name: regnetx-3.2gf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/repvgg-a0/accuracy-check.yml
+++ b/models/public/repvgg-a0/accuracy-check.yml
@@ -36,7 +36,7 @@ models:
   - name: repvgg-a0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/repvgg-b1/accuracy-check.yml
+++ b/models/public/repvgg-b1/accuracy-check.yml
@@ -36,7 +36,7 @@ models:
   - name: repvgg-b1
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/repvgg-b3/accuracy-check.yml
+++ b/models/public/repvgg-b3/accuracy-check.yml
@@ -36,7 +36,7 @@ models:
   - name: repvgg-b3
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/resnest-50-pytorch/accuracy-check.yml
+++ b/models/public/resnest-50-pytorch/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: resnest-50-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/resnet-18-pytorch/accuracy-check.yml
+++ b/models/public/resnet-18-pytorch/accuracy-check.yml
@@ -51,7 +51,7 @@ models:
   - name: resnet-18-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/resnet-34-pytorch/accuracy-check.yml
+++ b/models/public/resnet-34-pytorch/accuracy-check.yml
@@ -43,7 +43,7 @@ models:
   - name: resnet-34-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/resnet-50-pytorch/accuracy-check.yml
+++ b/models/public/resnet-50-pytorch/accuracy-check.yml
@@ -51,7 +51,7 @@ models:
   - name: resnet-50-pytorch
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/resnet-50-tf/accuracy-check.yml
+++ b/models/public/resnet-50-tf/accuracy-check.yml
@@ -31,7 +31,7 @@ models:
 
   - name: resnet-50-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/retinaface-resnet50-pytorch/accuracy-check.yml
+++ b/models/public/retinaface-resnet50-pytorch/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: retinaface-resnet50-pytorch
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: retinaface_pytorch
           bboxes_output: face_rpn_bbox_pred

--- a/models/public/retinanet-tf/accuracy-check.yml
+++ b/models/public/retinanet-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: retinanet-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/rexnet-v1-x1.0/accuracy-check.yml
+++ b/models/public/rexnet-v1-x1.0/accuracy-check.yml
@@ -39,7 +39,7 @@ models:
   - name: rexnet-v1-x1.0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/rfcn-resnet101-coco-tf/accuracy-check.yml
+++ b/models/public/rfcn-resnet101-coco-tf/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  rfcn-resnet101-coco-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
         inputs:
           - name: image_info

--- a/models/public/se-inception/accuracy-check.yml
+++ b/models/public/se-inception/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: se-inception
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/se-resnet-50/accuracy-check.yml
+++ b/models/public/se-resnet-50/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: se-resnet-50
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/se-resnext-50/accuracy-check.yml
+++ b/models/public/se-resnext-50/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: se-resnext-50
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/shufflenet-v2-x0.5/accuracy-check.yml
+++ b/models/public/shufflenet-v2-x0.5/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: shufflenet-v2-x0.5
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/shufflenet-v2-x1.0/accuracy-check.yml
+++ b/models/public/shufflenet-v2-x1.0/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: shufflenet-v2-x1.0
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/single-human-pose-estimation-0001/accuracy-check.yml
+++ b/models/public/single-human-pose-estimation-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: single-human-pose-estimation-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: single_human_pose_estimation
 

--- a/models/public/squeezenet1.0/accuracy-check.yml
+++ b/models/public/squeezenet1.0/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: squeezenet1.0
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/squeezenet1.1/accuracy-check.yml
+++ b/models/public/squeezenet1.1/accuracy-check.yml
@@ -26,7 +26,7 @@ models:
 
   - name: squeezenet1.1
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/ssd-resnet34-1200-onnx/accuracy-check.yml
+++ b/models/public/ssd-resnet34-1200-onnx/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  ssd-resnet34-1200-onnx
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ssd_onnx
           scores_out: '.*scores*'

--- a/models/public/ssd300/accuracy-check.yml
+++ b/models/public/ssd300/accuracy-check.yml
@@ -23,7 +23,7 @@ models:
 
   - name: ssd300
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/ssd512/accuracy-check.yml
+++ b/models/public/ssd512/accuracy-check.yml
@@ -24,7 +24,7 @@ models:
 
   - name: ssd512
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/ssd_mobilenet_v1_coco/accuracy-check.yml
+++ b/models/public/ssd_mobilenet_v1_coco/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  ssd_mobilenet_v1_coco
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/ssd_mobilenet_v1_fpn_coco/accuracy-check.yml
+++ b/models/public/ssd_mobilenet_v1_fpn_coco/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  ssd_mobilenet_v1_fpn_coco
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/ssdlite_mobilenet_v2/accuracy-check.yml
+++ b/models/public/ssdlite_mobilenet_v2/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name:  ssdlite_mobilenet_v2
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/swin-tiny-patch4-window7-224/accuracy-check.yml
+++ b/models/public/swin-tiny-patch4-window7-224/accuracy-check.yml
@@ -34,7 +34,7 @@ models:
   - name: swin-tiny-patch4-window7-224
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/t2t-vit-14/accuracy-check.yml
+++ b/models/public/t2t-vit-14/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: t2t-vit-14
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/text-recognition-resnet-fc/accuracy-check.yml
+++ b/models/public/text-recognition-resnet-fc/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: text-recognition-resnet-fc
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: simple_decoder
           eos_label: "[s]"

--- a/models/public/ultra-lightweight-face-detection-rfb-320/accuracy-check.yml
+++ b/models/public/ultra-lightweight-face-detection-rfb-320/accuracy-check.yml
@@ -40,7 +40,7 @@ models:
   - name: ultra-lightweight-face-detection-rfb-320
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ultra_lightweight_face_detection
           boxes_out: "boxes"

--- a/models/public/ultra-lightweight-face-detection-slim-320/accuracy-check.yml
+++ b/models/public/ultra-lightweight-face-detection-slim-320/accuracy-check.yml
@@ -40,7 +40,7 @@ models:
   - name: ultra-lightweight-face-detection-slim-320
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: ultra_lightweight_face_detection
           boxes_out: "boxes"

--- a/models/public/vehicle-license-plate-detection-barrier-0123/accuracy-check.yml
+++ b/models/public/vehicle-license-plate-detection-barrier-0123/accuracy-check.yml
@@ -6,7 +6,7 @@ models:
         model:   model/model.pb.frozen
         adapter: ssd
 
-      - framework: dlsdk
+      - framework: openvino
         adapter: ssd
 
     datasets:

--- a/models/public/vehicle-reid-0001/accuracy-check.yml
+++ b/models/public/vehicle-reid-0001/accuracy-check.yml
@@ -2,7 +2,7 @@ models:
   - name: vehicle-reid-0001
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: reid
 
     datasets:

--- a/models/public/vgg16/accuracy-check.yml
+++ b/models/public/vgg16/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: vgg16
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/vgg19/accuracy-check.yml
+++ b/models/public/vgg19/accuracy-check.yml
@@ -27,7 +27,7 @@ models:
 
   - name: vgg19
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: classification
 
     datasets:

--- a/models/public/vitstr-small-patch16-224/accuracy-check.yml
+++ b/models/public/vitstr-small-patch16-224/accuracy-check.yml
@@ -70,7 +70,7 @@ models:
 
   - name: vitstr-small-patch16-224
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: simple_decoder
           eos_label: '[s]'

--- a/models/public/wav2vec2-base/accuracy-check.yml
+++ b/models/public/wav2vec2-base/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: wav2vec2-base
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         allow_reshape_input: true
         adapter:
           type: wav2vec

--- a/models/public/wavernn/wavernn-rnn/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-rnn/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: wavernn-rnn
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: multi_output_regression
           outputs:

--- a/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
+++ b/models/public/wavernn/wavernn-upsampler/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: wavernn-upsampler
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: multi_output_regression
           outputs:

--- a/models/public/yolact-resnet50-fpn-pytorch/accuracy-check.yml
+++ b/models/public/yolact-resnet50-fpn-pytorch/accuracy-check.yml
@@ -30,7 +30,7 @@ models:
 
   - name: yolact-resnet50-fpn-pytorch
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolact
           boxes_out: "boxes"

--- a/models/public/yolo-v1-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v1-tiny-tf/accuracy-check.yml
@@ -49,7 +49,7 @@ models:
   - name: yolo-v1-tiny-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: "1.08,1.19, 3.42,4.41, 6.63,11.38, 9.42,5.11, 16.62,10.52"

--- a/models/public/yolo-v2-tf/accuracy-check.yml
+++ b/models/public/yolo-v2-tf/accuracy-check.yml
@@ -49,7 +49,7 @@ models:
   - name: yolo-v2-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: "0.57273, 0.677385, 1.87446, 2.06253, 3.33843, 5.47434, 7.88282, 3.52778, 9.77052, 9.16828"

--- a/models/public/yolo-v2-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v2-tiny-tf/accuracy-check.yml
@@ -47,7 +47,7 @@ models:
   - name: yolo-v2-tiny-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v2
           anchors: "0.57273, 0.677385, 1.87446, 2.06253, 3.33843, 5.47434, 7.88282, 3.52778, 9.77052, 9.16828"

--- a/models/public/yolo-v3-onnx/accuracy-check.yml
+++ b/models/public/yolo-v3-onnx/accuracy-check.yml
@@ -38,7 +38,7 @@ models:
 
   - name: yolo-v3-onnx
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3_onnx
           boxes_out: yolonms_layer_1/ExpandDims_1:0

--- a/models/public/yolo-v3-tf/accuracy-check.yml
+++ b/models/public/yolo-v3-tf/accuracy-check.yml
@@ -60,7 +60,7 @@ models:
   - name: yolo-v3-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           anchors: "10,13,  16,30,  33,23,  30,61,  62,45,  59,119,  116,90,  156,198,  373,326"

--- a/models/public/yolo-v3-tiny-onnx/accuracy-check.yml
+++ b/models/public/yolo-v3-tiny-onnx/accuracy-check.yml
@@ -38,12 +38,12 @@ models:
 
   - name: yolo-v3-tiny-onnx
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3_onnx
-          boxes_out: yolonms_layer_1
-          scores_out: yolonms_layer_1:1
-          indices_out: yolonms_layer_1:2
+          boxes_out: yolo_evaluation_layer_1/concat_6:0_btc
+          scores_out: yolo_evaluation_layer_1/concat_7:0_btc
+          indices_out: yolonms_layer_1/ExpandDims_5:01
         inputs:
           - name: image_shape
             type: ORIG_IMAGE_INFO

--- a/models/public/yolo-v3-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v3-tiny-tf/accuracy-check.yml
@@ -59,7 +59,7 @@ models:
   - name: yolo-v3-tiny-tf
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           anchors: tiny_yolo_v3

--- a/models/public/yolo-v4-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tf/accuracy-check.yml
@@ -64,7 +64,7 @@ models:
 
   - name: yolo-v4-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           anchors: 12,16,19,36,40,28,36,75,76,55,72,146,142,110,192,243,459,401
@@ -74,10 +74,11 @@ models:
           threshold: 0.001
           anchor_masks: [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
           raw_output: True
+          output_format: HWB
           outputs:
-            - StatefulPartitionedCall/model/conv2d_93/BiasAdd/Add
-            - StatefulPartitionedCall/model/conv2d_101/BiasAdd/Add
-            - StatefulPartitionedCall/model/conv2d_109/BiasAdd/Add
+            - conv2d_93/BiasAdd
+            - conv2d_101/BiasAdd
+            - conv2d_109/BiasAdd
     datasets:
       - name: ms_coco_detection_80_class_without_background
         preprocessing:

--- a/models/public/yolo-v4-tiny-tf/accuracy-check.yml
+++ b/models/public/yolo-v4-tiny-tf/accuracy-check.yml
@@ -62,7 +62,7 @@ models:
 
   - name: yolo-v4-tiny-tf
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolo_v3
           anchors: 10,14,23,27,37,58,81,82,135,169,344,319
@@ -72,9 +72,10 @@ models:
           threshold: 0.001
           anchor_masks: [[1, 2, 3], [3, 4, 5]]
           raw_output: True
+          output_format: HWB
           outputs:
-            - conv2d_20/BiasAdd/Add
-            - conv2d_17/BiasAdd/Add
+            - conv2d_20/BiasAdd
+            - conv2d_17/BiasAdd
     datasets:
       - name: ms_coco_detection_80_class_without_background
         preprocessing:

--- a/models/public/yolof/accuracy-check.yml
+++ b/models/public/yolof/accuracy-check.yml
@@ -1,7 +1,7 @@
 models:
   - name: yolof
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter:
           type: yolof
           anchors: 16,16,32,32,64,64,128,128,256,256,512,512

--- a/models/public/yolox-tiny/accuracy-check.yml
+++ b/models/public/yolox-tiny/accuracy-check.yml
@@ -44,7 +44,7 @@ models:
 
   - name: yolox-tiny
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: yolox
     datasets:
       - name: ms_coco_detection_80_class_without_background

--- a/tools/accuracy_checker/configs/README.md
+++ b/tools/accuracy_checker/configs/README.md
@@ -11,7 +11,7 @@ models:
   - name: model_name
 
     launchers:
-      - framework: dlsdk
+      - framework: openvino
         adapter: adapter_name
 
     datasets:
@@ -34,7 +34,7 @@ evaluations:
           adapter: adapter_name
 
       launchers:
-        - framework: dlsdk
+        - framework: openvino
 
       datasets:
         - name: dataset_name

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/__init__.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
@@ -80,6 +80,8 @@ class DLSDKLauncher(Launcher):
     def __init__(self, config_entry, model_name='', delayed_model_loading=False,
                  preprocessor=None, postpone_inputs_configuration=False):
         super().__init__(config_entry, model_name=model_name)
+        if ie.get_version().split('-')[0] >= '2022.1.0':
+            warnings.warn('dlsdk launcher is deprecated. Please use openvino instead', DeprecationWarning)
 
         self._set_variable = False
         self.ie_config = self.config.get('ie_config')

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher_readme.md
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher_readme.md
@@ -70,7 +70,7 @@ OpenVINO™ launcher config example:
 
 ```yml
 launchers:
-  - framework: dlsdk
+  - framework: openvino
     device: HETERO:GPU,CPU
     model: path_to_model/alexnet.xml
     weights: path_to_weights/alexnet.bin

--- a/tools/accuracy_checker/sample/sample_blob_config.yml
+++ b/tools/accuracy_checker/sample/sample_blob_config.yml
@@ -3,9 +3,9 @@ models:
 
     # list of launchers for your topology.
     launchers:
-      # launcher framework (e.g. caffe, dlsdk)
-      - framework: dlsdk
-        # device for infer (e.g. for dlsdk cpu, gpu, hetero:cpu,gpu ...)
+      # launcher framework (e.g. caffe, openvino)
+      - framework: openvino
+        # device for infer (e.g. for openvino cpu, gpu, hetero:cpu,gpu ...)
         # Note: not all devices support blob execution, it is the reason why for sample we will use myriad.
         device: MYRIAD
         # exported executable network blob

--- a/tools/accuracy_checker/sample/sample_config.yml
+++ b/tools/accuracy_checker/sample/sample_config.yml
@@ -5,7 +5,7 @@ models:
     launchers:
       # launcher framework (e.g. caffe, openvino)
       - framework: openvino
-        # device for infer (e.g. for dlsdk cpu, gpu, hetero:cpu,gpu ...)
+        # device for infer (e.g. for openvino cpu, gpu, hetero:cpu,gpu ...)
         device: CPU
         # model topology file (.xml, .onnx, e.t.c.)
         # path to topology is prefixed with directory, specified in "-m/--models" option


### PR DESCRIPTION
dlsdk (which was a quite old name of inference engine) will be replaced by openvino name in OpenVINO 2022.1