### PR TITLE
ov 2.0: python speech_recognition_deepspeech_demo

### DIFF
--- a/demos/speech_recognition_deepspeech_demo/python/asr_utils/deep_speech_seq_pipeline.py
+++ b/demos/speech_recognition_deepspeech_demo/python/asr_utils/deep_speech_seq_pipeline.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is based in part on deepspeech_openvino_0.5.py by Feng Yen-Chang at
@@ -13,12 +13,12 @@ from asr_utils.ctc_decoder_seq_pipeline import CtcDecoderSeqPipelineStage
 
 
 class DeepSpeechSeqPipeline:
-    def __init__(self, profile, ie, model, lm=None, beam_width=500, max_candidates=None,
+    def __init__(self, profile, core, model, lm=None, beam_width=500, max_candidates=None,
             device='CPU', online_decoding=False):
         """
             Args:
         profile (dict), a dict with pre/post-processing parameters, see profiles.py
-        ie (IECore or None), IECore object for model loading/compilation/inference
+        core (Core or None), Core object for model loading/compilation/inference
         model (str), filename of IE IR .xml file of the network
         lm (str), filename of LM (language model)
         beam_width (int), the number of prefix candidates to retain during decoding in beam search (default 500)
@@ -28,7 +28,7 @@ class DeepSpeechSeqPipeline:
         """
         self.p = deepcopy(profile)
         self.mfcc_stage = AudioFeaturesSeqPipelineStage(profile)
-        self.rnn_stage = RnnSeqPipelineStage(profile, ie, model, device=device)
+        self.rnn_stage = RnnSeqPipelineStage(profile, core, model, device=device)
         self.ctc_stage = CtcDecoderSeqPipelineStage(profile, lm=lm, beam_width=beam_width,
                 max_candidates=max_candidates, online=online_decoding)
 

--- a/demos/speech_recognition_deepspeech_demo/python/asr_utils/rnn_seq_pipeline.py
+++ b/demos/speech_recognition_deepspeech_demo/python/asr_utils/rnn_seq_pipeline.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is based in part on deepspeech_openvino_0.5.py by Feng Yen-Chang at
@@ -15,13 +15,13 @@ from asr_utils.pipelines import BlockedSeqPipelineStage
 
 
 class RnnSeqPipelineStage(BlockedSeqPipelineStage):
-    def __init__(self, profile, ie, model, device='CPU'):
+    def __init__(self, profile, core, model_path, device='CPU'):
         """
-        Load/compile to the target device the IE IR file with the network and initialize the pipeline stage.
+        Load/compile to the target device the Core IR file with the model and initialize the pipeline stage.
 
         profile (dict), a dict with pre/post-processing parameters, see profiles.py
-        ie (IECore), IECore object for model loading/compilation/inference
-        model (str), filename of .xml IR file
+        core (Core), Core object for model loading/compilation/inference
+        model_path (str), filename of .xml IR file
         device (str), inferemnce device
         """
         self.p = deepcopy(profile)
@@ -33,10 +33,11 @@ class RnnSeqPipelineStage(BlockedSeqPipelineStage):
             left_padding_len=padding_len, right_padding_len=padding_len,
             padding_shape=(self.p['num_mfcc_dct_coefs'],), cut_alignment=True)
 
-        log.info('Reading model {}'.format(model))
-        net = ie.read_network(model=model)
-        self.exec_net = ie.load_network(network=net, device_name=device)
-        log.info('The model {} is loaded to {}'.format(model, device))
+        log.info('Reading model {}'.format(model_path))
+        self.model = core.read_model(model_path)
+        compiled_model = core.compile_model(self.model, device)
+        self.infer_request = compiled_model.create_infer_request()
+        log.info('The model {} is loaded to {}'.format(model_path, device))
 
     def _reset_state(self):
         super()._reset_state()
@@ -71,20 +72,22 @@ class RnnSeqPipelineStage(BlockedSeqPipelineStage):
         )
 
         if self._rnn_state is None:
-            state_h = np.zeros(self.exec_net.input_info[self.p['in_state_h']].input_data.shape)
-            state_c = np.zeros(self.exec_net.input_info[self.p['in_state_c']].input_data.shape)
+            state_h = np.zeros(self.model.input(self.p['in_state_h']).shape)
+            state_c = np.zeros(self.model.input(self.p['in_state_c']).shape)
         else:
             state_h, state_c = self._rnn_state
 
-        infer_res = self.exec_net.infer(inputs={
+        self.infer_request.infer(inputs={
             self.p['in_state_c']: state_c,
             self.p['in_state_h']: state_h,
             self.p['in_data']: [mfcc_features],
         })
+        output_names = {'out_state_c', 'out_state_h', 'out_data'}
+        infer_res = {name: self.infer_request.get_tensor(self.p[name]).data for name in output_names}
 
-        state_c = infer_res[self.p['out_state_c']]
-        state_h = infer_res[self.p['out_state_h']]
+        state_c = infer_res['out_state_c']
+        state_h = infer_res['out_state_h']
         self._rnn_state = (state_h, state_c)
 
-        probs = infer_res[self.p['out_data']].squeeze(1)
+        probs = infer_res['out_data'].squeeze(1)
         return probs

--- a/demos/speech_recognition_deepspeech_demo/python/speech_recognition_deepspeech_demo.py
+++ b/demos/speech_recognition_deepspeech_demo/python/speech_recognition_deepspeech_demo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2021 Intel Corporation
+# Copyright (C) 2019-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # This file is based in part on deepspeech_openvino_0.5.py by Feng Yen-Chang at
@@ -16,7 +16,7 @@ import argparse
 import yaml
 import numpy as np
 from tqdm import tqdm
-from openvino.inference_engine import IECore, get_version
+from openvino.runtime import Core, get_version
 
 from asr_utils.profiles import PROFILES
 from asr_utils.deep_speech_seq_pipeline import DeepSpeechSeqPipeline
@@ -73,11 +73,11 @@ def main():
 
     log.info('OpenVINO Inference Engine')
     log.info('\tbuild: {}'.format(get_version()))
-    ie = IECore()
+    core = Core()
 
     start_load_time = time.perf_counter()
     stt = DeepSpeechSeqPipeline(
-        ie = ie,
+        core = core,
         model = args.model,
         lm = args.lm,
         beam_width = args.beam_width,


### PR DESCRIPTION
Migrate python speech_recognition_deepspeech_demo to OV2.0 API.
**The demo does not work, because the model's input/output nodes names are changed by original tensorflow names.** So, the profile file will contain different names for old and new API. Waiting for updates from MO side solving the issue of models nodes naming