### PR TITLE
text_spotting_demo: fix output layer name, restore the test

### DIFF
--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -1285,20 +1285,19 @@ PYTHON_DEMOS = [
         single_option_cases('-m', ModelArg('wav2vec2-base'))
     )),
 
-    # TODO: Demo supports only topologies with the following input tensor name: image
-    # PythonDemo(name='text_spotting_demo', device_keys=['-d'],
-    #            model_keys=['-m_m', '-m_te', '-m_td'], test_cases=combine_cases(
-    #     TestCase(options={'--no_show': None, '--delay': '1', **MONITORS,
-    #                       '-i': DataPatternArg('text-detection')}),
-    #     [
-    #         TestCase(options={
-    #             '-m_m': ModelArg('text-spotting-0005-detector'),
-    #             '-m_te': ModelArg('text-spotting-0005-recognizer-encoder'),
-    #             '-m_td': ModelArg('text-spotting-0005-recognizer-decoder'),
-    #             '--no_track': None
-    #         }),
-    #     ]
-    # )),
+    PythonDemo(name='text_spotting_demo', device_keys=['-d'],
+               model_keys=['-m_m', '-m_te', '-m_td'], test_cases=combine_cases(
+        TestCase(options={'--no_show': None, '--delay': '1', **MONITORS,
+                          '-i': DataPatternArg('text-detection')}),
+        [
+            TestCase(options={
+                '-m_m': ModelArg('text-spotting-0005-detector'),
+                '-m_te': ModelArg('text-spotting-0005-recognizer-encoder'),
+                '-m_td': ModelArg('text-spotting-0005-recognizer-decoder'),
+                '--no_track': None
+            }),
+        ]
+    )),
 
     PythonDemo(name='text_to_speech_demo', device_keys=['-d'],
                model_keys=['-m_duration', '-m_forward', '-m_upsample', '-m_rnn', '-m_melgan'], test_cases=combine_cases(

--- a/demos/text_spotting_demo/python/text_spotting_demo.py
+++ b/demos/text_spotting_demo/python/text_spotting_demo.py
@@ -184,7 +184,7 @@ def main():
     except RuntimeError:
         raise RuntimeError('Demo supports only topologies with the following input tensor name: {}'.format(input_tensor_name))
 
-    required_output_names = {'boxes', 'labels', 'masks', 'text_features.0'}
+    required_output_names = {'boxes', 'labels', 'masks', 'text_features'}
     for output_tensor_name in required_output_names:
         try:
             mask_rcnn_model.output(output_tensor_name)
@@ -269,7 +269,7 @@ def main():
         scores = outputs['boxes'][:, 4]
         classes = outputs['labels'].astype(np.uint32)
         raw_masks = outputs['masks']
-        text_features = outputs['text_features.0']
+        text_features = outputs['text_features']
 
         # Filter out detections with low confidence.
         detections_filter = scores > args.prob_threshold


### PR DESCRIPTION
In the latest IR version `text_features` name is used.