### PR TITLE
G-API: Background subtraction demo

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -12,6 +12,7 @@ The Open Model Zoo includes the following demos:
 - [3D Segmentation Python\* Demo](./3d_segmentation_demo/python/README.md) - Segmentation demo segments 3D images using 3D convolutional networks.
 - [Action Recognition Python\* Demo](./action_recognition_demo/python/README.md) - Demo application for Action Recognition algorithm, which classifies actions that are being performed on input video.
 - [Background Subtraction Python\* Demo](./background_subtraction_demo/python/README.md) - Background subtraction using instance segmentation based models.
+- [Background Subtraction C++ G-API\* Demo](./background_subtraction_demo/cpp_gapi/README.md) - Background subtraction G-API version.
 - [BERT Named Entity Recognition Python\* Demo](./bert_named_entity_recognition_demo/python/README.md) - NER Demo application that uses a CONLL2003-tuned BERT model for inference.
 - [BERT Question Answering Python\* Demo](./bert_question_answering_demo/python/README.md)
 - [BERT Question Answering Embedding Python\* Demo](./bert_question_answering_embedding_demo/python/README.md) - The demo demonstrates how to run BERT based models for question answering task.

--- a/demos/background_subtraction_demo/cpp_gapi/CMakeLists.txt
+++ b/demos/background_subtraction_demo/cpp_gapi/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+
+add_demo(NAME background_subtraction_demo_gapi
+    SOURCES ${SOURCES}
+    HEADERS ${HEADERS}
+    INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    DEPENDENCIES monitors utils_gapi
+    OPENCV_VERSION_REQUIRED 4.5.5)

--- a/demos/background_subtraction_demo/cpp_gapi/README.md
+++ b/demos/background_subtraction_demo/cpp_gapi/README.md
@@ -1,0 +1,115 @@
+# G-API Background Subtraction Demo
+
+This demo shows how to perform background subtraction using G-API.
+
+> **NOTE**: Only batch size of 1 is supported.
+
+## How It Works
+The demo application expects an instance-segmentation-security-???? or trimap free background matting based on pixel-level segmentation approach model in the Intermediate Representation (IR) format.
+
+1. for instance segmentation models based on `Mask RCNN` approach:
+    * One input: `image` for input image.
+    * At least three outputs including:
+        * `boxes` with absolute bounding box coordinates of the input image and its score
+        * `labels` with object class IDs for all bounding boxes
+        * `masks` with fixed-size segmentation heat maps for all classes of all bounding boxes
+2. for tripmap free background matting based on pixel-level segmentation approach:
+    * Single 1x3xWxH input.
+    * Single 1x1xWxH output - float tensor which is alpha channel for input.
+
+The use case for the demo is an online conference where is needed to show only foreground - people and, respectively, to hide or replace background.
+
+As input, the demo application accepts a path to a single image file, a video file or a numeric ID of a web camera specified with a command-line argument `-i`
+
+The demo workflow is the following:
+
+1. The demo application reads image/video frames one by one, resizes them to fit into the input image blob of the network (`image`).
+2. The demo visualizes the resulting background subtraction. Certain command-line options affect the visualization:
+    * If you specify `--target_bgr`, background will be replaced by a chosen image or video. By default background replaced by green field.
+    * If you specify `--blur_bgr`, background will be blurred according to a set value. By default equal to zero and is not applied.
+
+> **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
+
+## Preparing to Run
+
+For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).
+The list of models supported by the demo is in `<omz_dir>/demos/background_subtraction_demo/cpp_gapi/models.lst` file.
+This file can be used as a parameter for [Model Downloader](../../../tools/model_tools/README.md) and Converter to download and, if necessary, convert models to OpenVINO Inference Engine format (\*.xml + \*.bin).
+
+An example of using the Model Downloader:
+
+```sh
+omz_downloader --list models.lst
+```
+
+An example of using the Model Converter:
+
+```sh
+omz_converter --list models.lst
+```
+
+> **NOTE**: Refer to the tables [Intel's Pre-Trained Models Device Support](../../../models/intel/device_support.md) and [Public Pre-Trained Models Device Support](../../../models/public/device_support.md) for the details on models inference support at different devices.
+
+## Running
+
+Run the application with the `-h` option to see the following usage message:
+
+```
+[ INFO ] OpenVINO Inference Engine
+[ INFO ]        version: <version>
+[ INFO ]        build: <number>
+
+background_subtraction_demo_gapi [OPTION]
+Options:
+
+    -h                         Print a usage message.
+    -i                         Required. An input to process. The input must be a single image, a folder of images, video file or camera id.
+    -loop                      Optional. Enable reading the input in a loop.
+    -o "<path>"                Optional. Name of the output file(s) to save.
+    -limit "<num>"             Optional. Number of frames to store in output. If 0 is set, all frames are stored.
+    -res "<WxH>"               Optional. Set camera resolution in format WxH.
+    -at "<type>"               Required. Architecture type: maskrcnn.
+    -m "<path>"                Required. Path to an .xml file with a trained model.
+    -kernel_package "<string>" Optional. G-API kernel package type: opencv, fluid (by default opencv is used).
+    -d "<device>"              Optional. Target device for network (the list of available devices is shown below). The demo will look for a suitable plugin for a specified device. Default value is "CPU".
+    -nireq "<integer>"         Optional. Number of infer requests. If this option is omitted, number of infer requests is determined automatically.
+    -nthreads "<integer>"      Optional. Number of threads.
+    -nstreams                  Optional. Number of streams to use for inference on the CPU or/and GPU in throughput mode (for HETERO and MULTI device cases use format <device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)
+    -no_show                   Optional. Don't show output.
+    -blur_bgr                  Optional. Blur background.
+    -target_bgr                Optional. Background onto which to composite the output (by default to green field).
+    -u                         Optional. List of monitors to show initially.
+
+Available target devices:  <targets>
+```
+
+Running the application with an empty list of options yields the short version of the usage message and an error message.
+
+To run the demo, please provide paths to the model in the IR format, and to an input video, image, or folder with images:
+
+```bash
+./background_subtraction_demo_gapi/ -m <path_to_model> -i <path_to_file>
+```
+
+>**NOTE**: If you provide a single image as an input, the demo processes and renders it quickly, then exits. To continuously visualize inference results on the screen, apply the `loop` option, which enforces processing a single image in a loop.
+
+You can save processed results to a Motion JPEG AVI file or separate JPEG or PNG files using the `-o` option:
+
+* To save processed results in an AVI file, specify the name of the output file with `avi` extension, for example: `-o output.avi`.
+* To save processed results as images, specify the template name of the output image file with `jpg` or `png` extension, for example: `-o output_%03d.jpg`. The actual file names are constructed from the template at runtime by replacing regular expression `%03d` with the frame number, resulting in the following: `output_000.jpg`, `output_001.jpg`, and so on.
+To avoid disk space overrun in case of continuous input stream, like camera, you can limit the amount of data stored in the output file(s) with the `limit` option. The default value is 1000. To change it, you can apply the `-limit N` option, where `N` is the number of frames to store.
+
+>**NOTE**: Windows\* systems may not have the Motion JPEG codec installed by default. If this is the case, you can download OpenCV FFMPEG back end using the PowerShell script provided with the OpenVINO &trade; install package and located at `<INSTALL_DIR>/opencv/ffmpeg-download.ps1`. The script should be run with administrative privileges if OpenVINO &trade; is installed in a system protected folder (this is a typical case). Alternatively, you can save results as images.
+
+## Demo Output
+
+The application uses OpenCV to display resulting images.
+The demo reports
+
+* **FPS**: average rate of video frame processing (frames per second).
+
+## See Also
+
+* [Open Model Zoo Demos](../../README.md)
+* [Model Optimizer](https://docs.openvinotoolkit.org/latest/_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html)
+* [Model Downloader](../../../tools/model_tools/README.md)

--- a/demos/background_subtraction_demo/cpp_gapi/background_subtraction_demo_gapi.hpp
+++ b/demos/background_subtraction_demo/cpp_gapi/background_subtraction_demo_gapi.hpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <gflags/gflags.h>
+#include <utils/default_flags.hpp>
+
+DEFINE_INPUT_FLAGS
+DEFINE_OUTPUT_FLAGS
+
+static const char help_message[] = "Print a usage message.";
+static const char camera_resolution_message[] = "Optional. Set camera resolution in format WxH.";
+static const char at_message[] = "Required. Architecture type: maskrcnn, background-matting.";
+static const char model_message[] = "Required. Path to an .xml file with a trained model.";
+static const char kernel_package_message[] = "Optional. G-API kernel package type: opencv, fluid (by default opencv is used).";
+static const char device_message[] = "Optional. Target device for network (the list of available devices is shown below). "
+                                            "The demo will look for a suitable plugin for a specified device. Default value is \"CPU\".";
+static const char nireq_message[] = "Optional. Number of infer requests. If this option is omitted, number of infer requests is determined automatically.";
+static const char num_threads_message[] = "Optional. Number of threads.";
+static const char num_streams_message[] = "Optional. Number of streams to use for inference on the CPU or/and GPU in "
+"throughput mode (for HETERO and MULTI device cases use format "
+"<device1>:<nstreams1>,<device2>:<nstreams2> or just <nstreams>)";
+static const char no_show_message[] = "Optional. Don't show output.";
+static const char blur_bgr_message[] = "Optional. Blur background.";
+static const char target_bgr_message[] = "Optional. Background onto which to composite the output (by default to green field).";
+static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+
+DEFINE_bool(h, false, help_message);
+DEFINE_string(res, "1280x720", camera_resolution_message);
+DEFINE_string(at, "", at_message);
+DEFINE_string(m, "", model_message);
+DEFINE_string(kernel_package, "opencv", kernel_package_message);
+DEFINE_string(d, "CPU", device_message);
+DEFINE_uint32(nireq, 1, nireq_message);
+DEFINE_uint32(nthreads, 0, num_threads_message);
+DEFINE_string(nstreams, "", num_streams_message);
+DEFINE_bool(no_show, false, no_show_message);
+DEFINE_string(target_bgr, "", target_bgr_message);
+DEFINE_uint32(blur_bgr, 0, blur_bgr_message);
+DEFINE_string(u, "", utilization_monitors_message);
+
+/**
+* \brief This function shows a help message
+*/
+
+static void showUsage() {
+    std::cout << std::endl;
+    std::cout << "background_subtraction_demo_gapi [OPTION]" << std::endl;
+    std::cout << "Options:" << std::endl;
+    std::cout << std::endl;
+    std::cout << "    -h                         " << help_message << std::endl;
+    std::cout << "    -i                         " << input_message << std::endl;
+    std::cout << "    -loop                      " << loop_message << std::endl;
+    std::cout << "    -o \"<path>\"                " << output_message << std::endl;
+    std::cout << "    -limit \"<num>\"             " << limit_message << std::endl;
+    std::cout << "    -res \"<WxH>\"               " << camera_resolution_message << std::endl;
+    std::cout << "    -at \"<type>\"               " << at_message << std::endl;
+    std::cout << "    -m \"<path>\"                " << model_message << std::endl;
+    std::cout << "    -kernel_package \"<string>\" " << kernel_package_message << std::endl;
+    std::cout << "    -d \"<device>\"              " << device_message << std::endl;
+    std::cout << "    -nireq \"<integer>\"         " << nireq_message << std::endl;
+    std::cout << "    -nthreads \"<integer>\"      " << num_threads_message << std::endl;
+    std::cout << "    -nstreams                  " << num_streams_message << std::endl;
+    std::cout << "    -no_show                   " << no_show_message << std::endl;
+    std::cout << "    -blur_bgr \"<integer>\"      " << blur_bgr_message << std::endl;
+    std::cout << "    -target_bgr                " << target_bgr_message << std::endl;
+    std::cout << "    -u                         " << utilization_monitors_message << std::endl;
+}

--- a/demos/background_subtraction_demo/cpp_gapi/include/custom_kernels.hpp
+++ b/demos/background_subtraction_demo/cpp_gapi/include/custom_kernels.hpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <opencv2/gapi/gkernel.hpp>
+#include <opencv2/gapi/infer/ie.hpp>
+
+#include <inference_engine.hpp>
+
+namespace IE = InferenceEngine;
+
+namespace custom {
+G_API_OP(GTensorToImg, <cv::GMat(cv::GMat)>, "custom.tensorToImg") {
+    static cv::GMatDesc outMeta(const cv::GMatDesc& in) {
+        // NB: Input is ND mat.
+        return cv::GMatDesc{in.depth, in.dims[1], cv::Size(in.dims[3], in.dims[2])};
+    }
+};
+
+G_API_OP(GCalculateMaskRCNNBGMask,
+         <cv::GMat(cv::Size, cv::Size, cv::GMat, cv::GMat, cv::GMat)>,
+         "maskrcnn.calculate-background-mask") {
+    static cv::GMatDesc outMeta(const cv::Size& in_sz,
+                                const cv::Size&,
+                                const cv::GMatDesc&,
+                                const cv::GMatDesc&,
+                                const cv::GMatDesc&) {
+        return cv::GMatDesc{CV_8U, 1, in_sz};
+    }
+};
+
+class NNBGReplacer {
+public:
+    NNBGReplacer(const std::string& model_path);
+    virtual cv::GMat replace(cv::GMat, const cv::Size&, cv::GMat) = 0;
+    const std::string& getName() { return m_tag; }
+
+protected:
+    IE::CNNNetwork     m_cnn_network;
+    std::string        m_tag;
+    IE::InputsDataMap  m_inputs;
+    IE::OutputsDataMap m_outputs;
+};
+
+class MaskRCNNBGReplacer : public NNBGReplacer {
+public:
+    MaskRCNNBGReplacer(const std::string& model_path);
+    cv::GMat replace(cv::GMat, const cv::Size&, cv::GMat) override;
+
+private:
+    std::string m_input_name;
+    std::string m_labels_name;
+    std::string m_boxes_name;
+    std::string m_masks_name;
+};
+
+class BGMattingReplacer : public NNBGReplacer {
+public:
+    BGMattingReplacer(const std::string& model_path);
+    cv::GMat replace(cv::GMat, const cv::Size&, cv::GMat) override;
+
+private:
+    std::string m_input_name;
+    std::string m_output_name;
+};
+
+cv::gapi::GKernelPackage kernels();
+
+} // namespace custom

--- a/demos/background_subtraction_demo/cpp_gapi/main.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
         PerformanceMetrics metrics;
 
         /** Print info about Inference Engine **/
-        slog::info << *InferenceEngine::GetInferenceEngineVersion() << slog::endl;
+        slog::info << ov::get_openvino_version() << slog::endl;
         // ---------- Parsing and validating of input arguments ----------
         if (!util::ParseAndCheckCommandLine(argc, argv)) {
             return 0;

--- a/demos/background_subtraction_demo/cpp_gapi/main.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/main.cpp
@@ -1,0 +1,215 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <monitors/presenter.h>
+#include <utils/args_helper.hpp>
+#include <utils_gapi/stream_source.hpp>
+#include <utils/config_factory.h>
+
+#include <opencv2/gapi/streaming/cap.hpp>
+#include <opencv2/gapi/imgproc.hpp>
+#include <opencv2/gapi/core.hpp>
+
+#include <opencv2/gapi/fluid/core.hpp>
+#include <opencv2/gapi/fluid/imgproc.hpp>
+#include <opencv2/gapi/cpu/core.hpp>
+#include <opencv2/gapi/cpu/imgproc.hpp>
+
+#include <opencv2/highgui.hpp>
+
+#include "background_subtraction_demo_gapi.hpp"
+#include "custom_kernels.hpp"
+
+namespace util {
+bool ParseAndCheckCommandLine(int argc, char *argv[]) {
+    /** ---------- Parsing and validating input arguments ----------**/
+    gflags::ParseCommandLineNonHelpFlags(&argc, &argv, true);
+    if (FLAGS_h) {
+        showUsage();
+        showAvailableDevices();
+        return false;
+    }
+    if (FLAGS_i.empty())
+        throw std::logic_error("Parameter -i is not set");
+    if (FLAGS_m.empty())
+        throw std::logic_error("Parameter -m is not set");
+    if (FLAGS_at.empty()) {
+        throw std::logic_error("Parameter -at is not set");
+    }
+    return true;
+}
+
+static cv::gapi::GKernelPackage getKernelPackage(const std::string& type) {
+    if (type == "opencv") {
+        return cv::gapi::combine(cv::gapi::core::cpu::kernels(),
+                                 cv::gapi::imgproc::cpu::kernels());
+    } else if (type == "fluid") {
+        return cv::gapi::combine(cv::gapi::core::fluid::kernels(),
+                                 cv::gapi::imgproc::fluid::kernels());
+    } else {
+        throw std::logic_error("Unsupported kernel package type: " + type);
+    }
+    GAPI_Assert(false && "Unreachable code!");
+}
+
+} // namespace util
+
+int main(int argc, char *argv[]) {
+    try {
+        PerformanceMetrics metrics;
+
+        /** Print info about Inference Engine **/
+        slog::info << *InferenceEngine::GetInferenceEngineVersion() << slog::endl;
+        // ---------- Parsing and validating of input arguments ----------
+        if (!util::ParseAndCheckCommandLine(argc, argv)) {
+            return 0;
+        }
+
+        /** ---------------- Main graph of demo ---------------- **/
+        const bool is_blur = FLAGS_blur_bgr != 0;
+
+        std::shared_ptr<custom::NNBGReplacer> model;
+        if (FLAGS_at == "maskrcnn") {
+            model = std::make_shared<custom::MaskRCNNBGReplacer>(FLAGS_m);
+        } else if (FLAGS_at == "background-matting") {
+            model = std::make_shared<custom::BGMattingReplacer>(FLAGS_m);
+        } else {
+            slog::err << "No model type or invalid model type (-at) provided: " + FLAGS_at << slog::endl;
+            return -1;
+        }
+
+        /** Get information about frame **/
+        std::shared_ptr<ImagesCapture> cap = openImagesCapture(FLAGS_i, FLAGS_loop, 0,
+            std::numeric_limits<size_t>::max(), stringToSize(FLAGS_res));
+        const auto tmp = cap->read();
+        if (!tmp.data) {
+            throw std::runtime_error("Couldn't grab first frame");
+        }
+        cv::Size frame_size = cv::Size{tmp.cols, tmp.rows};
+
+        cv::GComputation comp([&]{
+            cv::GMat in;
+            // NB: target_bgr is optional second input which implies a background
+            // that will change user video background. If user don't specify
+            // it and specifies --bgr_blur then second input won't be used since
+            // it's needed only to blur user background, otherwise second input will be used.
+            cv::optional<cv::GMat> target_bgr;
+
+            cv::GMat bgr_resized;
+            if (is_blur && FLAGS_target_bgr.empty()) {
+                bgr_resized = in;
+            } else {
+                target_bgr = cv::util::make_optional<cv::GMat>(cv::GMat());
+                bgr_resized = cv::gapi::resize(target_bgr.value(), frame_size);
+            }
+
+            auto background = is_blur
+                ? cv::gapi::blur(bgr_resized, cv::Size(FLAGS_blur_bgr, FLAGS_blur_bgr))
+                : bgr_resized;
+
+            auto result = model->replace(in, frame_size, background);
+
+            auto graph_inputs = cv::GIn(in);
+            if (target_bgr.has_value()) {
+                graph_inputs += cv::GIn(target_bgr.value());
+            }
+
+            return cv::GComputation(std::move(graph_inputs), cv::GOut(result));
+        });
+
+        /** Configure network **/
+        auto config = ConfigFactory::getUserConfig(FLAGS_d, "", "", FLAGS_nireq,
+                                                   FLAGS_nstreams, FLAGS_nthreads);
+        const auto net = cv::gapi::ie::Params<cv::gapi::Generic> {
+            model->getName(),
+            FLAGS_m,                           // path to topology IR
+            fileNameNoExt(FLAGS_m) + ".bin",   // path to weights
+            FLAGS_d                            // device specifier
+        }.cfgNumRequests(config.maxAsyncRequests)
+         .pluginConfig(config.execNetworkConfig);
+        slog::info << "The background matting model " << FLAGS_m << " is loaded to " << FLAGS_d << " device." << slog::endl;
+
+        auto kernels = cv::gapi::combine(custom::kernels(),
+                                         util::getKernelPackage(FLAGS_kernel_package));
+        auto pipeline = comp.compileStreaming(cv::compile_args(kernels,
+                                                               cv::gapi::networks(net)));
+
+        /** Output container for result **/
+        cv::Mat output;
+
+        /** ---------------- The execution part ---------------- **/
+        cap = openImagesCapture(FLAGS_i, FLAGS_loop, 0,
+            std::numeric_limits<size_t>::max(), stringToSize(FLAGS_res));
+        auto pipeline_inputs = cv::gin(cv::gapi::wip::make_src<custom::CommonCapSrc>(cap));
+        if (!is_blur && FLAGS_target_bgr.empty()) {
+            cv::Scalar default_color(155, 255, 120);
+            pipeline_inputs += cv::gin(cv::Mat(frame_size, CV_8UC3, default_color));
+        } else if (!FLAGS_target_bgr.empty()) {
+            std::shared_ptr<ImagesCapture> target_bgr_cap = openImagesCapture(FLAGS_target_bgr, true, 0,
+                std::numeric_limits<size_t>::max());
+            pipeline_inputs += cv::gin(cv::gapi::wip::make_src<custom::CommonCapSrc>(target_bgr_cap));
+        }
+
+        pipeline.setSource(std::move(pipeline_inputs));
+        std::string windowName = "Background subtraction demo G-API";
+        int delay = 1;
+
+        cv::Size graphSize{static_cast<int>(frame_size.width / 4), 60};
+        Presenter presenter(FLAGS_u, frame_size.height - graphSize.height - 10, graphSize);
+
+        /** Save output result **/
+        cv::VideoWriter videoWriter;
+        if (!FLAGS_o.empty() && !videoWriter.open(FLAGS_o, cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+                                                  cap->fps(), frame_size)) {
+            throw std::runtime_error("Can't open video writer");
+        }
+
+        bool isStart = true;
+        uint64_t curr_frame_num = 0;
+        const auto startTime = std::chrono::steady_clock::now();
+        pipeline.start();
+
+        while(pipeline.pull(cv::gout(output))) {
+            ++curr_frame_num;
+            presenter.drawGraphs(output);
+            if (isStart) {
+                metrics.update(startTime, output, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX,
+                    0.65, { 200, 10, 10 }, 2, PerformanceMetrics::MetricTypes::FPS);
+                isStart = false;
+            }
+            else {
+                metrics.update({}, output, { 10, 22 }, cv::FONT_HERSHEY_COMPLEX,
+                    0.65, { 200, 10, 10 }, 2, PerformanceMetrics::MetricTypes::FPS);
+            }
+
+            if (videoWriter.isOpened() &&
+                (FLAGS_limit <= 0 || curr_frame_num <= FLAGS_limit)) {
+                videoWriter.write(output);
+            }
+
+            if (!FLAGS_no_show) {
+                cv::imshow(windowName, output);
+                int key = cv::waitKey(delay);
+                /** Press 'Esc' to quit **/
+                if (key == 27) {
+                    break;
+                } else {
+                    presenter.handleKey(key);
+                }
+            }
+        }
+        slog::info << "Metrics report:" << slog::endl;
+        slog::info << "\tFPS: " << std::fixed << std::setprecision(1) << metrics.getTotal().fps << slog::endl;
+        slog::info << presenter.reportMeans() << slog::endl;
+    }
+    catch (const std::exception& error) {
+        slog::err << error.what() << slog::endl;
+        return 1;
+    }
+    catch (...) {
+        slog::err << "Unknown/internal exception happened." << slog::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/demos/background_subtraction_demo/cpp_gapi/main.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/main.cpp
@@ -21,6 +21,8 @@
 #include "background_subtraction_demo_gapi.hpp"
 #include "custom_kernels.hpp"
 
+#include <openvino/openvino.hpp>
+
 namespace util {
 bool ParseAndCheckCommandLine(int argc, char *argv[]) {
     /** ---------- Parsing and validating input arguments ----------**/

--- a/demos/background_subtraction_demo/cpp_gapi/models.lst
+++ b/demos/background_subtraction_demo/cpp_gapi/models.lst
@@ -1,0 +1,3 @@
+# This file can be used with the --list option of the model downloader.
+# TODO: instance-segmentation-person-????
+instance-segmentation-security-????

--- a/demos/background_subtraction_demo/cpp_gapi/src/custom_kernels.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/src/custom_kernels.cpp
@@ -1,0 +1,213 @@
+#include "custom_kernels.hpp"
+
+#include <algorithm>
+
+#include <opencv2/gapi/cpu/gcpukernel.hpp>
+
+#include <opencv2/gapi/imgproc.hpp>
+#include <opencv2/gapi/core.hpp>
+#include <opencv2/gapi/operators.hpp>
+
+GAPI_OCV_KERNEL(OCVTensorToImg, custom::GTensorToImg) {
+    static void run(const cv::Mat  &in,
+                    cv::Mat        &out) {
+        auto* out_p = out.ptr<float>();
+        auto* in_p  = in.ptr<const float>();
+        std::copy_n(in_p, in.size[2] * in.size[3], out_p);
+    }
+};
+
+static cv::Rect expandBox(const float x0,
+                          const float y0,
+                          const float x1,
+                          const float y1,
+                          const float scale) {
+    const float w_half = ((x1 - x0) * 0.5f) * scale;
+    const float h_half = ((y1 - y0) * 0.5f) * scale;
+    const float x_c    =  (x1 + x0) * 0.5f;
+    const float y_c    =  (y1 + y0) * 0.5f;
+    cv::Point tl(x_c - w_half, y_c - h_half);
+    cv::Point br(x_c + w_half, y_c + h_half);
+    return cv::Rect(tl, br);
+}
+
+static int clip(int value, int lower, int upper) {
+    return std::max(lower, std::min(value, upper));
+};
+
+GAPI_OCV_KERNEL(OCVCalculateMaskRCNNBGMask, custom::GCalculateMaskRCNNBGMask) {
+    static void run(const cv::Size& original_sz,
+                    const cv::Size& model_in_size,
+                    const cv::Mat&  raw_labels,
+                    const cv::Mat&  raw_boxes,
+                    const cv::Mat&  raw_masks,
+                    cv::Mat&        mask) {
+        GAPI_Assert(raw_labels.depth() == CV_32S);
+        GAPI_Assert(raw_boxes.depth()  == CV_32F);
+        GAPI_Assert(raw_masks.depth()  == CV_32F);
+
+        const int   BOX_SIZE          = 5;
+        const int   CONFIDENCE_OFFSET = 4;
+        const int   BOX_X0_OFFSET     = 0;
+        const int   BOX_Y0_OFFSET     = 1;
+        const int   BOX_X1_OFFSET     = 2;
+        const int   BOX_Y1_OFFSET     = 3;
+        const int   PERSON_ID         = 0;
+        const float BIN_THRESHOLD     = 0.5f;
+
+        const int    num_boxes      = raw_boxes.size[0];
+        const float* boxes_ptr      = raw_boxes.ptr<float>();
+        // FIXME: In order to create "view" over raw_masks, need to obtain non const pointer.
+              float* masks_ptr      = const_cast<float*>(raw_masks.ptr<float>());
+        const int*   labels_ptr     = raw_labels.ptr<int>();
+        const float  prob_threshold = 0.5;
+        const cv::Size mask_sz(raw_masks.size[1], raw_masks.size[2]);
+
+        const float scale_x = static_cast<float>(model_in_size.width)  / original_sz.width;
+        const float scale_y = static_cast<float>(model_in_size.height) / original_sz.height;
+        const float scale   = 1.f;
+
+        std::vector<cv::Mat> person_masks;
+        for (int box_idx = 0; box_idx < num_boxes; ++box_idx) {
+            const int conf_idx = box_idx * BOX_SIZE + CONFIDENCE_OFFSET;
+
+            if (boxes_ptr[conf_idx] > prob_threshold &&
+                labels_ptr[box_idx] == PERSON_ID) {
+                const int mask_offset     = box_idx * mask_sz.area();
+                const int box_pos_offset  = box_idx * BOX_SIZE;
+
+                auto box = expandBox(boxes_ptr[box_pos_offset + BOX_X0_OFFSET] / scale_x,
+                                     boxes_ptr[box_pos_offset + BOX_Y0_OFFSET] / scale_y,
+                                     boxes_ptr[box_pos_offset + BOX_X1_OFFSET] / scale_x,
+                                     boxes_ptr[box_pos_offset + BOX_Y1_OFFSET] / scale_y,
+                                     scale);
+
+                const auto& br  = box.br();
+                const auto& tl  = box.tl();
+
+                const int x0 = clip(tl.x, 0, original_sz.width);
+                const int y0 = clip(tl.y, 0, original_sz.height);
+                const int x1 = clip(br.x, 0, original_sz.width);
+                const int y1 = clip(br.y, 0, original_sz.height);
+
+                cv::Mat person_mask(mask_sz, CV_32FC1, masks_ptr + mask_offset);
+                cv::Mat resized_person_mask;
+
+                const auto diff = br - tl;
+                const cv::Size expanded_size(std::max(diff.x + 1, 1),
+                                             std::max(diff.y + 1, 1));
+                cv::resize(person_mask, resized_person_mask, expanded_size);
+
+                cv::Mat bin_mask = resized_person_mask > BIN_THRESHOLD;
+                bin_mask.convertTo(bin_mask, CV_8U, 255);
+
+                auto bin_mask_slice = cv::Rect(cv::Point(x0 - tl.x, y0 - tl.y),
+                                               cv::Point(x1 - tl.x, y1 - tl.y));
+
+                cv::Mat result_mask(original_sz, CV_8UC1, cv::Scalar(0));
+                bin_mask(bin_mask_slice).copyTo(result_mask(cv::Rect(cv::Point(x0, y0),
+                                                                     cv::Point(x1, y1))));
+                person_masks.push_back(result_mask);
+            }
+        }
+
+        if (person_masks.empty()) {
+            mask.setTo(255.f);
+        } else {
+            person_masks[0].copyTo(mask);
+            for (const auto& m : person_masks) {
+                mask |= m;
+            }
+        }
+    }
+};
+
+custom::NNBGReplacer::NNBGReplacer(const std::string& model_path) {
+    IE::Core core;
+    m_cnn_network = core.ReadNetwork(model_path);
+    m_tag         = m_cnn_network.getName();
+    m_inputs      = m_cnn_network.getInputsInfo();
+    m_outputs     = m_cnn_network.getOutputsInfo();
+}
+
+custom::MaskRCNNBGReplacer::MaskRCNNBGReplacer(const std::string& model_path)
+    : custom::NNBGReplacer(model_path) {
+    for (const auto& p : m_outputs) {
+        const auto& layer_name = p.first;
+        if (layer_name.rfind("TopK") != std::string::npos) {
+            continue;
+        }
+
+        if (m_inputs.size() != 1) {
+            throw std::logic_error("Supported only single input MaskRCNN models!");
+        }
+        m_input_name = m_inputs.begin()->first;
+
+        const auto dims_size = p.second->getTensorDesc().getDims().size();
+        if (dims_size == 1) {
+            m_labels_name = layer_name;
+        } else if (dims_size == 2) {
+            m_boxes_name = layer_name;
+        } else if (dims_size == 3) {
+            m_masks_name = layer_name;
+        } else {
+            throw std::logic_error("Unexpected output layer shape for: " + layer_name);
+        }
+    }
+}
+
+cv::GMat custom::MaskRCNNBGReplacer::replace(cv::GMat in,
+                                             const cv::Size& in_size,
+                                             cv::GMat background) {
+    cv::GInferInputs inputs;
+    inputs[m_input_name] = in;
+    auto outputs = cv::gapi::infer<cv::gapi::Generic>(m_tag, inputs);
+    auto labels  = outputs.at(m_labels_name);
+    auto boxes   = outputs.at(m_boxes_name);
+    auto masks   = outputs.at(m_masks_name);
+
+    const auto& dims = m_inputs.at(m_input_name)->getTensorDesc().getDims();
+    GAPI_Assert(dims.size() == 4u);
+    auto mask = custom::GCalculateMaskRCNNBGMask::on(in_size,
+                                                     cv::Size(dims[3], dims[2]),
+                                                     labels,
+                                                     boxes,
+                                                     masks);
+    auto mask3ch = cv::gapi::medianBlur(cv::gapi::merge3(mask, mask, mask), 11);
+    return (mask3ch & in) + (~mask3ch & background);
+}
+
+custom::BGMattingReplacer::BGMattingReplacer(const std::string& model_path)
+    : NNBGReplacer(model_path) {
+    if (m_inputs.size() != 1) {
+        throw std::logic_error("Supported only single input background matting models!");
+    }
+    m_input_name = m_inputs.begin()->first;
+
+    if (m_outputs.size() != 1) {
+        throw std::logic_error("Supported only single output background matting models!");
+    }
+    m_output_name = m_outputs.begin()->first;
+}
+
+cv::GMat custom::BGMattingReplacer::replace(cv::GMat in,
+                                            const cv::Size& in_size,
+                                            cv::GMat background) {
+    cv::GInferInputs inputs;
+    inputs[m_input_name] = in;
+    auto outputs = cv::gapi::infer<cv::gapi::Generic>(m_tag, inputs);
+
+    auto alpha = cv::gapi::resize(
+            custom::GTensorToImg::on(outputs.at(m_output_name)), in_size);
+    auto alpha3ch = cv::gapi::merge3(alpha, alpha, alpha);
+    auto in_fp    = cv::gapi::convertTo(in, CV_32F);
+    auto bgr_fp   = cv::gapi::convertTo(background, CV_32F);
+
+    cv::GScalar one(cv::Scalar::all(1.));
+    auto out = cv::gapi::mul(alpha3ch, in_fp) + cv::gapi::mul((one - alpha3ch), bgr_fp);
+    return cv::gapi::convertTo(out, CV_8U);
+}
+
+cv::gapi::GKernelPackage custom::kernels() {
+    return cv::gapi::kernels<OCVTensorToImg, OCVCalculateMaskRCNNBGMask>();
+}

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -686,7 +686,7 @@ NATIVE_DEMOS = [
     )),
 
     CppDemo(name='background_subtraction_demo', device_keys=['-d'], implementation='cpp_gapi', test_cases=combine_cases(
-        TestCase(options={'--no_show': None,
+        TestCase(options={'--no_show': None, '-at': 'maskrcnn',
             **MONITORS,
             '-i': DataPatternArg('instance-segmentation'),
         }),

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -685,6 +685,16 @@ NATIVE_DEMOS = [
 
     )),
 
+    CppDemo(name='background_subtraction_demo', device_keys=['-d'], implementation='cpp_gapi', test_cases=combine_cases(
+        TestCase(options={'--no_show': None,
+            **MONITORS,
+            '-i': DataPatternArg('instance-segmentation'),
+        }),
+        single_option_cases('-m',
+        #       ModelArg('instance-segmentation-person-0007'),
+            ModelArg('instance-segmentation-security-0091')),
+    ))
+
 ]
 
 PYTHON_DEMOS = [


### PR DESCRIPTION
## Different from the python demo:

### Unsupported flags:
* `--adapter` - demo works only with single model
* `-t` since needed only for `detection` models
* `--resize-type`- needed only for model adapter which isn't used
* `--labels` - supported only `instance-segmentation-person-????` models, that don't need labels
* `--show_with_original_frame`  - extra behavior for that demo
* `--output_resolution` - needed for `--show_with_original_frame` flag
* `--raw_output_message` - relevant only for detection models?