### PR TITLE
Fixes in documentation for demos

### DIFF
--- a/demos/3d_segmentation_demo/python/README.md
+++ b/demos/3d_segmentation_demo/python/README.md
@@ -45,11 +45,10 @@ Run the application with the `-h` or `--help` option to see the usage message:
 
 ```
 usage: 3d_segmentation_demo.py [-h] -i PATH_TO_INPUT_DATA -m PATH_TO_MODEL -o
-                               PATH_TO_OUTPUT [-d TARGET_DEVICE]
-                               [-l PATH_TO_EXTENSION] [-nii]
+                               PATH_TO_OUTPUT [-d TARGET_DEVICE] [-nii]
                                [-nthreads NUMBER_THREADS]
-                               [-s [SHAPE [SHAPE ...]]]
-                               [-c PATH_TO_CLDNN_CONFIG]
+                               [-s [SHAPE [SHAPE ...]]] [-ms N1,N2,N3,N4]
+                               [--full_intensities_range]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -65,18 +64,12 @@ Options:
                         Optional. Specify a target device to infer on: CPU, GPU.
                         Use "-d HETERO:<comma separated devices list>" format
                         to specify HETERO plugin.
-  -l PATH_TO_EXTENSION, --path_to_extension PATH_TO_EXTENSION
-                        Required for CPU custom layers. Absolute path to a
-                        shared library with the kernels implementations.
   -nii, --output_nifti  Show output inference results as raw values
   -nthreads NUMBER_THREADS, --number_threads NUMBER_THREADS
                         Optional. Number of threads to use for inference on
                         CPU (including HETERO cases).
   -s [SHAPE [SHAPE ...]], --shape [SHAPE [SHAPE ...]]
                         Optional. Specify shape for a network
-  -c PATH_TO_CLDNN_CONFIG, --path_to_cldnn_config PATH_TO_CLDNN_CONFIG
-                        Required for GPU custom kernels. Absolute path to an
-                        .xml file with the kernels description.
   -ms N1,N2,N3,N4, --mri_sequence N1,N2,N3,N4
                         Optional. Transfer MRI-sequence from dataset order to the network order.
   --full_intensities_range

--- a/demos/README.md
+++ b/demos/README.md
@@ -139,7 +139,7 @@ The Open Model Zoo includes the following demos:
 - [Text Detection C++ Demo](./text_detection_demo/cpp/README.md) - Text Detection demo. It detects and recognizes multi-oriented scene text on an input image and puts a bounding box around detected area.
 - [Text Spotting Python\* Demo](./text_spotting_demo/python/README.md) - The demo demonstrates how to run Text Spotting models.
 - [Text-to-speech Python\* Demo](./text_to_speech_demo/python/README.md) - Shows an example of using Forward Tacotron and WaveRNN neural networks for text to speech task.
-- [Time Series Forecasting Python\* Demo](./time_series_forecasting_demo/python/README.md) - The demo shows how to use the OpenVINO™ toolkit to time series forecastig.
+- [Time Series Forecasting Python\* Demo](./time_series_forecasting_demo/python/README.md) - The demo shows how to use the OpenVINO™ toolkit to time series forecasting.
 - [Whiteboard Inpainting Python\* Demo](./whiteboard_inpainting_demo/python/README.md) - The demo shows how to use the OpenVINO™ toolkit to detect and hide a person on a video so that all text on a whiteboard is visible.
 
 ## Media Files Available for Demos

--- a/demos/action_recognition_demo/python/README.md
+++ b/demos/action_recognition_demo/python/README.md
@@ -17,13 +17,13 @@ Every step implements `PipelineStep` interface by creating a class derived from 
 
 * `DataStep` reads frames from the input video.
 *  Model step depends on architecture type:
-    - For encder-decoder models there are two steps:
+    - For encoder-decoder models there are two steps:
       -  `EncoderStep` preprocesses a frame and feeds it to the encoder model to produce a frame embedding. Simple averaging of encoder's outputs over a time window is applied.
       -  `DecoderStep` feeds embeddings produced by the `EncoderStep` to the decoder model and produces predictions. For models that use `DummyDecoder`, simple averaging of encoder's outputs over a time window is applied.
     - For the specific implemented single models, the corresponding `<ModelNameStep>` does preprocessing and produces predictions.
 * `RenderStep` renders prediction results.
 
-Pipeline steps are composed in `AsyncPipeline`. Every step can be run in separate thread by adding it to the pipeline with `parallel=True` option.
+Pipeline steps are composed in `AsyncPipeline`. Every step can be run in a separate thread by adding it to the pipeline with `parallel=True` option.
 When two consequent steps occur in separate threads, they communicate via message queue (for example, deliver step result or stop signal).
 
 To ensure maximum performance, models are wrapped in `AsyncWrapper`

--- a/demos/background_subtraction_demo/python/README.md
+++ b/demos/background_subtraction_demo/python/README.md
@@ -126,7 +126,7 @@ Options:
                         filtering.
   --resize_type {crop,standard,fit_to_window,fit_to_window_letterbox}
                         Optional. A resize type for model preprocess. By
-                        defauld used model predefined type.
+                        default used model predefined type.
   --labels LABELS       Optional. Labels mapping file.
   --target_bgr TARGET_BGR
                         Optional. Background onto which to composite the
@@ -215,7 +215,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/background_subtraction_demo/python/background_subtraction_demo.py
+++ b/demos/background_subtraction_demo/python/background_subtraction_demo.py
@@ -58,7 +58,7 @@ def build_argparser():
     args.add_argument('-t', '--prob_threshold', default=0.5, type=float,
                       help='Optional. Probability threshold for detections filtering.')
     args.add_argument('--resize_type', default=None, choices=RESIZE_TYPES.keys(),
-                      help='Optional. A resize type for model preprocess. By defauld used model predefined type.')
+                      help='Optional. A resize type for model preprocess. By default used model predefined type.')
     args.add_argument('--labels', help='Optional. Labels mapping file.', default=None, type=str)
     args.add_argument('--target_bgr', default=None, type=str,
                       help='Optional. Background onto which to composite the output (by default to green field).')

--- a/demos/bert_named_entity_recognition_demo/python/README.md
+++ b/demos/bert_named_entity_recognition_demo/python/README.md
@@ -5,7 +5,7 @@ This README describes the Named Entity Recognition (NER) demo application that u
 ## How It Works
 
 On startup the demo application reads command line parameters and loads a model to OpenVINO™ Runtime plugin.
-It also fetch data from the user-provided url to populate the "context" text.
+It also fetches data from the user-provided url to populate the "context" text.
 The text is then used to search named entities.
 
 ## Preparing to Run
@@ -117,7 +117,7 @@ Exemplary command:
 
 ## Classifying Documents with Long Texts
 
-Notice that when the original "context" (text from the url) do not fit the model input
+Notice that when the original "context" (text from the url) does not fit the model input
 (128 for the Bert-Base), the demo reshapes model to maximum sentence length in the "context".
 
 ## See Also

--- a/demos/bert_question_answering_embedding_demo/python/README.md
+++ b/demos/bert_question_answering_embedding_demo/python/README.md
@@ -7,7 +7,7 @@ This README describes the Question Answering Embedding demo application that use
 On startup the demo application reads command line parameters and loads model(s) to OpenVINO™ Runtime plugin.
 It also fetches data from the user-provided urls to populate the list of "contexts" with the text.
 Prior to the actual inference to answer user's questions, the embedding vectors are pre-calculated (via inference) for each context from the list.
-This is done using the first ("emdbeddings-only") BERT model.
+This is done using the first ("embeddings-only") BERT model.
 
 After that, when user types a question, the "embeddings" network is used to calculate an embedding vector for the specified question.
 Using the L2 distance between the embedding vector of the question and the embedding vectors for the contexts the best (closest) contexts are selected

--- a/demos/classification_benchmark_demo/cpp/README.md
+++ b/demos/classification_benchmark_demo/cpp/README.md
@@ -2,7 +2,7 @@
 
 ![](./classification_benchmark.gif)
 
-The demo visualize OpenVINO performance on inference of neural networks for image classification.
+The demo visualizes OpenVINO performance on inference of neural networks for image classification.
 
 ## How It Works
 
@@ -10,7 +10,7 @@ On startup, the application reads command line parameters and loads a classifica
 
 The demo starts in "Testing mode" with fixed grid size. After calculating the average FPS result, it will switch to normal mode and grid will be readjusted depending on model performance. Bigger grid means higher performance. You can repeat testing by pressing "Space" or "R" button.
 
-When "ground truth" data applied, the color coding for the text, drawn above each image, shows whether the classification was correct: green means correct class prediction, red means wrong.
+When "ground truth" data is applied, the color coding for the text, drawn above each image, shows whether the classification was correct: green means correct class prediction, red means wrong.
 
 You can stop the demo by pressing "Esc" or "Q" button. After that, the average metrics values will be printed to the console.
 

--- a/demos/crossroad_camera_demo/cpp/README.md
+++ b/demos/crossroad_camera_demo/cpp/README.md
@@ -2,7 +2,7 @@
 
 ![example](./crossroad_camera.gif)
 
-This demo provides an inference pipeline for person detection, recognition and reidentification. The demo uses Person Detection network followed by the Person Attributes Recognition and Person Reidentification Retail networks applied on top of the detection results. You can use a set of the following pre-trained models with the demo:
+This demo provides an inference pipeline for person detection, recognition and reidentification. The demo uses a Person Detection network followed by the Person Attributes Recognition and Person Reidentification Retail networks applied on top of the detection results. You can use a set of the following pre-trained models with the demo:
 
 * `person-vehicle-bike-detection-crossroad-0078`, which is a primary detection network for finding the persons (and other objects if needed)
 * `person-attributes-recognition-crossroad-0230`, which is executed on top of the results from the first network and
@@ -83,9 +83,6 @@ Options:
     -m "<path>"                  Required. Path to the Person/Vehicle/Bike Detection Crossroad model (.xml) file.
     -m_pa "<path>"               Optional. Path to the Person Attributes Recognition Crossroad model (.xml) file.
     -m_reid "<path>"             Optional. Path to the Person Reidentification Retail model (.xml) file.
-      -l "<absolute_path>"       Optional. For MKLDNN (CPU)-targeted custom layers, if any. Absolute path to a shared library with the kernels impl.
-          Or
-      -c "<absolute_path>"       Optional. For clDNN (GPU)-targeted custom kernels, if any. Absolute path to the xml file with the kernels desc.
     -d "<device>"                Optional. Specify the target device for Person/Vehicle/Bike Detection. The list of available devices is shown below. Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_pa "<device>"             Optional. Specify the target device for Person Attributes Recognition. The list of available devices is shown below. Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_reid "<device>"           Optional. Specify the target device for Person Reidentification Retail. The list of available devices is shown below. Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
@@ -106,7 +103,7 @@ For example, to do inference on a GPU with the OpenVINO&trade; toolkit pre-train
 ./crossroad_camera_demo -i <path_to_video>/inputVideo.mp4 -m <path_to_model>/person-vehicle-bike-detection-crossroad-0078.xml -m_pa <path_to_model>/person-attributes-recognition-crossroad-0230.xml -m_reid <path_to_model>/person-reidentification-retail-0079.xml -d GPU
 ```
 
-> **NOTE**: The detection network returns as the result a set of detected objects, where each detected object consists of a bounding box and an index of the object's category (person/vehicle/bike). The demo runs Person Attributes Recognition and Person Reidentification networks only for the bounding boxes that has the category "person".
+> **NOTE**: The detection network returns as the result a set of detected objects, where each detected object consists of a bounding box and an index of the object's category (person/vehicle/bike). The demo runs Person Attributes Recognition and Person Reidentification networks only for the bounding boxes that have the category "person".
 > Since different detection networks may have different category index corresponding to the category "person", this index may be pointed by the command line parameter `-person_label`.
 > Please, note that
 > * the model `person-vehicle-bike-detection-crossroad-0078` returns for persons the category index 1, it is the default value for the demo

--- a/demos/crossroad_camera_demo/cpp/crossroad_camera_demo.hpp
+++ b/demos/crossroad_camera_demo/cpp/crossroad_camera_demo.hpp
@@ -27,10 +27,6 @@ static const char target_device_message_person_reid[] = "Optional. Specify the t
                                                         "The list of available devices is shown below. Default value is CPU. "
                                                         "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "
                                                         "The application looks for a suitable plugin for the specified device.";
-static const char custom_cldnn_message[] = "Optional. For clDNN (GPU)-targeted custom kernels, if any. "
-                                           "Absolute path to the xml file with the kernels desc.";
-static const char custom_cpu_library_message[] = "Optional. For MKLDNN (CPU)-targeted custom layers, if any. "
-                                                 "Absolute path to a shared library with the kernels impl.";
 static const char threshold_output_message[] = "Optional. Probability threshold for person/vehicle/bike crossroad detections.";
 static const char threshold_output_message_person_reid[] = "Optional. Cosine similarity threshold between two vectors for person reidentification.";
 static const char raw_output_message[] = "Optional. Output Inference results as raw values.";
@@ -49,8 +45,6 @@ DEFINE_string(m_reid, "", person_reid_model_message);
 DEFINE_string(d, "CPU", target_device_message);
 DEFINE_string(d_pa, "CPU", target_device_message_person_attribs);
 DEFINE_string(d_reid, "CPU", target_device_message_person_reid);
-DEFINE_string(c, "", custom_cldnn_message);
-DEFINE_string(l, "", custom_cpu_library_message);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_double(t, 0.5, threshold_output_message);
 DEFINE_double(t_reid, 0.7, threshold_output_message_person_reid);
@@ -76,9 +70,6 @@ static void showUsage() {
     std::cout << "    -m \"<path>\"                  " << person_vehicle_bike_detection_model_message<< std::endl;
     std::cout << "    -m_pa \"<path>\"               " << person_attribs_model_message << std::endl;
     std::cout << "    -m_reid \"<path>\"             " << person_reid_model_message << std::endl;
-    std::cout << "      -l \"<absolute_path>\"       " << custom_cpu_library_message << std::endl;
-    std::cout << "          Or" << std::endl;
-    std::cout << "      -c \"<absolute_path>\"       " << custom_cldnn_message << std::endl;
     std::cout << "    -d \"<device>\"                " << target_device_message << std::endl;
     std::cout << "    -d_pa \"<device>\"             " << target_device_message_person_attribs << std::endl;
     std::cout << "    -d_reid \"<device>\"           " << target_device_message_person_reid << std::endl;

--- a/demos/deblurring_demo/python/README.md
+++ b/demos/deblurring_demo/python/README.md
@@ -131,7 +131,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/face_recognition_demo/python/README.md
+++ b/demos/face_recognition_demo/python/README.md
@@ -103,22 +103,20 @@ Running the application with the `-h` option or without
 any arguments yields the following message:
 
 ```
-python ./face_recognition_demo.py -h
-
 usage: face_recognition_demo.py [-h] -i INPUT [--loop] [-o OUTPUT]
-                                [-limit OUTPUT_LIMIT] [--no_show]
+                                [-limit OUTPUT_LIMIT]
                                 [--output_resolution OUTPUT_RESOLUTION]
-                                [--crop_size CROP_SIZE]
+                                [--no_show] [--crop_size CROP_SIZE CROP_SIZE]
                                 [--match_algo {HUNGARIAN,MIN_DIST}]
-                                [-u UTILIZATION_MONITORS]
-                                -fg PATH [--run_detector] [--allow_grow]
-                                -m_fd PATH -m_lm PATH -m_reid PATH
-                                [--fd_input_size FD_INPUT_SIZE]
+                                [-u UTILIZATION_MONITORS] [-fg FG]
+                                [--run_detector] [--allow_grow] -m_fd M_FD
+                                -m_lm M_LM -m_reid M_REID
+                                [--fd_input_size FD_INPUT_SIZE FD_INPUT_SIZE]
                                 [-d_fd {CPU,GPU,MYRIAD,HETERO,HDDL}]
                                 [-d_lm {CPU,GPU,MYRIAD,HETERO,HDDL}]
-                                [-d_reid {CPU,GPU,MYRIAD,HETERO,HDDL}]
-                                [-l PATH] [-c PATH] [-v] [-t_fd [0..1]]
-                                [-t_id [0..1]] [-exp_r_fd NUMBER]
+                                [-d_reid {CPU,GPU,MYRIAD,HETERO,HDDL}] [-v]
+                                [-t_fd [0..1]] [-t_id [0..1]]
+                                [-exp_r_fd NUMBER]
 
 Optional arguments:
   -h, --help            Show this help message and exit.
@@ -181,14 +179,6 @@ Inference options:
   -d_reid {CPU,GPU,MYRIAD,HETERO,HDDL}
                         Optional. Target device for Face Reidentification
                         model. Default value is CPU.
-  -l PATH, --cpu_lib PATH
-                        Optional. For MKLDNN (CPU)-targeted custom layers,
-                        if any. Path to a shared library with custom
-                        layers implementations.
-  -c PATH, --gpu_lib PATH
-                        Optional. For clDNN (GPU)-targeted custom layers,
-                        if any. Path to the XML file with descriptions
-                        of the kernels.
   -v, --verbose         Optional. Be more verbose.
   -t_fd [0..1]          Optional. Probability threshold for face detections.
   -t_id [0..1]          Optional. Cosine distance threshold between two vectors

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -76,7 +76,7 @@ You might also face the missing `standalone.cls` file problem, which could be fi
 
 The example of the interface:
 ![interactive example](./interactive_interface.png)
-When User runs demo application with the `-i` option and passes video or number of the webcam device as an argument (typically 0), window with the image simillar to above should pop up.
+When User runs demo application with the `-i` option and passes video or number of the webcam device as an argument (typically 0), window with the image similar to above should pop up.
 
 Example of usage of the interactive mode:
 
@@ -103,7 +103,7 @@ Navigation keys:
 * Use `o` to decrease the size of the input (red) window
 * Use `p` to increase the size of the input window
 
-The overall process is simillar to the Non-interactive mode with the exception that it runs asynchronously.
+The overall process is similar to the Non-interactive mode with the exception that it runs asynchronously.
 This means model inference and rendering of the formula do not block main thread, so the image from the web camera can move smoothly.
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).

--- a/demos/gesture_recognition_demo/python/README.md
+++ b/demos/gesture_recognition_demo/python/README.md
@@ -60,8 +60,7 @@ usage: gesture_recognition_demo.py [-h] -m_a ACTION_MODEL -m_d DETECTION_MODEL
                                    -i INPUT [-o OUTPUT] [-limit OUTPUT_LIMIT]
                                    -c CLASS_MAP [-s SAMPLES_DIR]
                                    [-t ACTION_THRESHOLD] [-d DEVICE]
-                                   [-l CPU_EXTENSION] [--no_show]
-                                   [-u UTILIZATION_MONITORS]
+                                   [--no_show] [-u UTILIZATION_MONITORS]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -92,10 +91,6 @@ Options:
                         GPU, HDDL or MYRIAD. The demo will look for a
                         suitable plugin for device specified (by default, it
                         is CPU).
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        Optional. Required for CPU custom layers. Absolute
-                        path to a shared library with the kernels
-                        implementations.
   --no_show             Optional. Do not visualize inference results.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.

--- a/demos/gpt2_text_prediction_demo/python/README.md
+++ b/demos/gpt2_text_prediction_demo/python/README.md
@@ -72,7 +72,7 @@ The application reads and encodes text from input string, then performs transfor
 
 ## Demo Outputs
 
-The application outputs predicted text, continuing input string for each input strings.
+The application outputs predicted text, continuing input string for each input string.
 
 ## Example Demo Cmd-Line
 

--- a/demos/human_pose_estimation_demo/python/README.md
+++ b/demos/human_pose_estimation_demo/python/README.md
@@ -149,7 +149,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/image_inpainting_demo/python/README.md
+++ b/demos/image_inpainting_demo/python/README.md
@@ -106,7 +106,7 @@ Also, these hot keys are available:
 * **Tab** to show/hide original image
 * **Esc or Q** to quit
 
-If Backpace, C or R keys are pressed while demo is showing original image, demo will hide original image and return back to editing mode.
+If Backspace, C or R keys are pressed while demo is showing original image, demo will hide original image and return back to editing mode.
 
 ## Demo Output
 

--- a/demos/image_processing_demo/cpp/README.md
+++ b/demos/image_processing_demo/cpp/README.md
@@ -15,7 +15,7 @@ All images on result frame will be marked one of these flags:
 * 'R' - result image.
 * 'D' - difference image (|result - original|).
 
-1. Exmaple for deblurring type (left - source image, right - image after deblurring):
+1. Example for deblurring type (left - source image, right - image after deblurring):
 
 ![](./assets/image_processing_deblurred_image.png)
 
@@ -37,7 +37,7 @@ Super resolution:
 
 ![](./assets/parrots_restoration.png)
 
-For this type of image processing user can use flag `-jc`. It allows to perform compression before the inference (usefull when user want to test model on high quality jpeg images).
+For this type of image processing user can use flag `-jc`. It allows to perform compression before the inference (useful when user wants to test model on high quality jpeg images).
 
 4. Example for style_transfer:
 
@@ -83,7 +83,7 @@ This file can be used as a parameter for [Model Downloader](../../../tools/model
 
 Running the demo with `-h` shows this help message:
 ```
-image_processing_demo_async [OPTION]
+image_processing_demo [OPTION]
 Options:
 
     -h                        Print a usage message.

--- a/demos/image_processing_demo/cpp/main.cpp
+++ b/demos/image_processing_demo/cpp/main.cpp
@@ -81,7 +81,7 @@ DEFINE_bool(jc, false, jc_message);
 */
 static void showUsage() {
     std::cout << std::endl;
-    std::cout << "image_processing_demo_async [OPTION]" << std::endl;
+    std::cout << "image_processing_demo [OPTION]" << std::endl;
     std::cout << "Options:" << std::endl;
     std::cout << std::endl;
     std::cout << "    -h                        " << help_message << std::endl;

--- a/demos/image_retrieval_demo/python/README.md
+++ b/demos/image_retrieval_demo/python/README.md
@@ -63,11 +63,10 @@ omz_converter --list models.lst
 Run the application with the `-h` option to see the following usage message:
 
 ```
-usage: image_retrieval_demo.py [-h] -m MODEL -i INPUT [--loop]
-                               [-o OUTPUT] [-limit OUTPUT_LIMIT]
-                               -g GALLERY [-gt GROUND_TRUTH]
-                               [-d DEVICE] [-l CPU_EXTENSION]
-                               [--no_show] [-u UTILIZATION_MONITORS]
+usage: image_retrieval_demo.py [-h] -m MODEL -i INPUT [--loop] [-o OUTPUT]
+                               [-limit OUTPUT_LIMIT] -g GALLERY
+                               [-gt GROUND_TRUTH] [-d DEVICE] [--no_show]
+                               [-u UTILIZATION_MONITORS]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -91,10 +90,6 @@ Options:
                         GPU, HDDL or MYRIAD. The demo will look for a
                         suitable plugin for device specified (by default, it
                         is CPU).
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        Optional. Required for CPU custom layers. Absolute
-                        path to a shared library with the kernels
-                        implementations.
   --no_show             Optional. Do not visualize inference results.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.

--- a/demos/instance_segmentation_demo/python/README.md
+++ b/demos/instance_segmentation_demo/python/README.md
@@ -165,7 +165,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/mask_rcnn_demo/cpp/README.md
+++ b/demos/mask_rcnn_demo/cpp/README.md
@@ -46,9 +46,6 @@ Options:
     -h                                Print a usage message.
     -i "<path>"                       Required. Path to a .bmp image.
     -m "<path>"                       Required. Path to an .xml file with a trained model.
-      -l "<absolute_path>"            Required for CPU custom layers. Absolute path to a shared library with the kernels implementations.
-          Or
-      -c "<absolute_path>"            Required for GPU custom kernels. Absolute path to the .xml file with the kernels descriptions.
     -d "<device>"                     Optional. Specify the target device to infer on (the list of available devices is shown below). Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The demo will look for a suitable plugin for a specified device (CPU by default)
     -detection_output_name "<string>" Optional. The name of detection output layer. Default value is "reshape_do_2d"
     -masks_name "<string>"            Optional. The name of masks layer. Default value is "masks"

--- a/demos/mask_rcnn_demo/cpp/mask_rcnn_demo.h
+++ b/demos/mask_rcnn_demo/cpp/mask_rcnn_demo.h
@@ -13,15 +13,9 @@ static const char model_message[] = "Required. Path to an .xml file with a train
 static const char target_device_message[] = "Optional. Specify the target device to infer on (the list of available devices is shown below). "
                                             "Use \"-d HETERO:<comma-separated_devices_list>\" format to specify HETERO plugin. "
                                             "The demo will look for a suitable plugin for a specified device (CPU by default)";
-static const char custom_cldnn_message[] = "Required for GPU custom kernels. "
-                                           "Absolute path to the .xml file with the kernels descriptions.";
-static const char custom_cpu_library_message[] = "Required for CPU custom layers. "
-                                                 "Absolute path to a shared library with the kernels implementations.";
 static const char detection_output_layer_name_message[] = "Optional. The name of detection output layer. Default value is \"reshape_do_2d\"";
 static const char masks_layer_name_message[] = "Optional. The name of masks layer. Default value is \"masks\"";
 
-DEFINE_string(c, "", custom_cldnn_message);
-DEFINE_string(l, "", custom_cpu_library_message);
 DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", image_message);
 DEFINE_string(m, "", model_message);
@@ -40,9 +34,6 @@ static void showUsage() {
     std::cout << "    -h                                " << help_message << std::endl;
     std::cout << "    -i \"<path>\"                       " << image_message << std::endl;
     std::cout << "    -m \"<path>\"                       " << model_message << std::endl;
-    std::cout << "      -l \"<absolute_path>\"            " << custom_cpu_library_message << std::endl;
-    std::cout << "          Or" << std::endl;
-    std::cout << "      -c \"<absolute_path>\"            " << custom_cldnn_message << std::endl;
     std::cout << "    -d \"<device>\"                     " << target_device_message << std::endl;
     std::cout << "    -detection_output_name \"<string>\" " << detection_output_layer_name_message << std::endl;
     std::cout << "    -masks_name \"<string>\"            " << masks_layer_name_message << std::endl;

--- a/demos/multi_camera_multi_target_tracking_demo/python/README.md
+++ b/demos/multi_camera_multi_target_tracking_demo/python/README.md
@@ -85,7 +85,6 @@ usage: multi_camera_multi_target_tracking_demo.py [-h] -i INPUT [INPUT ...]
                                                   [--history_file HISTORY_FILE]
                                                   [--save_detections SAVE_DETECTIONS]
                                                   [--no_show] [-d DEVICE]
-                                                  [-l CPU_EXTENSION]
                                                   [-u UTILIZATION_MONITORS]
 
 Multi camera multi object tracking live demo script
@@ -118,9 +117,6 @@ optional arguments:
                         boxes
   --no_show             Optional. Don't show output
   -d DEVICE, --device DEVICE
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        MKLDNN (CPU)-targeted custom layers.Absolute path to a
-                        shared library with the kernels impl.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
 ```

--- a/demos/object_detection_demo/python/README.md
+++ b/demos/object_detection_demo/python/README.md
@@ -188,7 +188,7 @@ Common model options:
                         Optional. Probability threshold for detections
                         filtering.
   --resize_type {standard,fit_to_window,fit_to_window_letterbox}
-                        Optional. A resize type for model preprocess. By defauld used model predefined type.
+                        Optional. A resize type for model preprocess. By default used model predefined type.
   --input_size INPUT_SIZE INPUT_SIZE
                         Optional. The first image size used for CTPN model
                         reshaping. Default: 600 600. Note that submitted
@@ -304,7 +304,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/object_detection_demo/python/object_detection_demo.py
+++ b/demos/object_detection_demo/python/object_detection_demo.py
@@ -63,7 +63,7 @@ def build_argparser():
     common_model_args.add_argument('-t', '--prob_threshold', default=0.5, type=float,
                                    help='Optional. Probability threshold for detections filtering.')
     common_model_args.add_argument('--resize_type', default=None, choices=RESIZE_TYPES.keys(),
-                                   help='Optional. A resize type for model preprocess. By defauld used model predefined type.')
+                                   help='Optional. A resize type for model preprocess. By default used model predefined type.')
     common_model_args.add_argument('--input_size', default=(600, 600), type=int, nargs=2,
                                    help='Optional. The first image size used for CTPN model reshaping. '
                                         'Default: 600 600. Note that submitted images should have the same resolution, '

--- a/demos/place_recognition_demo/python/README.md
+++ b/demos/place_recognition_demo/python/README.md
@@ -60,8 +60,7 @@ Run the application with the `-h` option to see the following usage message:
 usage: place_recognition_demo.py [-h] -m MODEL -i INPUT -gf GALLERY_FOLDER
                                  [--gallery_size GALLERY_SIZE] [--loop]
                                  [-o OUTPUT] [-limit OUTPUT_LIMIT] [-d DEVICE]
-                                 [-l CPU_EXTENSION] [--no_show]
-                                 [-u UTILIZATION_MONITORS]
+                                 [--no_show] [-u UTILIZATION_MONITORS]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -87,10 +86,6 @@ Options:
                         GPU, HDDL or MYRIAD. The demo will look for a
                         suitable plugin for device specified (by default, it
                         is CPU).
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        Optional. Required for CPU custom layers. Absolute
-                        path to a shared library with the kernels
-                        implementations.
   --no_show             Optional. Do not visualize inference results.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.

--- a/demos/security_barrier_camera_demo/cpp/README.md
+++ b/demos/security_barrier_camera_demo/cpp/README.md
@@ -78,9 +78,6 @@ Options:
     -m "<path>"                Required. Path to the Vehicle and License Plate Detection model .xml file.
     -m_va "<path>"             Optional. Path to the Vehicle Attributes model .xml file.
     -m_lpr "<path>"            Optional. Path to the License Plate Recognition model .xml file.
-      -l "<absolute_path>"     Required for CPU custom layers. Absolute path to a shared library with the kernels implementation.
-          Or
-      -c "<absolute_path>"     Required for GPU custom kernels. Absolute path to an .xml file with the kernels description.
     -d "<device>"              Optional. Specify the target device for Vehicle Detection (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_va "<device>"           Optional. Specify the target device for Vehicle Attributes (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_lpr "<device>"          Optional. Specify the target device for License Plate Recognition (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.

--- a/demos/security_barrier_camera_demo/cpp/security_barrier_camera_demo.hpp
+++ b/demos/security_barrier_camera_demo/cpp/security_barrier_camera_demo.hpp
@@ -28,10 +28,6 @@ static const char target_device_message_lpr[] = "Optional. Specify the target de
                                                 "The application looks for a suitable plugin for the specified device.";
 static const char raw_output_message[] = "Optional. Output inference results as raw values.";
 static const char thresh_output_message[] = "Optional. Probability threshold for vehicle and license plate detections.";
-static const char custom_cldnn_message[] = "Required for GPU custom kernels. "
-                                           "Absolute path to an .xml file with the kernels description.";
-static const char custom_cpu_library_message[] = "Required for CPU custom layers. "
-                                                 "Absolute path to a shared library with the kernels implementation.";
 static const char no_show_message[] = "Optional. Don't show output.";
 static const char input_resizable_message[] = "Optional. Enable resizable input with support of ROI crop and auto resize.";
 static const char ninfer_request_message[] = "Optional. Number of infer requests. 0 sets the number of infer requests equal to the number of inputs.";
@@ -65,8 +61,6 @@ DEFINE_string(d_va, "CPU", target_device_message_vehicle_attribs);
 DEFINE_string(d_lpr, "CPU", target_device_message_lpr);
 DEFINE_bool(r, false, raw_output_message);
 DEFINE_double(t, 0.5, thresh_output_message);
-DEFINE_string(c, "", custom_cldnn_message);
-DEFINE_string(l, "", custom_cpu_library_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_bool(auto_resize, false, input_resizable_message);
 DEFINE_uint32(nireq, 0, ninfer_request_message);
@@ -95,9 +89,6 @@ void showUsage() {
     std::cout << "    -m \"<path>\"                " << detection_model_message << std::endl;
     std::cout << "    -m_va \"<path>\"             " << vehicle_attribs_model_message << std::endl;
     std::cout << "    -m_lpr \"<path>\"            " << lpr_model_message << std::endl;
-    std::cout << "      -l \"<absolute_path>\"     " << custom_cpu_library_message << std::endl;
-    std::cout << "          Or" << std::endl;
-    std::cout << "      -c \"<absolute_path>\"     " << custom_cldnn_message << std::endl;
     std::cout << "    -d \"<device>\"              " << target_device_message << std::endl;
     std::cout << "    -d_va \"<device>\"           " << target_device_message_vehicle_attribs << std::endl;
     std::cout << "    -d_lpr \"<device>\"          " << target_device_message_lpr << std::endl;

--- a/demos/segmentation_demo/cpp/README.md
+++ b/demos/segmentation_demo/cpp/README.md
@@ -93,7 +93,7 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask. By setting `-only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
+The demo uses OpenCV to display the resulting images with a blended segmentation mask. By setting `-only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
 The demo reports:
 
 * **FPS**: average rate of video frame processing (frames per second).

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -8,7 +8,7 @@ This topic demonstrates how to run the Image Segmentation demo application, whic
 
 ## How It Works
 
-On startup the demo application reads command line parameters and loads a model to OpenVINO™ Runtime plugin. The demo runs inference and shows results for each image captured from an input. Demo provides default mapping of classes to colors and optionally, allow to specify mapping of classes to colors from simple text file, with using `--colors` argument. Depending on number of inference requests processing simultaneously (-nireq parameter) the pipeline might minimize the time required to process each single image (for nireq 1) or maximize utilization of the device and overall processing performance.
+On startup the demo application reads command line parameters and loads a model to OpenVINO™ Runtime plugin. The demo runs inference and shows results for each image captured from an input. Demo provides default mapping of classes to colors and optionally, allows to specify mapping of classes to colors from simple text file, with using `--colors` argument. Depending on number of inference requests processing simultaneously (-nireq parameter) the pipeline might minimize the time required to process each single image (for nireq 1) or maximize utilization of the device and overall processing performance.
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
@@ -147,7 +147,7 @@ To avoid disk space overrun in case of continuous input stream, like camera, you
 
 The color palette is used to visualize predicted classes. By default, the colors from PASCAL VOC dataset are applied. In case when the number of output classes is larger than number of classes provided by PASCAL VOC dataset, the rest classes are randomly colorized. Also, one can use predefined colors from other datasets, like CAMVID.
 
-Available colors files located in the `<omz_dir>/data/palettes` folder. If you want to assign custom colors for classes, you should create a `.txt` file, where the each line contains colors in `(R, G, B)` format. The demo application treat the number of each line as a dataset class identificator and apply specified color to pixels belonging to this class.
+Available colors files located in the `<omz_dir>/data/palettes` folder. If you want to assign custom colors for classes, you should create a `.txt` file, where each line contains colors in `(R, G, B)` format. The demo application treats the number of each line as a dataset class identificator and applies specified color to pixels belonging to this class.
 
 ## Running with OpenVINO Model Server
 
@@ -161,7 +161,7 @@ Exemplary command:
 
 ## Demo Output
 
-The demo uses OpenCV to display the resulting images with blended segmentation mask by default. By setting `--only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
+The demo uses OpenCV to display the resulting images with a blended segmentation mask by default. By setting `--only_mask` option (or pressing the `TAB` key during demo running) the resulting image would contain only masks.
 
 > **NOTE**: the output file contains the same image as displayed one.
 
@@ -169,7 +169,14 @@ The demo reports
 
 * **FPS**: average rate of video frame processing (frames per second).
 * **Latency**: average time required to process one frame (from reading the frame to displaying the results).
-You can use both of these metrics to measure application-level performance.
+* Latency for each of the following pipeline stages:
+  * **Decoding** — capturing input data.
+  * **Preprocessing** — data preparation for inference.
+  * **Inference** — infering input data (images) and getting a result.
+  * **Postrocessing** — preparation inference result for output.
+  * **Rendering** — generating output image.
+
+You can use these metrics to measure application-level performance.
 
 ## See Also
 

--- a/demos/smartlab_demo/python/README.md
+++ b/demos/smartlab_demo/python/README.md
@@ -2,8 +2,8 @@
 
 This is the demo application with smartlab action recognition and smartlab object detection algorithms.
 This demo takes multi-view video inputs to identify actions and objects, then evaluates scores of current state.
-Action recognition architecure uses two encoders for front-view and top-view respectively, and a single decoder.
-Object detection uses two models for each view to detect large object and small objects, respectively.
+Action recognition architecture uses two encoders for front-view and top-view respectively, and a single decoder.
+Object detection uses two models for each view to detect large and small objects, respectively.
 The following pre-trained models are delivered with the product:
 
 * `i3d-rgb-tf` + `smartlab-sequence-modelling-0001`, which are other models for identifying actions 2 actions of smartlab (adjust_rider, put_take).

--- a/demos/social_distance_demo/cpp/README.md
+++ b/demos/social_distance_demo/cpp/README.md
@@ -74,9 +74,6 @@ Options:
     -i "<path1>" "<path2>"     Required for video or image files input. Path to video or image files.
     -m_det "<path>"            Required. Path to the Person Detection model .xml file.
     -m_reid "<path>"           Optional. Path to the Person Re-Identification model .xml file.
-      -l "<absolute_path>"     Required for CPU custom layers. Absolute path to a shared library with the kernels implementation.
-          Or
-      -c "<absolute_path>"     Required for GPU custom kernels. Absolute path to an .xml file with the kernels description.
     -d_det "<device>"          Optional. Specify the target device for Person Detection (the list of available devices is shown below). Default value is CPU. Use "-d HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -d_reid "<device>"         Optional. Specify the target device for Person Re-Identification (the list of available devices is shown below). Default value is CPU. Use "-d_reid HETERO:<comma-separated_devices_list>" format to specify HETERO plugin. The application looks for a suitable plugin for the specified device.
     -r                         Optional. Output inference results as raw values.

--- a/demos/sound_classification_demo/python/README.md
+++ b/demos/sound_classification_demo/python/README.md
@@ -36,9 +36,9 @@ omz_converter --list models.lst
 Run the application with the `-h` option to see the usage message:
 
 ```
-usage: sound_classification_demo.py [-h] -i INPUT -m MODEL [-l CPU_EXTENSION]
-                                    [-d DEVICE] [--labels LABELS]
-                                    [-sr SAMPLE_RATE] [-ol OVERLAP]
+usage: sound_classification_demo.py [-h] -i INPUT -m MODEL [-d DEVICE]
+                                    [--labels LABELS] [-sr SAMPLE_RATE]
+                                    [-ol OVERLAP]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -46,10 +46,6 @@ Options:
                         Required. Input to process
   -m MODEL, --model MODEL
                         Required. Path to an .xml file with a trained model.
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        Optional. Required for CPU custom layers. Absolute
-                        path to a shared library with the kernels
-                        implementations.
   -d DEVICE, --device DEVICE
                         Optional. Specify the target device to infer on; CPU,
                         GPU, HDDL or MYRIAD is acceptable. The demo

--- a/demos/text_spotting_demo/python/README.md
+++ b/demos/text_spotting_demo/python/README.md
@@ -71,17 +71,17 @@ Run the application with the `-h` option to see the following usage message:
 
 ```
 usage: text_spotting_demo.py [-h] -m_m "<path>" -m_te "<path>" -m_td "<path>"
-                             -i INPUT [--loop] [-o OUTPUT] [-limit OUTPUT_LIMIT]
-                             [-d "<device>"] [-l "<absolute_path>"] [--delay "<num>"]
-                             [-pt "<num>"] [-a ALPHABET]
+                             -i INPUT [--loop] [-o OUTPUT]
+                             [-limit OUTPUT_LIMIT] [-d "<device>"]
+                             [--delay "<num>"] [-pt "<num>"] [-a ALPHABET]
                              [--trd_input_prev_symbol TRD_INPUT_PREV_SYMBOL]
                              [--trd_input_prev_hidden TRD_INPUT_PREV_HIDDEN]
                              [--trd_input_encoder_outputs TRD_INPUT_ENCODER_OUTPUTS]
                              [--trd_output_symbols_distr TRD_OUTPUT_SYMBOLS_DISTR]
                              [--trd_output_cur_hidden TRD_OUTPUT_CUR_HIDDEN]
-                             [--keep_aspect_ratio] [--no_track]
-                             [--show_scores] [--show_boxes] [-r]
-                             [--no_show] [-u UTILIZATION_MONITORS]
+                             [-trt "<num>"] [--keep_aspect_ratio] [--no_track]
+                             [--show_scores] [--show_boxes] [-r] [--no_show]
+                             [-u UTILIZATION_MONITORS]
 
 Options:
   -h, --help            Show this help message and exit.
@@ -108,9 +108,6 @@ Options:
                         The demo will look for a suitable plugin for device specified
                         (by default, it is CPU). Please refer to OpenVINO documentation
                         for the list of devices supported by the model.
-  -l "<absolute_path>", --cpu_extension "<absolute_path>"
-                        Required for CPU custom layers. Absolute path to a
-                        shared library with the kernels implementation.
   --delay "<num>"       Optional. Interval in milliseconds of waiting for a
                         key to be pressed.
   -pt "<num>", --prob_threshold "<num>"
@@ -133,6 +130,8 @@ Options:
   --trd_output_cur_hidden TRD_OUTPUT_CUR_HIDDEN
                         Optional. Name of current hidden output node from text
                         recognition head decoder part.
+  -trt "<num>", --tr_threshold "<num>"
+                        Optional. Text recognition confidence threshold.
   --keep_aspect_ratio   Optional. Force image resize to keep aspect ratio.
   --no_track            Optional. Disable tracking.
   --show_scores         Optional. Show detection scores.

--- a/demos/text_to_speech_demo/python/README.md
+++ b/demos/text_to_speech_demo/python/README.md
@@ -1,6 +1,6 @@
 # Text-to-speech Python\* Demo
 
-The text to speech demo show how to run the ForwardTacotron and WaveRNN models or modified ForwardTacotron and MelGAN models to produce an audio file for a given input text file.
+The text to speech demo shows how to run the ForwardTacotron and WaveRNN models or modified ForwardTacotron and MelGAN models to produce an audio file for a given input text file.
 The demo is based on https://github.com/seungwonpark/melgan, https://github.com/as-ideas/ForwardTacotron and https://github.com/fatchord/WaveRNN repositories.
 
 ## How It Works

--- a/demos/time_series_forecasting_demo/python/README.md
+++ b/demos/time_series_forecasting_demo/python/README.md
@@ -41,7 +41,7 @@ omz_converter --list models.lst
 
 The demo works with the test dataset in the .pickle format provided by accuracy_checker.
 
-* Install accuracy_checker following to the [instruction](../../../tools/accuracy_checker/README.md).
+* Install accuracy_checker following the [instruction](../../../tools/accuracy_checker/README.md).
 * Convert test dataset:
 
 ```sh

--- a/demos/whiteboard_inpainting_demo/python/README.md
+++ b/demos/whiteboard_inpainting_demo/python/README.md
@@ -64,10 +64,9 @@ Run the application with the `-h` option to see the following usage message:
 ```
 usage: whiteboard_inpainting_demo.py [-h] -i INPUT [--loop] [-o OUTPUT]
                                      [-limit OUTPUT_LIMIT]
-                                     -m_i M_INSTANCE_SEGMENTATION
-                                     -m_s M_SEMANTIC_SEGMENTATION
-                                     [-t THRESHOLD] [--no_show]
-                                     [-d DEVICE] [-l CPU_EXTENSION]
+                                     [-m_i M_INSTANCE_SEGMENTATION]
+                                     [-m_s M_SEMANTIC_SEGMENTATION]
+                                     [-t THRESHOLD] [--no_show] [-d DEVICE]
                                      [-u UTILIZATION_MONITORS]
 
 Whiteboard inpainting demo
@@ -94,9 +93,6 @@ optional arguments:
                         Optional. Specify a target device to infer on. CPU,
                         GPU, HDDL or MYRIAD is acceptable. The demo will
                         look for a suitable plugin for the device specified.
-  -l CPU_EXTENSION, --cpu_extension CPU_EXTENSION
-                        MKLDNN (CPU)-targeted custom layers. Absolute path to a
-                        shared library with the kernels impl.
   -u UTILIZATION_MONITORS, --utilization_monitors UTILIZATION_MONITORS
                         Optional. List of monitors to show initially.
 ```


### PR DESCRIPTION
1. Add info about latency for pipeline stages in documentation for python demos to align with cpp documentation
2. Remove the remaining description about -l, -c flags from documentation
3. Fix spelling in documentation