### PR TITLE
text_detection_demo: fix auto resize 

### DIFF
--- a/demos/text_detection_demo/cpp/include/cnn.hpp
+++ b/demos/text_detection_demo/cpp/include/cnn.hpp
@@ -16,7 +16,7 @@
 class Cnn {
 public:
     Cnn(const std::string& modelPath, const std::string& modelType, const std::string& deviceName,
-        ov::Core& core, const cv::Size& new_input_resolution = cv::Size());
+        ov::Core& core, const cv::Size& new_input_resolution = cv::Size(), bool use_auto_resize = false);
 
     virtual std::map<std::string, ov::Tensor> Infer(const cv::Mat& frame) = 0;
 
@@ -40,4 +40,5 @@ protected:
 
     double m_time_elapsed;
     size_t m_ncalls;
+    bool use_auto_resize;
 };

--- a/demos/text_detection_demo/cpp/include/text_detection.hpp
+++ b/demos/text_detection_demo/cpp/include/text_detection.hpp
@@ -17,8 +17,8 @@
 class TextDetector : public Cnn {
 public:
     TextDetector(const std::string& model_path, const std::string& model_type, const std::string& deviceName,
-        ov::Core& core, const cv::Size& new_input_resolution = cv::Size()) :
-        Cnn(model_path, model_type, deviceName, core) {};
+        ov::Core& core, const cv::Size& new_input_resolution = cv::Size(), bool use_auto_resize = false) :
+        Cnn(model_path, model_type, deviceName, core, {}, use_auto_resize) {};
 
     std::map<std::string, ov::Tensor> Infer(const cv::Mat& frame) override;
 

--- a/demos/text_detection_demo/cpp/include/text_recognition.hpp
+++ b/demos/text_detection_demo/cpp/include/text_recognition.hpp
@@ -27,7 +27,8 @@ public:
         const std::string& in_dec_symbol_name,
         const std::string& out_dec_symbol_name,
         const std::string& logits_name,
-        size_t end_token);
+        size_t end_token,
+        bool use_auto_resize = false);
 
     std::map<std::string, ov::runtime::Tensor> Infer(const cv::Mat& frame) override;
 

--- a/demos/text_detection_demo/cpp/main.cpp
+++ b/demos/text_detection_demo/cpp/main.cpp
@@ -170,7 +170,8 @@ int main(int argc, char* argv[]) {
 
         std::unique_ptr<TextDetector> text_detector;
         if (!FLAGS_m_td.empty())
-            text_detector = std::unique_ptr<TextDetector>(new TextDetector(FLAGS_m_td, "Text Detection", FLAGS_d_td, core, cv::Size(FLAGS_w_td, FLAGS_h_td)));
+            text_detector = std::unique_ptr<TextDetector>(new TextDetector(FLAGS_m_td, "Text Detection", FLAGS_d_td, core,
+                cv::Size(FLAGS_w_td, FLAGS_h_td), FLAGS_auto_resize));
 
         auto cls_conf_threshold = static_cast<float>(FLAGS_cls_pixel_thr);
         auto link_conf_threshold = static_cast<float>(FLAGS_link_pixel_thr);
@@ -238,7 +239,7 @@ int main(int argc, char* argv[]) {
                     FLAGS_m_tr, "Composite Text Recognition", FLAGS_d_tr, core,
                     FLAGS_out_enc_hidden_name, FLAGS_out_dec_hidden_name,
                     FLAGS_in_dec_hidden_name, FLAGS_features_name, FLAGS_in_dec_symbol_name,
-                    FLAGS_out_dec_symbol_name, FLAGS_tr_o_blb_nm, kAlphabet.find(kPadSymbol, 2)));
+                    FLAGS_out_dec_symbol_name, FLAGS_tr_o_blb_nm, kAlphabet.find(kPadSymbol, 2), FLAGS_auto_resize));
         }
         const double min_text_recognition_confidence = FLAGS_thr;
 

--- a/demos/text_detection_demo/cpp/src/cnn.cpp
+++ b/demos/text_detection_demo/cpp/src/cnn.cpp
@@ -13,9 +13,9 @@
 
 Cnn::Cnn(
     const std::string& modelPath, const std::string& modelType, const std::string& deviceName,
-    ov::Core& core, const cv::Size& new_input_resolution) :
+    ov::Core& core, const cv::Size& new_input_resolution, bool use_auto_resize) :
     m_modelPath(modelPath), m_modelType(modelType), m_deviceName(deviceName),
-    m_core(core), m_new_input_resolution(new_input_resolution),
+    m_core(core), m_new_input_resolution(new_input_resolution), use_auto_resize(use_auto_resize),
     m_channels(0), m_time_elapsed(0), m_ncalls(0)
 {
     slog::info << "Reading model: " << m_modelPath << slog::endl;
@@ -66,16 +66,19 @@ Cnn::Cnn(
 
     // we'd like to pass input image (NCWH, u8) to model input
     // and let OpenVINO do necessary conversions
+
     ppp.input().tensor()
         .set_element_type(ov::element::u8)
-        .set_layout({ "NHWC" })
-        .set_spatial_dynamic_shape();
+        .set_layout({ "NHWC" });
 
-    ppp.input().preprocess().convert_layout(input_layout);
+    if (use_auto_resize) {
+        ppp.input().tensor()
+            .set_spatial_dynamic_shape();
 
-    ppp.input().preprocess()
-        .convert_element_type(ov::element::f32)
-        .resize(ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR);
+        ppp.input().preprocess()
+            .convert_element_type(ov::element::f32)
+            .resize(ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR);
+    }
     ppp.input().model().set_layout(input_layout);
 
     m_model = ppp.build();

--- a/demos/text_detection_demo/cpp/src/cnn.cpp
+++ b/demos/text_detection_demo/cpp/src/cnn.cpp
@@ -64,7 +64,7 @@ Cnn::Cnn(
     // Configuring input and output
     ov::preprocess::PrePostProcessor ppp(m_model);
 
-    // we'd like to pass input image (NCWH, u8) to model input
+    // we'd like to pass input image (NHWC, u8) to model input
     // and let OpenVINO do necessary conversions
 
     ppp.input().tensor()

--- a/demos/text_detection_demo/cpp/src/text_detection.cpp
+++ b/demos/text_detection_demo/cpp/src/text_detection.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "utils/image_utils.h"
 #include "utils/ocv_common.hpp"
 #include "text_detection.hpp"
 
@@ -173,7 +174,12 @@ cv::Mat get_all(const std::vector<cv::Point>& points, int w, int h, std::unorder
 std::map<std::string, ov::runtime::Tensor> TextDetector::Infer(const cv::Mat& frame) {
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 
-    m_infer_request.set_input_tensor({ ov::element::u8, {1, size_t(frame.rows), size_t(frame.cols), size_t(frame.channels())}, frame.data});
+    cv::Mat resizedImg = frame;
+    if (!use_auto_resize) {
+        resizedImg = resizeImageExt(frame, m_input_size.width, m_input_size.height);
+    }
+
+    m_infer_request.set_input_tensor(wrapMat2Tensor(resizedImg));
 
     m_infer_request.infer();
 

--- a/demos/text_detection_demo/cpp/text_detection_demo.hpp
+++ b/demos/text_detection_demo/cpp/text_detection_demo.hpp
@@ -50,6 +50,7 @@ static const char text_detection_target_device_message[] = "Optional. Specify th
 static const char text_recognition_target_device_message[] = "Optional. Specify the target device for the Text Recognition model to infer on "
                                                              "(the list of available devices is shown below). "
                                                              "The demo will look for a suitable plugin for a specified device. By default, it is CPU.";
+static const char input_resizable_message[] = "Optional. Enables resizable input with support of ROI crop & auto resize.";
 static const char no_show_message[] = "Optional. If it is true, then detected text will not be shown on image frame. By default, it is false.";
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
 static const char input_data_type_message[] = "Required. Input data type: \"image\" (for a single image), "
@@ -84,6 +85,7 @@ DEFINE_double(link_pixel_thr, 0.8, pixel_linkage_threshold_message);
 DEFINE_int32(max_rect_num, -1, text_max_rectangles_number_message);
 DEFINE_string(d_td, "CPU", text_detection_target_device_message);
 DEFINE_string(d_tr, "CPU", text_recognition_target_device_message);
+DEFINE_bool(auto_resize, false, input_resizable_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_string(u, "", utilization_monitors_message);
@@ -126,6 +128,7 @@ static void showUsage() {
     std::cout << "    -max_rect_num \"<value>\"        " << text_max_rectangles_number_message << std::endl;
     std::cout << "    -d_td \"<device>\"               " << text_detection_target_device_message << std::endl;
     std::cout << "    -d_tr \"<device>\"               " << text_recognition_target_device_message << std::endl;
+    std::cout << "    -auto_resize                   " << input_resizable_message << std::endl;
     std::cout << "    -no_show                       " << no_show_message << std::endl;
     std::cout << "    -r                             " << raw_output_message << std::endl;
     std::cout << "    -u                             " << utilization_monitors_message << std::endl;


### PR DESCRIPTION
GPU plugin doesn't support auto resize feature. Make opencv resize as default.
p.s  `text-recognition-0015-encoder` model will fail with stack overflow error.