### PR TITLE
AC requirements: pin imagecodecs for py3.7

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -5,9 +5,10 @@ tqdm>=4.54.1
 # note: python 3.6 wheels is not available since 0.18
 scikit-image>=0.17.2
 
-# there is issue with resolving versions for python3.6, pin to specific version of lib
+# there is issue with resolving versions for python3.6 and python3.7, pin to specific version of lib
 imagecodecs~=2020.5.30;python_version<"3.7"
-imagecodecs;python_version>="3.7"
+imagecodecs~=2021.11.20;python_version=="3.7"
+imagecodecs;python_version>="3.8"
 
 # reid
 # python3.6 dropped in v1.0


### PR DESCRIPTION
latest version of imagecodecs droped python3.7 support, pin the last available for avoiding troubles