### PR TITLE
BertNamedEntityRecognition wrapper: fix bounds for filtered_labels_id

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/models/bert.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/bert.py
@@ -106,7 +106,7 @@ class BertNamedEntityRecognition(Bert):
 
         filtered_labels_id = [
             (i, label_i) for i, label_i in enumerate(labels_id)
-            if label_i != 0 and 0 < i < self.max_length - meta['pad_len']
+            if label_i != 0 and 0 < i < self.max_length - meta['pad_len'] - 1
         ]
         return score, filtered_labels_id
 


### PR DESCRIPTION
Prevent the `IndexError: list index out of range` error in bert_named_entity_recongition_demo