### PR TITLE
update OTE links

### DIFF
--- a/models/intel/face-detection-0200/README.md
+++ b/models/intel/face-detection-0200/README.md
@@ -48,7 +48,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/face-detection-0202/README.md
+++ b/models/intel/face-detection-0202/README.md
@@ -48,7 +48,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/face-detection-0204/README.md
+++ b/models/intel/face-detection-0204/README.md
@@ -48,7 +48,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/face-detection-0205/README.md
+++ b/models/intel/face-detection-0205/README.md
@@ -49,7 +49,7 @@ Expected color order: `BGR`.
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/face-detection-0206/README.md
+++ b/models/intel/face-detection-0206/README.md
@@ -49,7 +49,7 @@ Expected color order: `BGR`.
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/face-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/horizontal-text-detection-0001/README.md
+++ b/models/intel/horizontal-text-detection-0001/README.md
@@ -44,7 +44,7 @@ Expected color order - `BGR`.
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/horizontal-text-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/horizontal-text-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/instance-segmentation-person-0007/README.md
+++ b/models/intel/instance-segmentation-person-0007/README.md
@@ -47,7 +47,7 @@ The expected channel order is `BGR`
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/master/models/instance_segmentation/model_templates/custom-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/custom-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/instance-segmentation-security-0002/README.md
+++ b/models/intel/instance-segmentation-security-0002/README.md
@@ -48,7 +48,7 @@ The expected channel order is `BGR`.
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 [*] Other names and brands may be claimed as the property of others.

--- a/models/intel/instance-segmentation-security-0091/README.md
+++ b/models/intel/instance-segmentation-security-0091/README.md
@@ -48,7 +48,7 @@ The expected channel order is `BGR`
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/instance-segmentation-security-0228/README.md
+++ b/models/intel/instance-segmentation-security-0228/README.md
@@ -46,7 +46,7 @@ The expected channel order is `BGR`
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/instance-segmentation-security-1039/README.md
+++ b/models/intel/instance-segmentation-security-1039/README.md
@@ -46,7 +46,7 @@ The expected channel order is `BGR`
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/instance-segmentation-security-1040/README.md
+++ b/models/intel/instance-segmentation-security-1040/README.md
@@ -46,7 +46,7 @@ The expected channel order is `BGR`
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/instance_segmentation/model_templates/coco-instance-segmentation/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/person-detection-0200/README.md
+++ b/models/intel/person-detection-0200/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/person-detection-0201/README.md
+++ b/models/intel/person-detection-0201/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/person-detection-0202/README.md
+++ b/models/intel/person-detection-0202/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/person-detection-0203/README.md
+++ b/models/intel/person-detection-0203/README.md
@@ -48,7 +48,7 @@ Expected color order is `BGR`.
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/person-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/text-spotting-0005/README.md
+++ b/models/intel/text-spotting-0005/README.md
@@ -92,7 +92,7 @@ alphabet. The 0 and 1 are special Start of Sequence and End of Sequence symbols 
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/text_spotting/model_templates/alphanumeric-text-spotting/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/text_spotting/model_templates/alphanumeric-text-spotting/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/vehicle-detection-0200/README.md
+++ b/models/intel/vehicle-detection-0200/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/vehicle-detection-0201/README.md
+++ b/models/intel/vehicle-detection-0201/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 

--- a/models/intel/vehicle-detection-0202/README.md
+++ b/models/intel/vehicle-detection-0202/README.md
@@ -47,7 +47,7 @@ bounding boxes. Each detection has the format [`image_id`, `label`, `conf`, `x_m
 
 ## Training Pipeline
 
-The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/develop/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/develop/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
+The OpenVINO [Training Extensions](https://github.com/openvinotoolkit/training_extensions/blob/misc/README.md) provide a [training pipeline](https://github.com/openvinotoolkit/training_extensions/blob/misc/models/object_detection/model_templates/vehicle-detection/readme.md), allowing to fine-tune the model on custom dataset.
 
 ## Legal Information
 


### PR DESCRIPTION
OTE changed `develop` branch to `misc` branch, so we have to update OTE links

- [x] face-detection-0200
- [x] face-detection-0202
- [x] face-detection-0204
- [x] face-detection-0205
- [x] face-detection-0206
- [x] horizontal-text-detection-0001
- [x] instance-segmentation-person-0007
- [x] instance-segmentation-security-0002
- [x] instance-segmenation-security-0091
- [x] instance-segmenation-security-0228
- [x] instance-segmenation-security-1039
- [x] instance-segmenation-security-1041
- [x] person-detection-0200
- [x] person-detection-0201
- [x] person-detection-0202
- [x] person-detection-0203
- [x] person-vehicle-bike-detection-2000
- [x] person-vehicle-bike-detection-2001
- [x] person-vehicle-bike-detection-2002
- [x] person-vehicle-bike-detection-2003
- [x] person-vehicle-bike-detection-2004
- [x] text-spotting-0005
- [x] vehicle-detection-0200
- [x] vehicle-detection-0201
- [x] vehicle-detection-0202
