### PR TITLE
Cvs 62354/adopt download engine for onezoo

### DIFF
--- a/tools/model_tools/src/openvino/model_zoo/_configuration.py
+++ b/tools/model_tools/src/openvino/model_zoo/_configuration.py
@@ -377,4 +377,3 @@ def load_models_from_args(parser, args, models_root):
                 models[model.name] = model
 
         return list(models.values())
-

--- a/tools/model_tools/src/openvino/model_zoo/_configuration.py
+++ b/tools/model_tools/src/openvino/model_zoo/_configuration.py
@@ -71,11 +71,11 @@ class Model:
 
     @classmethod
     def deserialize(cls, model, name, subdirectory, composite_model_name, known_frameworks = None, known_task_types = None):
-        if known_frameworks is None: 
+        if known_frameworks is None:
             known_frameworks = _common.KNOWN_FRAMEWORKS
         if known_task_types is None:
             known_task_types = _common.KNOWN_TASK_TYPES
-        
+
         with validation.deserialization_context('In model "{}"'.format(name)):
             if not RE_MODEL_NAME.fullmatch(name):
                 raise validation.DeserializationError('Invalid name, must consist only of letters, digits or ._-')
@@ -183,11 +183,11 @@ class CompositeModel:
 
     @classmethod
     def deserialize(cls, model, name, subdirectory, stages, known_frameworks = None, known_task_types = None):
-        if known_frameworks is None: 
+        if known_frameworks is None:
             known_frameworks = _common.KNOWN_FRAMEWORKS
         if known_task_types is None:
             known_task_types = _common.KNOWN_TASK_TYPES
-        
+
         with validation.deserialization_context('In model "{}"'.format(name)):
             if not RE_MODEL_NAME.fullmatch(name):
                 raise validation.DeserializationError('Invalid name, must consist only of letters, digits or ._-')

--- a/tools/model_tools/src/openvino/model_zoo/_configuration.py
+++ b/tools/model_tools/src/openvino/model_zoo/_configuration.py
@@ -366,3 +366,4 @@ def load_models_from_args(parser, args, models_root):
                 models[model.name] = model
 
         return list(models.values())
+

--- a/tools/model_tools/src/openvino/model_zoo/_configuration.py
+++ b/tools/model_tools/src/openvino/model_zoo/_configuration.py
@@ -182,7 +182,7 @@ class CompositeModel:
         self.composite_model_name = composite_model_name
 
     @classmethod
-    def deserialize(cls, model, name, subdirectory, stages, known_frameworks = None, known_task_types = None):
+    def deserialize(cls, model, name, subdirectory, stages, known_frameworks=None, known_task_types=None):
         if known_frameworks is None:
             known_frameworks = _common.KNOWN_FRAMEWORKS
         if known_task_types is None:

--- a/tools/model_tools/src/openvino/model_zoo/_configuration.py
+++ b/tools/model_tools/src/openvino/model_zoo/_configuration.py
@@ -70,7 +70,7 @@ class Model:
         self.model_stages = {}
 
     @classmethod
-    def deserialize(cls, model, name, subdirectory, composite_model_name, known_frameworks = None, known_task_types = None):
+    def deserialize(cls, model, name, subdirectory, composite_model_name, known_frameworks=None, known_task_types=None):
         if known_frameworks is None:
             known_frameworks = _common.KNOWN_FRAMEWORKS
         if known_task_types is None:

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
@@ -118,9 +118,28 @@ class ChecksumSHA384(Checksum):
 
         sha384 = bytes.fromhex(sha384_str)
         return cls(sha384)
+    
+    
+class ChecksumSHA256(Checksum):
+    RE_SHA256SUM = re.compile(r"[0-9a-fA-F]{64}")
+
+    def __init__(self, value):
+        self.type = hashlib.sha256
+        self.value = value
+
+    @classmethod
+    def deserialize(cls, checksum):
+        sha256_str = validation.validate_string('"sha256"', checksum['value'])
+        if not cls.RE_SHA256SUM.fullmatch(sha256_str):
+            raise validation.DeserializationError(
+                '"sha256": got invalid hash {!r}'.format(sha256_str))
+
+        sha256 = bytes.fromhex(sha256_str)
+        return cls(sha256)
 
 
 Checksum.types['sha384'] = ChecksumSHA384
+Checksum.types['sha256'] = ChecksumSHA256
 
 
 def verify_hash(reporter, actual_hash, expected_hash, path):

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/cache.py
@@ -118,28 +118,9 @@ class ChecksumSHA384(Checksum):
 
         sha384 = bytes.fromhex(sha384_str)
         return cls(sha384)
-    
-    
-class ChecksumSHA256(Checksum):
-    RE_SHA256SUM = re.compile(r"[0-9a-fA-F]{64}")
-
-    def __init__(self, value):
-        self.type = hashlib.sha256
-        self.value = value
-
-    @classmethod
-    def deserialize(cls, checksum):
-        sha256_str = validation.validate_string('"sha256"', checksum['value'])
-        if not cls.RE_SHA256SUM.fullmatch(sha256_str):
-            raise validation.DeserializationError(
-                '"sha256": got invalid hash {!r}'.format(sha256_str))
-
-        sha256 = bytes.fromhex(sha256_str)
-        return cls(sha256)
 
 
 Checksum.types['sha384'] = ChecksumSHA384
-Checksum.types['sha256'] = ChecksumSHA256
 
 
 def verify_hash(reporter, actual_hash, expected_hash, path):

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
@@ -76,7 +76,6 @@ class Downloader:
         self._requested_precisions = _requested_precisions
 
     def _process_download(self, reporter, chunk_iterable, size, progress, file):
-        #same
         start_time = time.monotonic()
         start_size = progress.size
 

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
@@ -12,24 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import functools
 import requests
 import ssl
+import sys
+import threading
 import time
 import types
 
+from pathlib import Path
+from typing import Set
+
+from openvino.model_zoo import _common, _concurrency, _reporting
 from openvino.model_zoo.download_engine import cache
 
 DOWNLOAD_TIMEOUT = 5 * 60
 
+
+# There is no evidence that the requests.Session class is thread-safe,
+# so for safety, we use one Session per thread. This class ensures that
+# each thread gets its own Session.
+class ThreadSessionFactory:
+    def __init__(self, exit_stack):
+        self._lock = threading.Lock()
+        self._thread_local = threading.local()
+        self._exit_stack = exit_stack
+
+    def __call__(self):
+        try:
+            session = self._thread_local.session
+        except AttributeError:
+            with self._lock: # ExitStack might not be thread-safe either
+                session = self._exit_stack.enter_context(requests.Session())
+            self._thread_local.session = session
+        return session
+
+
 class Downloader:
-    def __init__(self, output_dir=None, cache_dir=None, num_attempts=1, timeout=DOWNLOAD_TIMEOUT):
+    def __init__(self, requested_precisions: str = None, output_dir: Path = None, 
+                 cache_dir: Path = None, num_attempts: int = 1, timeout: int = DOWNLOAD_TIMEOUT):
         self.output_dir = output_dir
         self.cache = cache.NullCache() if cache_dir is None else cache.DirCache(cache_dir)
         self.num_attempts = num_attempts
         self.timeout = timeout
+        self.requested_precisions = requested_precisions
+        
+    @property
+    def requested_precisions(self) -> Set[str]:
+        return self._requested_precisions
+    
+    @requested_precisions.setter
+    def requested_precisions(self, value: str = None):
+        if value is None:
+            _requested_precisions = _common.KNOWN_PRECISIONS
+        else:
+            _requested_precisions = set(value.split(','))
+            
+        unknown_precisions = _requested_precisions - _common.KNOWN_PRECISIONS
+        if unknown_precisions:
+            sys.exit('Unknown precisions specified: {}.'.format(', '.join(sorted(unknown_precisions))))
+        
+        self._requested_precisions = _requested_precisions
 
     def _process_download(self, reporter, chunk_iterable, size, progress, file):
+        #same
         start_time = time.monotonic()
         start_size = progress.size
 
@@ -130,6 +177,14 @@ class Downloader:
             cache.put(hash, source)
         except Exception:
             reporter.log_warning('Failed to update the cache', exc_info=True)
+            
+    @staticmethod
+    def make_reporter(progress_format: str, context=None):
+        if context is None:
+            context = _reporting.DirectOutputContext()
+        return _reporting.Reporter(context,
+                                   enable_human_output=progress_format == 'text',
+                                   enable_json_output=progress_format == 'json')
 
     def _try_retrieve(self, reporter, destination, model_file, start_download):
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -151,7 +206,10 @@ class Downloader:
         reporter.print()
         return success
 
-    def download_model(self, reporter, session_factory, requested_precisions, model, known_precisions):
+    def _download_model(self, reporter, session_factory, model, known_precisions: set = None):
+        if known_precisions is None:
+            known_precisions = _common.KNOWN_PRECISIONS
+        
         session = session_factory()
 
         reporter.print_group_heading('Downloading {}', model.name)
@@ -164,7 +222,7 @@ class Downloader:
         for model_file in model.files:
             if len(model_file.name.parts) == 2:
                 p = model_file.name.parts[0]
-                if p in known_precisions and p not in requested_precisions:
+                if p in known_precisions and p not in self.requested_precisions:
                     continue
 
             model_file_reporter = reporter.with_event_context(model=model.name, model_file=model_file.name.as_posix())
@@ -198,3 +256,25 @@ class Downloader:
             reporter.print()
 
         return True
+    
+    def download_model(self, model, reporter, session):
+        if model.model_stages:
+            results = []
+            for model_stage in model.model_stages:
+                results.append(self._download_model(reporter, session, model_stage))
+            return sum(results) == len(model.model_stages)
+        else:
+            return self._download_model(reporter, session, model)
+        
+    def bulk_download_model(self, models, reporter, jobs: int, progress_format: str) -> Set[str]:
+        with contextlib.ExitStack() as exit_stack:
+            session_factory = ThreadSessionFactory(exit_stack)
+            if jobs == 1:
+                results = [self.download_model(model, reporter, session_factory) for model in models]
+            else:
+                results = _concurrency.run_in_parallel(jobs,
+                    lambda context, model: self.download_model(model, self.make_reporter(progress_format, context), 
+                                                               session_factory),
+                    models)
+
+        return {model.name for model, successful in zip(models, results) if not successful}

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/file_source.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/file_source.py
@@ -67,7 +67,7 @@ class FileSourceHttp(FileSource):
     def deserialize(cls, source):
         return cls(validation.validate_string('"url"', source['url']))
 
-    def start_download(self, session, chunk_size, offset, timeout):
+    def start_download(self, session, chunk_size, offset, timeout, **kwargs):
         response = session.get(self.url, stream=True, timeout=timeout,
             headers=self.http_range_headers(offset))
         response.raise_for_status()
@@ -84,7 +84,7 @@ class FileSourceGoogleDrive(FileSource):
     def deserialize(cls, source):
         return cls(validation.validate_string('"id"', source['id']))
 
-    def start_download(self, session, chunk_size, offset, timeout):
+    def start_download(self, session, chunk_size, offset, timeout, **kwargs):
         range_headers = self.http_range_headers(offset)
         URL = 'https://docs.google.com/uc?export=download'
         response = session.get(URL, params={'id': self.id}, headers=range_headers,

--- a/tools/model_tools/src/openvino/model_zoo/omz_downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/omz_downloader.py
@@ -15,17 +15,12 @@
 """
 
 import argparse
-import contextlib
 import json
-import requests
 import sys
-import threading
 
 from pathlib import Path
 
-from openvino.model_zoo import (
-    _configuration, _common, _concurrency, _reporting,
-)
+from openvino.model_zoo import _configuration, _common
 from openvino.model_zoo.download_engine.downloader import Downloader
 
 
@@ -35,6 +30,7 @@ class DownloaderArgumentParser(argparse.ArgumentParser):
         self.print_help()
         sys.exit(2)
 
+
 def positive_int_arg(value_str):
     try:
         value = int(value_str)
@@ -43,26 +39,7 @@ def positive_int_arg(value_str):
         pass
 
     raise argparse.ArgumentTypeError('must be a positive integer (got {!r})'.format(value_str))
-
-
-# There is no evidence that the requests.Session class is thread-safe,
-# so for safety, we use one Session per thread. This class ensures that
-# each thread gets its own Session.
-class ThreadSessionFactory:
-    def __init__(self, exit_stack):
-        self._lock = threading.Lock()
-        self._thread_local = threading.local()
-        self._exit_stack = exit_stack
-
-    def __call__(self):
-        try:
-            session = self._thread_local.session
-        except AttributeError:
-            with self._lock: # ExitStack might not be thread-safe either
-                session = self._exit_stack.enter_context(requests.Session())
-            self._thread_local.session = session
-        return session
-
+        
 
 def main():
     parser = DownloaderArgumentParser()
@@ -90,12 +67,7 @@ def main():
 
     args = parser.parse_args()
 
-    def make_reporter(context):
-        return _reporting.Reporter(context,
-            enable_human_output=args.progress_format == 'text',
-            enable_json_output=args.progress_format == 'json')
-
-    reporter = make_reporter(_reporting.DirectOutputContext())
+    reporter = Downloader.make_reporter(args.progress_format)
 
     with _common.telemetry_session('Model Downloader', 'downloader') as telemetry:
         models = _configuration.load_models_from_args(parser, args, _common.MODEL_ROOT)
@@ -104,13 +76,12 @@ def main():
             if getattr(args, mode):
                 telemetry.send_event('md', 'downloader_selection_mode', mode)
 
-        if args.precisions is None:
-            requested_precisions = _common.KNOWN_PRECISIONS
-        else:
-            requested_precisions = set(args.precisions.split(','))
+        failed_models = set()
 
+        downloader = Downloader(args.precisions, args.output_dir, args.cache_dir, args.num_attempts)
+        
         for model in models:
-            precisions_to_send = requested_precisions if args.precisions else requested_precisions & model.precisions
+            precisions_to_send = downloader.requested_precisions if args.precisions else downloader.requested_precisions & model.precisions
             model_information = {
                 'name': model.name,
                 'framework': model.framework,
@@ -118,35 +89,7 @@ def main():
             }
             telemetry.send_event('md', 'downloader_model', json.dumps(model_information))
 
-        failed_models = set()
-
-        unknown_precisions = requested_precisions - _common.KNOWN_PRECISIONS
-        if unknown_precisions:
-            sys.exit('Unknown precisions specified: {}.'.format(', '.join(sorted(unknown_precisions))))
-
-        downloader = Downloader(args.output_dir, args.cache_dir, args.num_attempts)
-
-        def download_model(model, reporter, session):
-            if model.model_stages:
-                results = []
-                for model_stage in model.model_stages:
-                    results.append(downloader.download_model(
-                        reporter, session, requested_precisions, model_stage, _common.KNOWN_PRECISIONS))
-                return sum(results) == len(model.model_stages)
-            else:
-                return downloader.download_model(
-                    reporter, session, requested_precisions, model, _common.KNOWN_PRECISIONS)
-
-        with contextlib.ExitStack() as exit_stack:
-            session_factory = ThreadSessionFactory(exit_stack)
-            if args.jobs == 1:
-                results = [download_model(model, reporter, session_factory) for model in models]
-            else:
-                results = _concurrency.run_in_parallel(args.jobs,
-                    lambda context, model: download_model(model, make_reporter(context), session_factory),
-                    models)
-
-        failed_models = {model.name for model, successful in zip(models, results) if not successful}
+        failed_models = downloader.bulk_download_model(models, reporter, args.jobs, args.progress_format)
 
         if failed_models:
             reporter.print('FAILED:')
@@ -154,6 +97,7 @@ def main():
                 reporter.print(failed_model_name)
                 telemetry.send_event('md', 'downloader_failed_models', failed_model_name)
             sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/model_tools/src/openvino/model_zoo/omz_downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/omz_downloader.py
@@ -39,7 +39,7 @@ def positive_int_arg(value_str):
         pass
 
     raise argparse.ArgumentTypeError('must be a positive integer (got {!r})'.format(value_str))
-        
+
 
 def main():
     parser = DownloaderArgumentParser()
@@ -79,7 +79,7 @@ def main():
         failed_models = set()
 
         downloader = Downloader(args.precisions, args.output_dir, args.cache_dir, args.num_attempts)
-        
+
         for model in models:
             precisions_to_send = downloader.requested_precisions if args.precisions else downloader.requested_precisions & model.precisions
             model_information = {


### PR DESCRIPTION
Summary:
1. Some code from the `omz_downloader` main function is moved to a `bulk_download_model` method to make it easier to reuse.
2. Embedded functions are deprecated for the same reason.
3. `KNOWN_FRAMEWORKS` and `KNOWN TASK_TYPES` are turned into optional parameters to allow developers to use their own configs and thus handle validation.
4. Small code movement in order to save lib users from importing protected modules from OMZ.
5. Interface of `start_download` is slightly changed for those file types which need checksum info for downloading. Also, it allows to validate downloaded files additionally (e.g. compare the checksum of a downloaded file with the expected one).