### PR TITLE
Reduce test set for mask rcnn demo

### DIFF
--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -316,7 +316,7 @@ NATIVE_DEMOS = [
     )),
 
     CppDemo(name='mask_rcnn_demo', device_keys=['-d'], test_cases=combine_cases(
-        TestCase(options={'-i': DataDirectoryArg('semantic-segmentation-adas')}),
+        TestCase(options={'-i': DataDirectoryArg('instance-segmentaion-mask-rcnn')}),
         single_option_cases('-m',
             ModelArg('mask_rcnn_inception_resnet_v2_atrous_coco'),
             ModelArg('mask_rcnn_resnet50_atrous_coco'))

--- a/demos/tests/data_sequences.py
+++ b/demos/tests/data_sequences.py
@@ -211,6 +211,14 @@ DATA_SEQUENCES = {
         image_net_arg('00048316'),
     ],
 
+    # reduced test set for mask rcnn demo
+    'instance-segmentaion-mask-rcnn': [
+        image_net_arg('00002790'),
+        image_net_arg('00005809'),
+        image_net_arg('00038629'),
+        image_net_arg('00048316')
+    ],
+
     'single-image-super-resolution': [
         image_net_arg('00005409'),
     ],


### PR DESCRIPTION
`semantic-segmentation-adas` testset is used in segmentation demos also, so I decided to create separate smaller test set for this demo to avoid CI issues.