### PR TITLE
segmentation_demo.py: load default Pascal palette from file 

### DIFF
--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -130,7 +130,7 @@ Running the application with the empty list of options yields the usage message 
 You can use the following command to do inference on CPU on images captured by a camera using a pre-trained network:
 
 ```sh
-    python3 segmentation_demo.py -d CPU -i 0 -m <path_to_model>/semantic-segmentation-adas-0001.xml
+    python3 segmentation_demo.py -d CPU -i 0 -at segmentation -m <path_to_model>/semantic-segmentation-adas-0001.xml
 ```
 
 >**NOTE**: If you provide a single image as an input, the demo processes and renders it quickly, then exits. To continuously visualize inference results on the screen, apply the `loop` option, which enforces processing a single image in a loop.
@@ -156,7 +156,7 @@ You can also run this demo with model served in [OpenVINO Model Server](https://
 Exemplary command:
 
 ```sh
-    python3 segmentation_demo.py -i 0 -m localhost:9000/models/image_segmentation --adapter ovms
+    python3 segmentation_demo.py -i 0 -at segmentation -m localhost:9000/models/image_segmentation --adapter ovms
 ```
 
 ## Demo Output

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -39,36 +39,14 @@ log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.DEBUG, stream=
 
 
 class SegmentationVisualizer:
-    pascal_voc_palette = [
-        (0,   0,   0),
-        (128, 0,   0),
-        (0,   128, 0),
-        (128, 128, 0),
-        (0,   0,   128),
-        (128, 0,   128),
-        (0,   128, 128),
-        (128, 128, 128),
-        (64,  0,   0),
-        (192, 0,   0),
-        (64,  128, 0),
-        (192, 128, 0),
-        (64,  0,   128),
-        (192, 0,   128),
-        (64,  128, 128),
-        (192, 128, 128),
-        (0,   64,  0),
-        (128, 64,  0),
-        (0,   192, 0),
-        (128, 192, 0),
-        (0,   64,  128)
-    ]
-
     def __init__(self, colors_path=None):
         if colors_path:
             self.color_palette = self.get_palette_from_file(colors_path)
             log.debug('The palette is loaded from {}'.format(colors_path))
         else:
-            self.color_palette = self.pascal_voc_palette
+            pascal_palette_path = Path(__file__).resolve().parents[3] /\
+                'data/palettes/pascal_voc_21cl_colors.txt'
+            self.color_palette = self.get_palette_from_file(pascal_palette_path)
             log.debug('The PASCAL VOC palette is used')
         log.debug('Get {} colors'.format(len(self.color_palette)))
         self.color_map = self.create_color_map()

--- a/demos/segmentation_demo/python/segmentation_demo.py
+++ b/demos/segmentation_demo/python/segmentation_demo.py
@@ -82,7 +82,7 @@ class SaliencyMapVisualizer:
 def render_segmentation(frame, masks, visualiser, resizer, only_masks=False):
     output = visualiser.apply_color_map(masks)
     if not only_masks:
-        output = np.floor_divide(frame, 2) + np.floor_divide(output, 2)
+        output = cv2.addWeighted(frame, 0.5, output, 0.5, 0)
     return resizer.resize(output)
 
 def build_argparser():


### PR DESCRIPTION
The purpose is to not keep this palette in SegmentationVisualizer class itself, but load colors from file in palettes folder, representing this palette.
Also, rendering is updated in order to decrease the latency of rendering time (80ms->10ms)