### PR TITLE
Restrict tokenizers version to workaround install on Mac and Win

### DIFF
--- a/demos/machine_translation_demo/python/requirements.txt
+++ b/demos/machine_translation_demo/python/requirements.txt
@@ -1,2 +1,2 @@
-tokenizers>=0.10.1
+tokenizers~=0.10.1
 numpy>=1.16.6,<1.20

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -6,6 +6,6 @@ numpy>=1.16.6,<1.20
 scikit-learn~=0.24.1
 scipy~=1.5.4
 sympy>=1.8
-tokenizers>=0.10.1
+tokenizers~=0.10.1
 tensorboardX>=2.1
 tqdm>=4.54.1

--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -29,7 +29,7 @@ pydicom>=2.1.2
 
 # nlp, tokenization
 sentencepiece>=0.1.95
-tokenizers>=0.10.1
+tokenizers~=0.10.1
 transformers>=4.5
 nltk>=3.5
 


### PR DESCRIPTION
We need to restrict tokenizers version in scope of 0.10 release at least temporarily, to fix issues with installation on Mac and Win in precommits (see https://openvino-ci.intel.com/job/private-ci/job/ie/job/e2e-tests-windows-pip-conflicts/21672/). Proper fix require updating environment on all physical nodes, which can be done later