### PR TITLE
Set nstreams in cofig_factory.cpp for CPU 

### DIFF
--- a/demos/common/cpp/utils/src/config_factory.cpp
+++ b/demos/common/cpp/utils/src/config_factory.cpp
@@ -44,6 +44,9 @@ ModelConfig ConfigFactory::getUserConfig(const std::string& flags_d,
                 config.compiledModelConfig.emplace(ov::inference_num_threads.name(), flags_nthreads);
 
             config.compiledModelConfig.emplace(ov::affinity.name(), ov::Affinity::NONE);
+
+            ov::streams::Num nstreams = deviceNstreams.count(device) > 0 ? ov::streams::Num(deviceNstreams[device]) : ov::streams::AUTO;
+            config.compiledModelConfig.emplace(ov::streams::num.name(), nstreams);
         } else if (device == "GPU") {
             ov::streams::Num nstreams = deviceNstreams.count(device) > 0 ? ov::streams::Num(deviceNstreams[device]) : ov::streams::AUTO;
             config.compiledModelConfig.emplace(ov::streams::num.name(), nstreams);


### PR DESCRIPTION
Restore the setting of nstreams for CPU. Before the default value for nstreams was 1 and the value from -nireq cmd parameter did not passed to the config