### PR TITLE
model_tools: add message about unsupported model precisions

### DIFF
--- a/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
@@ -213,6 +213,12 @@ class Downloader:
 
         reporter.print_group_heading('Downloading {}', model.name)
 
+        model_unsupported_precisions = self.requested_precisions - model.precisions
+        if model_unsupported_precisions:
+            reporter.print_section_heading('Model {} is not supported in {} precisions. '
+                + 'Skipping downloading for these precisions.', model.name, model_unsupported_precisions)
+            reporter.print()
+
         reporter.emit_event('model_download_begin', model=model.name, num_files=len(model.files))
 
         output = self.output_dir / model.subdirectory

--- a/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
+++ b/tools/model_tools/src/openvino/model_zoo/download_engine/downloader.py
@@ -214,10 +214,12 @@ class Downloader:
         reporter.print_group_heading('Downloading {}', model.name)
 
         model_unsupported_precisions = self.requested_precisions - model.precisions
-        if model_unsupported_precisions:
-            reporter.print_section_heading('Model {} is not supported in {} precisions. '
-                + 'Skipping downloading for these precisions.', model.name, model_unsupported_precisions)
+        if model_unsupported_precisions and not self.requested_precisions & model.precisions:
+            reporter.print_section_heading('Skipping {} (model is unsupported in {} precisions)',
+                model.name, model_unsupported_precisions)
             reporter.print()
+
+            return True
 
         reporter.emit_event('model_download_begin', model=model.name, num_files=len(model.files))
 


### PR DESCRIPTION
Fixes downloader message in case if specified precision is unsupported by the model (76778)