### PR TITLE
G-API: Align limit flag behavior of G-API demos with OMZ

### DIFF
--- a/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
+++ b/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
@@ -152,6 +152,7 @@ protected:
     std::mutex thread_frame_lock; // lock for shared frame
     std::chrono::steady_clock::time_point read_time; // timepoint from cv::read()
     bool is_filling_possible = true; // access for batch filling
+    cv::Size first_frame_size = {0, 0};
 
     virtual bool pull(cv::gapi::wip::Data& data) override {
         /** Is first already pulled **/
@@ -159,6 +160,7 @@ protected:
             if (first_batch.empty()) {
                 throw std::runtime_error("GestRecCapSource::pull() have got empty first_batch");
             }
+            first_frame_size = first_batch[first_batch.size() - 2].size();
             first_pulled = true;
             cv::detail::VectorRef ref(std::move(first_batch));
             data = std::move(ref);
@@ -170,7 +172,7 @@ protected:
         cv::Mat fast_frame = cap->read();
 
         /** Check size of captured frame **/
-        if (fast_frame.size() != first_batch[first_batch.size() - 2].size()) {
+        if (fast_frame.size() != first_frame_size) {
             throw std::runtime_error("Frames of source must have the same sizes");
         }
 

--- a/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
+++ b/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
@@ -152,7 +152,6 @@ protected:
     std::mutex thread_frame_lock; // lock for shared frame
     std::chrono::steady_clock::time_point read_time; // timepoint from cv::read()
     bool is_filling_possible = true; // access for batch filling
-    cv::Size first_frame_size = {0, 0};
 
     virtual bool pull(cv::gapi::wip::Data& data) override {
         /** Is first already pulled **/
@@ -160,7 +159,6 @@ protected:
             if (first_batch.empty()) {
                 throw std::runtime_error("GestRecCapSource::pull() have got empty first_batch");
             }
-            first_frame_size = first_batch[first_batch.size() - 2].size();
             first_pulled = true;
             cv::detail::VectorRef ref(std::move(first_batch));
             data = std::move(ref);
@@ -170,11 +168,6 @@ protected:
         /** Frame reading with ImagesCapture class **/
         read_time = std::chrono::steady_clock::now();
         cv::Mat fast_frame = cap->read();
-
-        /** Check size of captured frame **/
-        if (fast_frame.size() != first_frame_size) {
-            throw std::runtime_error("Frames of source must have the same sizes");
-        }
 
         if (!fast_frame.data) {
             is_filling_possible = false;

--- a/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
+++ b/demos/gesture_recognition_demo/cpp_gapi/include/stream_source.hpp
@@ -102,13 +102,13 @@ static void runBatchFill(const cv::Mat& frame,
     }
 }
 
-class CustomCapSource : public cv::gapi::wip::IStreamSource {
+class GestRecCapSource : public cv::gapi::wip::IStreamSource {
 public:
-    explicit CustomCapSource(const std::shared_ptr<ImagesCapture>& cap,
-                             const cv::Size& frame_size,
-                             const int batch_size,
-                             const float batch_fps,
-                             const std::shared_ptr<bool>& drop_batch)
+    explicit GestRecCapSource(const std::shared_ptr<ImagesCapture>& cap,
+                              const cv::Size& frame_size,
+                              const int batch_size,
+                              const float batch_fps,
+                              const std::shared_ptr<bool>& drop_batch)
         : cap(cap), producer(batch_size, batch_fps, drop_batch), source_fps(cap->fps()) {
         if (source_fps <= 0.) {
             source_fps = 30.;
@@ -117,7 +117,7 @@ public:
         }
         /** Create and get first image for batch **/
         if (!first_batch.empty()) {
-            throw std::runtime_error("first_batch must be empty");
+            throw std::runtime_error("first_batch must be empty before creation");
         }
         if (batch_size == 0 || batch_size == 1) {
             throw std::runtime_error("Batch must contain more than one image");
@@ -126,7 +126,7 @@ public:
         /** Reading of frame with ImagesCapture class **/
         read_time = std::chrono::steady_clock::now();
         cv::Mat fast_frame = cap->read();
-        if (batch_size == 0 || batch_size == 1) {
+        if (!fast_frame.data) {
             throw std::runtime_error("Couldn't grab the frame");
         }
         producer.fillFastFrame(fast_frame);
@@ -157,7 +157,7 @@ protected:
         /** Is first already pulled **/
         if (!first_pulled) {
             if (first_batch.empty()) {
-                throw std::runtime_error("pull() have got empty first_batch");
+                throw std::runtime_error("GestRecCapSource::pull() have got empty first_batch");
             }
             first_pulled = true;
             cv::detail::VectorRef ref(std::move(first_batch));
@@ -202,7 +202,7 @@ protected:
 
     virtual cv::GMetaArg descr_of() const override {
         if (first_batch.empty()) {
-            throw std::runtime_error("descr_of() have got empty first_batch");
+            throw std::runtime_error("GestRecCapSource::descr_of() have got empty first_batch");
         }
         return cv::GMetaArg{ cv::empty_array_desc() };
     }

--- a/demos/gesture_recognition_demo/cpp_gapi/main.cpp
+++ b/demos/gesture_recognition_demo/cpp_gapi/main.cpp
@@ -129,11 +129,11 @@ int main(int argc, char *argv[]) {
         /** ---------------- The execution part ---------------- **/
         const float batch_constant_FPS = 15;
         auto drop_batch = std::make_shared<bool>(false);
-        pipeline.setSource(cv::gin(cv::gapi::wip::make_src<custom::CustomCapSource>(cap,
-                                                                                    frame_size,
-                                                                                    int(ar_net_shape[1]),
-                                                                                    batch_constant_FPS,
-                                                                                    drop_batch),
+        pipeline.setSource(cv::gin(cv::gapi::wip::make_src<custom::GestRecCapSource>(cap,
+                                                                                     frame_size,
+                                                                                     int(ar_net_shape[1]),
+                                                                                     batch_constant_FPS,
+                                                                                     drop_batch),
                                    current_person_id_m));
 
         std::string gestureWindowName = "Gesture";

--- a/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
+++ b/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
@@ -424,8 +424,7 @@ int main(int argc, char *argv[]) {
         std::unique_ptr<Presenter> presenter;
 
          /** Get information about frame **/
-        std::shared_ptr<ImagesCapture> cap = openImagesCapture(FLAGS_i, FLAGS_loop, 0,
-            FLAGS_limit);
+        std::shared_ptr<ImagesCapture> cap = openImagesCapture(FLAGS_i, FLAGS_loop);
         const auto tmp = cap->read();
         cap.reset();
         if (!tmp.data) {

--- a/demos/smart_classroom_demo/cpp_gapi/include/tracker.hpp
+++ b/demos/smart_classroom_demo/cpp_gapi/include/tracker.hpp
@@ -187,12 +187,6 @@ public:
     void Process(const cv::Mat &frame, const TrackedObjects &detections);
 
     ///
-    /// \brief Get tracked detections.
-    /// \return Tracked detections.
-    ///
-    TrackedObjects TrackedDetections() const;
-
-    ///
     /// \brief Get tracked detections with labels.
     /// \return Tracked detections.
     ///

--- a/demos/smart_classroom_demo/cpp_gapi/smart_classroom_demo_gapi.hpp
+++ b/demos/smart_classroom_demo/cpp_gapi/smart_classroom_demo_gapi.hpp
@@ -108,6 +108,7 @@ static void showUsage() {
     std::cout << "    -loop                          " << loop_message << std::endl;
     std::cout << "    -read_limit                    " << read_limit_message << std::endl;
     std::cout << "    -o \"<path>\"                    " << output_message << std::endl;
+    std::cout << "    -limit \"<num>\"                 " << limit_message << std::endl;
     std::cout << "    -m_act '<path>'                " << person_action_detection_model_message << std::endl;
     std::cout << "    -m_fd '<path>'                 " << face_detection_model_message << std::endl;
     std::cout << "    -m_lm '<path>'                 " << facial_landmarks_model_message << std::endl;

--- a/demos/smart_classroom_demo/cpp_gapi/src/tracker.cpp
+++ b/demos/smart_classroom_demo/cpp_gapi/src/tracker.cpp
@@ -473,17 +473,6 @@ bool Tracker::IsTrackForgotten(size_t id) const {
     return tracks_.at(id).lost > params_.forget_delay;
 }
 
-TrackedObjects Tracker::TrackedDetections() const {
-    TrackedObjects detections;
-    for (size_t idx : active_track_ids()) {
-        auto track = tracks().at(idx);
-        if (IsTrackValid(idx) && !track.lost) {
-            detections.emplace_back(track.objects.back());
-        }
-    }
-    return detections;
-}
-
 TrackedObjects Tracker::TrackedDetectionsWithLabels() const {
     TrackedObjects detections;
     for (size_t idx : active_track_ids()) {


### PR DESCRIPTION
Minor:
- Removed limit flag from ImagesCapture for IFD;
- Added help message for FLAG_limit for SCD;
- Changed name of CustomCaptureSource class for GestRec demo (common class has the same name);
- throw with extended messages for GestRec demo.