### PR TITLE
Python demos documentation: remove info about requirements installation

### DIFF
--- a/demos/3d_segmentation_demo/python/README.md
+++ b/demos/3d_segmentation_demo/python/README.md
@@ -10,12 +10,6 @@ On startup, the demo reads command-line parameters and loads a model and images 
 
 ## Preparing to Run
 
-The demo dependencies should be installed before run. That can be achieved with the following command:
-
-```sh
-python3 -mpip install --user -r <omz_dir>/demos/3d_segmentation_demo/python/requirements.txt
-```
-
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).
 The list of models supported by the demo is in `<omz_dir>/demos/3d_segmentation_demo/python/models.lst` file.
 This file can be used as a parameter for [Model Downloader](../../../tools/model_tools/README.md) and Converter to download and, if necessary, convert models to OpenVINO IR format (\*.xml + \*.bin).

--- a/demos/README.md
+++ b/demos/README.md
@@ -286,6 +286,14 @@ cmake -A x64 <open_model_zoo>/demos
   cmake --build . --config Debug
   ```
 
+### <a name="python_requirements"></a>Dependencies for Python* Demos
+
+The dependencies for Python demos must be installed before running. It can be achieved with the following command:
+
+```sh
+python -mpip install --user -r requirements.txt
+```
+
 ### <a name="python_model_api"></a>Python\* model API package
 
 To run Python demo applications, you need to install the Python* Model API package. Refer to [Python* Model API documentation](common/python/openvino/model_zoo/model_api/README.md#installing-python*-model-api-package) to learn about its installation.

--- a/demos/README.md
+++ b/demos/README.md
@@ -291,7 +291,7 @@ cmake -A x64 <open_model_zoo>/demos
 The dependencies for Python demos must be installed before running. It can be achieved with the following command:
 
 ```sh
-python -mpip install --user -r requirements.txt
+python -mpip install --user -r <omz_dir>/demos/requirements.txt
 ```
 
 ### <a name="python_model_api"></a>Python\* model API package

--- a/demos/face_recognition_demo/python/README.md
+++ b/demos/face_recognition_demo/python/README.md
@@ -31,20 +31,6 @@ visualized and displayed on the screen or written to the output file.
 
 ## Preparing to Run
 
-### Installation and dependencies
-
-The demo depends on:
-
-* OpenVINO library (2021.4 or newer)
-* Python (any, which is supported by OpenVINO)
-* OpenCV (>=4.2.5)
-
-To install all the required Python modules you can use:
-
-``` sh
-pip install -r requirements.txt
-```
-
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).
 The list of models supported by the demo is in `<omz_dir>/demos/face_recognition_demo/python/models.lst` file.
 This file can be used as a parameter for [Model Downloader](../../../tools/model_tools/README.md) and Converter to download and, if necessary, convert models to OpenVINO IR format (\*.xml + \*.bin).

--- a/demos/formula_recognition_demo/python/README.md
+++ b/demos/formula_recognition_demo/python/README.md
@@ -56,8 +56,6 @@ Regardless of what mode is selected (interactive or non-interactive) the process
 
 ##### Requirements for rendering
 
-Sympy python package is used for rendering. To install it, please, run:
-`pip install -r requirements.txt`
 Sympy package needs LaTeX system installed in the operating system.
 For Windows you can use [MiKTeX\*](https://miktex.org/) (just download and install it), for Ubuntu/MacOS you can use TeX Live\*:
 Ubuntu:

--- a/demos/handwritten_text_recognition_demo/python/README.md
+++ b/demos/handwritten_text_recognition_demo/python/README.md
@@ -32,19 +32,6 @@ omz_converter --list models.lst
 
 > **NOTE**: Refer to the tables [Intel's Pre-Trained Models Device Support](../../../models/intel/device_support.md) and [Public Pre-Trained Models Device Support](../../../models/public/device_support.md) for the details on models inference support at different devices.
 
-### Installation and Dependencies
-
-The demo depends on:
-
-* opencv-python
-* numpy
-
-To install all the required Python modules you can use:
-
-``` sh
-pip install -r requirements.txt
-```
-
 ## Running
 
 Running the application with the `-h` option yields the following usage message:

--- a/demos/image_retrieval_demo/python/README.md
+++ b/demos/image_retrieval_demo/python/README.md
@@ -31,12 +31,6 @@ The demo workflow is the following:
 
 The demo sample input videos and gallery images can be found in this [repository](https://github.com/19900531/test). An example of file listing gallery images can be found [here](https://github.com/openvinotoolkit/training_extensions/blob/089de2f24667329a58e8560ed4e01ef203e99def/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt).
 
-The demo dependencies should be installed before run. That can be achieved with the following command:
-
-```sh
-python3 -mpip install --user -r <omz_dir>/demos/requirements.txt
-```
-
 The list of models supported by the demo is in `<omz_dir>/demos/image_retrieval_demo/python/models.lst` file.
 This file can be used as a parameter for [Model Downloader](../../../tools/model_tools/README.md) and Converter to download and, if necessary, convert models to OpenVINO IR format (\*.xml + \*.bin).
 

--- a/demos/multi_camera_multi_target_tracking_demo/python/README.md
+++ b/demos/multi_camera_multi_target_tracking_demo/python/README.md
@@ -26,14 +26,6 @@ and then for each detected object it extracts embeddings using re-identification
 
 ## Preparing to Run
 
-### Installation of Dependencies
-
-To install required dependencies, run
-
-```bash
-pip3 install -r requirements.txt
-```
-
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).
 The list of models supported by the demo is in `<omz_dir>/demos/multi_camera_multi_target_tracking_demo/python/models.lst` file.
 This file can be used as a parameter for [Model Downloader](../../../tools/model_tools/README.md) and Converter to download and, if necessary, convert models to OpenVINO IR format (\*.xml + \*.bin).

--- a/demos/speech_recognition_deepspeech_demo/python/README.md
+++ b/demos/speech_recognition_deepspeech_demo/python/README.md
@@ -106,9 +106,6 @@ optional arguments:
 The typical command line for offline mode is:
 
 ```shell
-pip install -r requirements.txt
-source <openvino_dir>/bin/setupvars.sh
-
 python3 speech_recognition_deepspeech_demo.py \
     -p mds08x_en \
     -m <path_to_model>/mozilla-deepspeech-0.8.2.xml \

--- a/demos/whiteboard_inpainting_demo/python/README.md
+++ b/demos/whiteboard_inpainting_demo/python/README.md
@@ -49,14 +49,6 @@ omz_converter --list models.lst
 
 > **NOTE**: Refer to the tables [Intel's Pre-Trained Models Device Support](../../../models/intel/device_support.md) and [Public Pre-Trained Models Device Support](../../../models/public/device_support.md) for the details on models inference support at different devices.
 
-### Install Dependencies
-
-To install required dependencies, open a terminal and run the following:
-
-```bash
-pip3 install -r requirements.txt
-```
-
 ## Running
 
 Run the application with the `-h` option to see the following usage message:


### PR DESCRIPTION
Remove description of how to install requirements.txt for Python demos, since all requirements files are merged into one common file (https://github.com/openvinotoolkit/open_model_zoo/pull/3160)