### PR TITLE
return size_t type to result in kuhn munkres

### DIFF
--- a/demos/common/cpp/utils/include/utils/kuhn_munkres.hpp
+++ b/demos/common/cpp/utils/include/utils/kuhn_munkres.hpp
@@ -31,7 +31,7 @@ public:
     /// \return Optimal column index for each row. -1 means that there is no
     /// column for row.
     ///
-    std::vector<int> Solve(const cv::Mat &dissimilarity_matrix);
+    std::vector<size_t> Solve(const cv::Mat &dissimilarity_matrix);
 
 private:
     static constexpr int kStar = 1;

--- a/demos/common/cpp/utils/src/kuhn_munkres.cpp
+++ b/demos/common/cpp/utils/src/kuhn_munkres.cpp
@@ -10,7 +10,7 @@
 
 KuhnMunkres::KuhnMunkres(bool greedy) : n_(), greedy_(greedy) {}
 
-std::vector<int> KuhnMunkres::Solve(const cv::Mat& dissimilarity_matrix) {
+std::vector<size_t> KuhnMunkres::Solve(const cv::Mat& dissimilarity_matrix) {
     CV_Assert(dissimilarity_matrix.type() == CV_32F);
     double min_val;
     cv::minMaxLoc(dissimilarity_matrix, &min_val);
@@ -28,12 +28,12 @@ std::vector<int> KuhnMunkres::Solve(const cv::Mat& dissimilarity_matrix) {
 
     Run();
 
-    std::vector<int> results(dissimilarity_matrix.rows, -1);
+    std::vector<size_t> results(dissimilarity_matrix.rows, -1);
     for (int i = 0; i < dissimilarity_matrix.rows; i++) {
         const auto ptr = marked_.ptr<char>(i);
         for (int j = 0; j < dissimilarity_matrix.cols; j++) {
             if (ptr[j] == kStar) {
-                results[i] = j;
+                results[i] = (size_t)j;
             }
         }
     }

--- a/demos/gesture_recognition_demo/cpp_gapi/src/tracker.cpp
+++ b/demos/gesture_recognition_demo/cpp_gapi/src/tracker.cpp
@@ -49,7 +49,7 @@ void Tracker::solveAssignmentProblem(
     cv::Mat dissimilarity;
     computeDissimilarityMatrix(track_ids, detections, &dissimilarity);
 
-    std::vector<int> res = KuhnMunkres().Solve(dissimilarity);
+    auto res = KuhnMunkres().Solve(dissimilarity);
 
     for (size_t i = 0; i < detections.size(); i++) {
         unmatched_detections->insert(i);
@@ -57,7 +57,7 @@ void Tracker::solveAssignmentProblem(
 
     size_t i = 0;
     for (size_t id : track_ids) {
-        if (res[i] < (int)detections.size()) {
+        if (res[i] < detections.size()) {
             matches->emplace(id, res[i], 1 - dissimilarity.at<float>(i, res[i]));
         } else {
             unmatched_tracks->insert(id);

--- a/demos/pedestrian_tracker_demo/cpp/src/tracker.cpp
+++ b/demos/pedestrian_tracker_demo/cpp/src/tracker.cpp
@@ -237,7 +237,7 @@ void PedestrianTracker::SolveAssignmentProblem(
     ComputeDissimilarityMatrix(track_ids, detections, descriptors,
                                &dissimilarity);
 
-    std::vector<int> res = KuhnMunkres().Solve(dissimilarity);
+    std::vector<size_t> res = KuhnMunkres().Solve(dissimilarity);
 
     for (size_t i = 0; i < detections.size(); i++) {
         unmatched_detections->insert(i);

--- a/demos/smart_classroom_demo/cpp/src/tracker.cpp
+++ b/demos/smart_classroom_demo/cpp/src/tracker.cpp
@@ -67,7 +67,7 @@ void Tracker::SolveAssignmentProblem(
     cv::Mat dissimilarity;
     ComputeDissimilarityMatrix(track_ids, detections, &dissimilarity);
 
-    std::vector<int> res = KuhnMunkres().Solve(dissimilarity);
+    auto res = KuhnMunkres().Solve(dissimilarity);
 
     for (size_t i = 0; i < detections.size(); i++) {
         unmatched_detections->insert(i);
@@ -75,7 +75,7 @@ void Tracker::SolveAssignmentProblem(
 
     size_t i = 0;
     for (size_t id : track_ids) {
-        if (res[i] < (int)detections.size()) {
+        if (res[i] < detections.size()) {
             matches->emplace(id, res[i], 1 - dissimilarity.at<float>(i, res[i]));
         } else {
             unmatched_tracks->insert(id);


### PR DESCRIPTION
Undo changes done in https://github.com/openvinotoolkit/open_model_zoo/pull/3227 and https://github.com/openvinotoolkit/open_model_zoo/pull/2923. 
Changing `size_t` to `int` broke initial logic and causes next error:
`
[ ERROR ] OpenCV(4.5.2-openvino) C:\Users\ivikhrev\Documents\Work\openvino\temp\opencv_4.5.2\opencv\include\opencv2/core/mat.inl.hpp:872: error: (-215:Assertion failed) (unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()) in function 'cv::Mat::at' 
`
in some cases.
