### PR TITLE
handwritten_text_recognition_demo.py: set_property if GPU is specified in args.device

### DIFF
--- a/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
+++ b/demos/handwritten_text_recognition_demo/python/handwritten_text_recognition_demo.py
@@ -77,7 +77,9 @@ def main():
     log.info('OpenVINO Inference Engine')
     log.info('\tbuild: {}'.format(get_version()))
     core = Core()
-    core.set_property("GPU", {"GPU_ENABLE_LOOP_UNROLLING": "NO", "CACHE_DIR": "./"})
+
+    if 'GPU' in args.device:
+        core.set_property("GPU", {"GPU_ENABLE_LOOP_UNROLLING": "NO", "CACHE_DIR": "./"})
 
     # Read IR
     log.info('Reading model {}'.format(args.model))


### PR DESCRIPTION
Use `set_property()` for GPU if only device is set in args.device. This behavior is aligned with action_recognition_demo.py, where we call set_property for MYRIAD device if the user set it directly.