### PR TITLE
PYTHON DEMOS: remove ov from requirements

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -6,7 +6,6 @@ nibabel>=3.2.1
 numpy>=1.16.6,<1.20; python_version <= "3.6"
 numpy>=1.16.6,<=1.21; python_version > "3.6"
 opencv-python==4.5.*
-openvino
 pillow>=8.1.2
 pyyaml>=5.4.1
 scikit-learn~=0.24.1


### PR DESCRIPTION
temporaly remove demo dependency on openvino as pypi version is not compatible with upcoming release