### PR TITLE
deps: move paddle version

### DIFF
--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -87,7 +87,7 @@ onnx==1.10.1
     #   -r tools/model_tools/requirements-pytorch.in
 opt-einsum==3.3.0
     # via tensorflow
-paddlepaddle==2.1.3
+paddlepaddle==2.2.0
     # via
     #   -r tools/model_tools/requirements-paddle.in
 pillow==8.3.2

--- a/tools/model_tools/requirements-paddle.in
+++ b/tools/model_tools/requirements-paddle.in
@@ -1,1 +1,1 @@
-paddlepaddle~=2.1.0
+paddlepaddle~=2.2.0


### PR DESCRIPTION
paddle 2.1.3 has incompatible dependency with tf on windows, in 2.2.0 this problem is resolved