### PR TITLE
Python Model API: apply few changes

### DIFF
--- a/demos/background_subtraction_demo/python/README.md
+++ b/demos/background_subtraction_demo/python/README.md
@@ -55,6 +55,12 @@ The demo workflow is the following:
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different background subtraction model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).

--- a/demos/bert_named_entity_recognition_demo/python/README.md
+++ b/demos/bert_named_entity_recognition_demo/python/README.md
@@ -8,6 +8,12 @@ On startup the demo application reads command line parameters and loads a model 
 It also fetches data from the user-provided url to populate the "context" text.
 The text is then used to search named entities.
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different named entity recognition model topologies in one demo.
+
 ## Preparing to Run
 
 The list of models supported by the demo is in `<omz_dir>/demos/bert_named_entity_recognition_demo/python/models.lst` file.

--- a/demos/bert_question_answering_demo/python/README.md
+++ b/demos/bert_question_answering_demo/python/README.md
@@ -8,6 +8,12 @@ On startup the demo application reads command line parameters and loads a model 
 It also fetches data from the user-provided url to populate the "context" text.
 The text is then used to search answers for user-provided questions.
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different question answering model topologies in one demo.
+
 ## Preparing to Run
 
 The list of models supported by the demo is in `<omz_dir>/demos/bert_question_answering_demo/python/models.lst` file.

--- a/demos/bert_question_answering_embedding_demo/python/README.md
+++ b/demos/bert_question_answering_embedding_demo/python/README.md
@@ -17,6 +17,12 @@ Notice that question is usually much shorter than the contexts, so calculating t
 
 If second (conventional SQuAD-tuned) Bert model is provided as well, it is used to further search for the exact answer in the best contexts found in the first step, and the result then also displayed to the user.
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different question answering model topologies in one demo.
+
 ## Preparing to Run
 
 The list of models supported by the demo is in `<omz_dir>/demos/bert_question_answering_embedding_demo/python/models.lst` file.

--- a/demos/classification_demo/python/README.md
+++ b/demos/classification_demo/python/README.md
@@ -12,6 +12,12 @@ You can stop the demo by pressing "Esc" or "Q" button. After that, the average m
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different classification model topologies in one demo.
+
 ## Preparing to Run
 
 The list of models supported by the demo is in `<omz_dir>/demos/classification_demo/python/models.lst` file.

--- a/demos/common/python/openvino/model_zoo/model_api/models/background_matting.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/background_matting.py
@@ -18,7 +18,6 @@ import cv2
 import numpy as np
 
 from .image_model import ImageModel
-from .model import WrapperError
 
 
 class VideoBackgroundMatting(ImageModel):
@@ -41,7 +40,7 @@ class VideoBackgroundMatting(ImageModel):
             if len(metadata.shape) == 4 and metadata.shape[1] == 3:
                 image_blob_names.append(name)
         if not image_blob_names:
-            raise WrapperError(self.__model__, 'Compatible inputs are not found')
+            self.raise_error('Compatible inputs are not found')
         return image_blob_names, image_info_blob_names
 
     def _get_outputs(self):
@@ -52,7 +51,7 @@ class VideoBackgroundMatting(ImageModel):
             elif len(metadata.shape) == 4 and metadata.shape[1] == 1:
                 image_blob_names['pha'] = name
         if len(image_blob_names) != 2:
-            raise WrapperError(self.__model__, 'Compatible outputs are not found')
+            self.raise_error('Compatible outputs are not found')
         return image_blob_names
 
     def get_inputs_map(self):
@@ -108,13 +107,13 @@ class ImageMattingWithBackground(ImageModel):
             if len(metadata.shape) == 4 and metadata.shape[1] == 3:
                 image_blob_names.append(name)
         if len(image_blob_names) != 2:
-            raise WrapperError(self.__model__, 'Compatible inputs are not found')
+            self.raise_error('Compatible inputs are not found')
         return image_blob_names, image_info_blob_names
 
     def set_input_shape(self):
         shapes = [tuple(self.inputs[name].shape) for name in self.image_blob_names]
         if len(set(shapes)) != 1:
-            raise WrapperError(self.__model__, 'Image inputs have incompatible shapes: {}'.format(shapes))
+            self.raise_error('Image inputs have incompatible shapes: {}'.format(shapes))
         return shapes[0]
 
     def _get_outputs(self):
@@ -125,7 +124,7 @@ class ImageMattingWithBackground(ImageModel):
             elif len(metadata.shape) == 4 and metadata.shape[1] == 1:
                 image_blob_names['pha'] = name
         if len(image_blob_names) != 2:
-            raise WrapperError(self.__model__, 'Compatible outputs are not found')
+            self.raise_error('Compatible outputs are not found')
         return image_blob_names
 
     def preprocess(self, inputs):
@@ -138,8 +137,8 @@ class ImageMattingWithBackground(ImageModel):
             if target_shape is None:
                 target_shape = meta['original_shape']
             elif meta['original_shape'] != target_shape:
-                raise WrapperError(self.__model__, 'Image inputs must have equal shapes but got: {} vs {}'
-                                    .format(target_shape, meta['original_shape']))
+                self.raise_error('Image inputs must have equal shapes but got: {} vs {}'.format(
+                    target_shape, meta['original_shape']))
         return dict_inputs, meta
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/openvino/model_zoo/model_api/models/bert.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/bert.py
@@ -13,7 +13,7 @@
 
 import numpy as np
 
-from .model import Model, WrapperError
+from .model import Model
 from .types import DictValue, NumericalValue, StringValue, BooleanValue
 
 
@@ -27,7 +27,7 @@ class Bert(Model):
         self.token_pad = [self.vocab['[PAD]']]
         self.input_names = [i.strip() for i in self.input_names.split(',')]
         if self.inputs.keys() != set(self.input_names):
-            raise WrapperError(self.__model__, 'The Wrapper expects input names: {}, actual network input names: {}'.format(
+            self.raise_error('The Wrapper expects input names: {}, actual network input names: {}'.format(
                 self.input_names, list(self.inputs.keys())))
         self.max_length = self.inputs[self.input_names[0]].shape[1]
 
@@ -142,7 +142,7 @@ class BertQuestionAnswering(Bert):
 
         self.output_names = [o.strip() for o in self.output_names.split(',')]
         if self.outputs.keys() != set(self.output_names):
-            raise WrapperError(self.__model__, 'The Wrapper output names: {}, actual network output names: {}'.format(
+            self.raise_error('The Wrapper expects output names: {}, actual network output names: {}'.format(
                 self.output_names, list(self.outputs.keys())))
 
     @classmethod

--- a/demos/common/python/openvino/model_zoo/model_api/models/classification.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/classification.py
@@ -23,6 +23,7 @@ from .image_model import ImageModel
 
 
 class Classification(ImageModel):
+    __model__ = 'Classification'
     def __init__(self, model_adapter, configuration=None, preload=False):
         super().__init__(model_adapter, configuration, preload)
         self._check_io_number(1, 1)
@@ -30,14 +31,13 @@ class Classification(ImageModel):
             self.labels = self._load_labels(self.path_to_labels)
         self.out_layer_name = self._get_outputs()
 
-    @staticmethod
-    def _load_labels(labels_file):
+    def _load_labels(self, labels_file):
         with open(labels_file, 'r') as f:
             labels = []
             for s in f:
                 begin_idx = s.find(' ')
                 if (begin_idx == -1):
-                    raise RuntimeError('The labels file has incorrect format.')
+                    self.raise_error('The labels file has incorrect format.')
                 end_idx = s.find(',')
                 labels.append(s[(begin_idx + 1):end_idx])
         return labels
@@ -47,17 +47,17 @@ class Classification(ImageModel):
         layer_shape = self.outputs[layer_name].shape
 
         if len(layer_shape) != 2 and len(layer_shape) != 4:
-            raise RuntimeError('The Classification model wrapper supports topologies only with 2D or 4D output')
+            self.raise_error('The Classification model wrapper supports topologies only with 2D or 4D output')
         if len(layer_shape) == 4 and (layer_shape[2] != 1 or layer_shape[3] != 1):
-            raise RuntimeError('The Classification model wrapper supports topologies only with 4D '
-                               'output which has last two dimensions of size 1')
+            self.raise_error('The Classification model wrapper supports topologies only with 4D '
+                             'output which has last two dimensions of size 1')
         if self.labels:
             if (layer_shape[1] == len(self.labels) + 1):
                 self.labels.insert(0, 'other')
                 self.logger.warning("\tInserted 'other' label as first.")
             if layer_shape[1] != len(self.labels):
-                raise RuntimeError("Model's number of classes and parsed "
-                                'labels must match ({} != {})'.format(layer_shape[1], len(self.labels)))
+                self.raise_error("Model's number of classes and parsed "
+                                 'labels must match ({} != {})'.format(layer_shape[1], len(self.labels)))
         return layer_name
 
     @classmethod

--- a/demos/common/python/openvino/model_zoo/model_api/models/ctpn.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/ctpn.py
@@ -17,7 +17,6 @@
 import cv2
 import numpy as np
 
-from .model import WrapperError
 from .detection_model import DetectionModel
 from .types import ListValue, NumericalValue
 from .utils import Detection, nms, clip_detections
@@ -65,7 +64,7 @@ class CTPN(DetectionModel):
         (boxes_name, boxes_data_repr), (scores_name, scores_data_repr) = self.outputs.items()
 
         if len(boxes_data_repr.shape) != 4 or len(scores_data_repr.shape) != 4:
-            raise WrapperError(self.__model__, "Unexpected output blob shape. Only 4D output blobs are supported")
+            self.raise_error("Unexpected output blob shape. Only 4D output blobs are supported")
 
         if self.nchw_layout:
             scores_channels = scores_data_repr.shape[1]
@@ -78,7 +77,7 @@ class CTPN(DetectionModel):
             return scores_name, boxes_name
         if boxes_channels == scores_channels * 2:
             return boxes_name, scores_name
-        raise WrapperError(self.__model__, "One of outputs must be two times larger than another")
+        self.raise_error("One of outputs must be two times larger than another")
 
     @classmethod
     def parameters(cls):

--- a/demos/common/python/openvino/model_zoo/model_api/models/deblurring.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/deblurring.py
@@ -15,7 +15,6 @@ import cv2
 import math
 import numpy as np
 
-from .model import WrapperError
 from .image_model import ImageModel
 
 
@@ -46,7 +45,7 @@ class Deblurring(ImageModel):
         output_blob_name = next(iter(self.outputs))
         output_size = self.outputs[output_blob_name].shape
         if len(output_size) != 4:
-            raise WrapperError(self.__model__, "Unexpected output blob shape {}. Only 4D output blob is supported".format(output_size))
+            self.raise_error("Unexpected output blob shape {}. Only 4D output blob is supported".format(output_size))
 
         return output_blob_name
 

--- a/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
@@ -14,7 +14,6 @@
  limitations under the License.
 """
 from .types import ListValue, NumericalValue, StringValue
-from .model import WrapperError
 from .image_model import ImageModel
 from .utils import load_labels, clip_detections
 
@@ -42,13 +41,13 @@ class DetectionModel(ImageModel):
             iou_threshold(float): threshold for NMS filtering
 
         Raises:
-            RuntimeError: If loaded model has more than one image inputs
+            WrapperError: If loaded model has more than one image inputs
         '''
         super().__init__(model_adapter, configuration, preload)
 
         if not self.image_blob_name:
-            raise WrapperError(self.__model__, "The Wrapper supports only one image input, but {} found"
-                               .format(len(self.image_blob_names)))
+            self.raise_error("The Wrapper supports only one image input, but {} found".format(
+                len(self.image_blob_names)))
 
         if self.path_to_labels:
             self.labels = load_labels(self.path_to_labels)
@@ -80,7 +79,7 @@ class DetectionModel(ImageModel):
             List of detections fit to initial image (resized and clipped)
 
         Raises:
-            RuntimeError: If model uses custom resize or `resize_type` not set
+            WrapperError: If model uses custom resize or `resize_type` not set
         '''
         resized_shape = meta['resized_shape']
         original_shape = meta['original_shape']
@@ -92,7 +91,7 @@ class DetectionModel(ImageModel):
         elif self.resize_type == 'standard':
             detections = resize_detections(detections, original_shape[1::-1])
         else:
-            raise WrapperError(self.__model__, 'Unknown resize type {}'.format(self.resize_type))
+            self.raise_error('Unknown resize type {}'.format(self.resize_type))
         return clip_detections(detections, original_shape)
 
 

--- a/demos/common/python/openvino/model_zoo/model_api/models/detr.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/detr.py
@@ -15,7 +15,6 @@
 """
 import numpy as np
 
-from .model import WrapperError
 from .detection_model import DetectionModel
 from .utils import Detection, softmax
 
@@ -32,16 +31,16 @@ class DETR(DetectionModel):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.outputs.items()
 
         if bboxes_layer.shape[1] != scores_layer.shape[1]:
-            raise WrapperError(self.__model__, "Expected the same second dimension for boxes and scores, but got {} and {}"
-                               .format(bboxes_layer.shape, scores_layer.shape))
+            self.raise_error("Expected the same second dimension for boxes and scores, but got {} and {}".format(
+                bboxes_layer.shape, scores_layer.shape))
 
         if bboxes_layer.shape[2] == 4:
             return bboxes_blob_name, scores_blob_name
         elif scores_layer.shape[2] == 4:
             return scores_blob_name, bboxes_blob_name
         else:
-            raise WrapperError(self.__model__, "Expected shape [:,:,4] for bboxes output, but got {} and {}"
-                               .format(bboxes_layer.shape, scores_layer.shape))
+            self.raise_error("Expected shape [:,:,4] for bboxes output, but got {} and {}".format(
+                bboxes_layer.shape, scores_layer.shape))
 
     @classmethod
     def parameters(cls):

--- a/demos/common/python/openvino/model_zoo/model_api/models/faceboxes.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/faceboxes.py
@@ -18,7 +18,6 @@ import math
 import numpy as np
 
 from .types import NumericalValue
-from .model import WrapperError
 from .detection_model import DetectionModel
 from .utils import Detection, nms
 
@@ -38,8 +37,8 @@ class FaceBoxes(DetectionModel):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.outputs.items()
 
         if bboxes_layer.shape[1] != scores_layer.shape[1]:
-            raise WrapperError(self.__model__, "Expected the same second dimension for boxes and scores, but got {} and {}"
-                               .format(bboxes_layer.shape, scores_layer.shape))
+            self.raise_error("Expected the same second dimension for boxes and scores, but got {} and {}".format(
+                bboxes_layer.shape, scores_layer.shape))
 
         if bboxes_layer.shape[2] == 4:
             return bboxes_blob_name, scores_blob_name

--- a/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
@@ -82,9 +82,9 @@ class ImageModel(Model):
             elif len(metadata.shape) == 2:
                 image_info_blob_names.append(name)
             else:
-                raise RuntimeError('Failed to identify the input for ImageModel: only 2D and 4D input layer supported')
+                self.raise_error('Failed to identify the input for ImageModel: only 2D and 4D input layer supported')
         if not image_blob_names:
-            raise RuntimeError('Failed to identify the input for the image: no 4D input layer found')
+            self.raise_error('Failed to identify the input for the image: no 4D input layer found')
         return image_blob_names, image_info_blob_names
 
     def preprocess(self, inputs):

--- a/demos/common/python/openvino/model_zoo/model_api/models/instance_segmentation.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/instance_segmentation.py
@@ -18,7 +18,6 @@ import cv2
 import numpy as np
 
 from .image_model import ImageModel
-from .model import WrapperError
 from .types import NumericalValue, ListValue, StringValue
 from .utils import nms, load_labels
 
@@ -65,7 +64,7 @@ class MaskRCNNModel(ImageModel):
             elif len(layer_shape) == 3:
                 outputs['masks'] = layer_name
             else:
-                raise WrapperError(self.__model__, "Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
+                self.raise_error("Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
 
         return outputs
 
@@ -82,7 +81,7 @@ class MaskRCNNModel(ImageModel):
             elif layer_name == 'raw_masks' and len(layer_shape) == 4:
                 outputs['masks'] = layer_name
             else:
-                raise WrapperError(self.__model__, "Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
+                self.raise_error("Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
         return outputs
 
     def preprocess(self, inputs):
@@ -189,7 +188,7 @@ class YolactModel(ImageModel):
             elif layer_name == 'mask' and len(layer_shape) == 3:
                 outputs['masks'] = layer_name
             else:
-                raise WrapperError(self.__model__, "Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
+                self.raise_error("Unexpected output layer shape {} with name {}".format(layer_shape, layer_name))
         return outputs
 
     def postprocess(self, outputs, meta):

--- a/demos/common/python/openvino/model_zoo/model_api/models/model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/model.py
@@ -19,8 +19,7 @@ import logging as log
 
 class WrapperError(RuntimeError):
     def __init__(self, wrapper_name, message):
-        self.message = f"{wrapper_name}: {message}"
-        super().__init__(self.message)
+        super().__init__(f"{wrapper_name}: {message}")
 
 
 class Model:
@@ -61,8 +60,8 @@ class Model:
         for subclass in subclasses:
             if name.lower() == subclass.__model__.lower():
                 return subclass
-        raise WrapperError(cls.__model__, 'There is no model with name "{}" in list: {}'.
-                         format(name, ', '.join([subclass.__model__ for subclass in subclasses])))
+        cls.raise_error('There is no model with name "{}" in list: {}'.format(
+            name, ', '.join([subclass.__model__ for subclass in subclasses])))
 
     @classmethod
     def create_model(cls, name, model_adapter, configuration=None, preload=False):
@@ -94,14 +93,21 @@ class Model:
             if name in parameters:
                 errors = parameters[name].validate(value)
                 if errors:
-                    log.error(f'Error with "{name}" parameter:')
+                    self.logger.error(f'Error with "{name}" parameter:')
                     for error in errors:
-                        log.error(f"\t{error}")
-                    raise WrapperError(self.__model__, 'Incorrect user configuration')
+                        self.logger.error(f"\t{error}")
+                    self.raise_error('Incorrect user configuration')
                 value = parameters[name].get_value(value)
                 self.__setattr__(name, value)
             else:
-                log.warning(f'The parameter "{name}" not found in {self.__model__} wrapper, will be omitted')
+                self.logger.warning(f'The parameter "{name}" not found in {self.__model__} wrapper, will be omitted')
+
+    def raise_error(self, message):
+        '''Raises the WrapperError
+        Args:
+            message: error message
+        '''
+        raise WrapperError(self.__model__, message)
 
     def preprocess(self, inputs):
         '''Interface for preprocess method
@@ -131,30 +137,30 @@ class Model:
             number_of_outputs(int, Tuple(int)): number of output blobs, supported by wrapper. Use -1 to omit check
 
         Raises:
-            RuntimeError: if loaded model has unsupported number of input or output blob
+            WrapperError: if loaded model has unsupported number of input or output blob
         '''
         if not isinstance(number_of_inputs, tuple):
             if len(self.inputs) != number_of_inputs and number_of_inputs != -1:
-                raise WrapperError(self.__model__, "Expected {} input blob{}, but {} found: {}".format(
+                self.raise_error("Expected {} input blob{}, but {} found: {}".format(
                     number_of_inputs, 's' if number_of_inputs !=1 else '',
                     len(self.inputs), ', '.join(self.inputs)
                 ))
         else:
             if not len(self.inputs) in number_of_inputs:
-                raise WrapperError(self.__model__, "Expected {} or {} input blobs, but {} found: {}".format(
+                self.raise_error("Expected {} or {} input blobs, but {} found: {}".format(
                     ', '.join(str(n) for n in number_of_inputs[:-1]), int(number_of_inputs[-1]),
                     len(self.inputs), ', '.join(self.inputs)
                 ))
 
         if not isinstance(number_of_outputs, tuple):
             if len(self.outputs) != number_of_outputs and number_of_outputs != -1:
-                raise WrapperError(self.__model__, "Expected {} output blob{}, but {} found: {}".format(
+                self.raise_error("Expected {} output blob{}, but {} found: {}".format(
                     number_of_outputs, 's' if number_of_outputs !=1 else '',
                     len(self.outputs), ', '.join(self.outputs)
                 ))
         else:
             if not len(self.outputs) in number_of_outputs:
-                raise WrapperError(self.__model__, "Expected {} or {} output blobs, but {} found: {}".format(
+                self.raise_error("Expected {} or {} output blobs, but {} found: {}".format(
                     ', '.join(str(n) for n in number_of_outputs[:-1]), int(number_of_outputs[-1]),
                     len(self.outputs), ', '.join(self.outputs)
                 ))
@@ -174,7 +180,8 @@ class Model:
 
     def reshape(self, new_shape):
         if self.model_loaded:
-            log.warning(f'{self.__model__}: the model already loaded to device, should be reloaded after reshaping.')
+            self.logger.warning(f'{self.__model__}: the model already loaded to device, ',
+                                'should be reloaded after reshaping.')
             self.model_loaded = False
         self.model_adapter.reshape_model(new_shape)
         self.inputs = self.model_adapter.get_input_layers()
@@ -197,8 +204,8 @@ class Model:
 
     def log_layers_info(self):
         for name, metadata in self.inputs.items():
-            log.info('\tInput layer: {}, shape: {}, precision: {}, layout: {}'.format(name, metadata.shape,
-                                                                                      metadata.precision, metadata.layout))
+            self.logger.info('\tInput layer: {}, shape: {}, precision: {}, layout: {}'.format(
+                name, metadata.shape, metadata.precision, metadata.layout))
         for name, metadata in self.outputs.items():
-            log.info('\tOutput layer: {}, shape: {}, precision: {}, layout: {}'.format(name, metadata.shape,
-                                                                                       metadata.precision, metadata.layout))
+            self.logger.info('\tOutput layer: {}, shape: {}, precision: {}, layout: {}'.format(
+                name, metadata.shape, metadata.precision, metadata.layout))

--- a/demos/common/python/openvino/model_zoo/model_api/models/model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/model.py
@@ -188,9 +188,15 @@ class Model:
         self.outputs = self.model_adapter.get_output_layers()
 
     def infer_sync(self, dict_data):
+        if not self.model_loaded:
+            self.raise_error("The model is not loaded to the device. Please, create the wrapper "
+                "with preload=True option or call load() method before infer_sync()")
         return self.model_adapter.infer_sync(dict_data)
 
     def infer_async(self, dict_data, callback_data):
+        if not self.model_loaded:
+            self.raise_error("The model is not loaded to the device. Please, create the wrapper "
+                "with preload=True option or call load() method before infer_async()")
         self.model_adapter.infer_async(dict_data, callback_data)
 
     def is_ready(self):

--- a/demos/common/python/openvino/model_zoo/model_api/models/open_pose.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/open_pose.py
@@ -42,14 +42,14 @@ class OpenPose(ImageModel):
 
         heatmap_shape = heatmap.output(0).get_shape()
         if len(paf_shape) != 4 and len(heatmap_shape) != 4:
-            raise RuntimeError('OpenPose outputs must be 4-dimensional')
+            self.raise_error('OpenPose outputs must be 4-dimensional')
         if paf_shape[2] != heatmap_shape[2] and paf_shape[3] != heatmap_shape[3]:
-            raise RuntimeError('Last two dimensions of OpenPose outputs must match')
+            self.raise_error('Last two dimensions of OpenPose outputs must match')
         if paf_shape[1] * 2 == heatmap_shape[1]:
             paf, heatmap = heatmap, paf
         elif paf_shape[1] != heatmap_shape[1] * 2:
-            raise RuntimeError('Size of second dimension of OpenPose of one output must be two times larger then size '
-                'of second dimension of another output')
+            self.raise_error('Size of second dimension of OpenPose of one output must be two times larger then size '
+                             'of second dimension of another output')
 
         paf = paf.inputs()[0].get_source_output().get_node()
         paf.get_output_tensor(0).set_names({self.pafs_blob_name})
@@ -113,7 +113,7 @@ class OpenPose(ImageModel):
         img = self._resize_image(inputs, self.h)
         h, w = img.shape[:2]
         if self.w < w:
-            raise RuntimeError("The image aspect ratio doesn't fit current model shape")
+            self.raise_error("The image aspect ratio doesn't fit current model shape")
         if not (self.w - self.size_divisor < w <= self.w):
             self.logger.warning("\tChosen model aspect ratio doesn't match image aspect ratio")
         resize_img_scale = np.array((inputs.shape[1] / w, inputs.shape[0] / h), np.float32)

--- a/demos/common/python/openvino/model_zoo/model_api/models/ssd.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/ssd.py
@@ -15,7 +15,6 @@
 """
 import numpy as np
 
-from .model import WrapperError
 from .detection_model import DetectionModel
 from .utils import Detection
 
@@ -67,7 +66,7 @@ class SSD(DetectionModel):
             return parser
         except ValueError:
             pass
-        raise WrapperError(self.__model__, 'Unsupported model outputs')
+        self.raise_error('Unsupported model outputs')
 
     def _parse_outputs(self, outputs, meta):
         detections = self.output_parser(outputs)

--- a/demos/common/python/openvino/model_zoo/model_api/models/ultra_lightweight_face_detection.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/ultra_lightweight_face_detection.py
@@ -15,7 +15,6 @@
 """
 import numpy as np
 
-from .model import WrapperError
 from .detection_model import DetectionModel
 from .types import NumericalValue
 from .utils import Detection, nms
@@ -34,18 +33,16 @@ class UltraLightweightFaceDetection(DetectionModel):
         (bboxes_blob_name, bboxes_layer), (scores_blob_name, scores_layer) = self.outputs.items()
 
         if bboxes_layer.shape[1] != scores_layer.shape[1]:
-            raise WrapperError(self.__model__,
-                               "Expected the same second dimension for boxes and scores, but got {} and {}"
-                               .format(bboxes_layer.shape, scores_layer.shape))
+            self.raise_error("Expected the same second dimension for boxes and scores, but got {} and {}".format(
+                bboxes_layer.shape, scores_layer.shape))
 
         if bboxes_layer.shape[2] == 4:
             return bboxes_blob_name, scores_blob_name
         elif scores_layer.shape[2] == 4:
             return scores_blob_name, bboxes_blob_name
         else:
-            raise WrapperError(self.__model__,
-                               "Expected shape [:,:,4] for bboxes output, but got {} and {}"
-                               .format(bboxes_layer.shape, scores_layer.shape))
+            self.raise_error("Expected shape [:,:,4] for bboxes output, but got {} and {}".format(
+                bboxes_layer.shape, scores_layer.shape))
 
     @classmethod
     def parameters(cls):

--- a/demos/deblurring_demo/python/README.md
+++ b/demos/deblurring_demo/python/README.md
@@ -17,6 +17,12 @@ For each image demo performs the following steps:
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different deblurring model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).

--- a/demos/human_pose_estimation_demo/python/README.md
+++ b/demos/human_pose_estimation_demo/python/README.md
@@ -10,6 +10,12 @@ On startup, the application reads command-line parameters and loads a model to O
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different human pose estimation model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).

--- a/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
+++ b/demos/human_pose_estimation_demo/python/human_pose_estimation_demo.py
@@ -183,7 +183,7 @@ def main():
         'aspect_ratio': frame.shape[1] / frame.shape[0],
         'confidence_threshold': args.prob_threshold,
         'padding_mode': 'center' if args.architecture_type == 'higherhrnet' else None, # the 'higherhrnet' and 'ae' specific
-        'delta': 0.5 if 'higherhrnet' else None, # the 'higherhrnet' and 'ae' specific
+        'delta': 0.5 if args.architecture_type == 'higherhrnet' else None, # the 'higherhrnet' and 'ae' specific
     }
     model = ImageModel.create_model(ARCHITECTURES[args.architecture_type], model_adapter, config)
     model.log_layers_info()

--- a/demos/instance_segmentation_demo/python/README.md
+++ b/demos/instance_segmentation_demo/python/README.md
@@ -37,6 +37,12 @@ The demo workflow is the following:
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different instance segmentation model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).

--- a/demos/monodepth_demo/python/README.md
+++ b/demos/monodepth_demo/python/README.md
@@ -16,6 +16,12 @@ Async API operates with a notion of the "Infer Request" that encapsulates the in
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different monocular depth estimation model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).

--- a/demos/segmentation_demo/python/README.md
+++ b/demos/segmentation_demo/python/README.md
@@ -12,6 +12,12 @@ On startup the demo application reads command line parameters and loads a model 
 
 > **NOTE**: By default, Open Model Zoo demos expect input with BGR channels order. If you trained your model to work with RGB order, you need to manually rearrange the default channels order in the demo application or reconvert your model using the Model Optimizer tool with the `--reverse_input_channels` argument specified. For more information about the argument, refer to **When to Reverse Input Channels** section of [Converting a Model Using General Conversion Parameters](https://docs.openvino.ai/latest/openvino_docs_MO_DG_prepare_model_convert_model_Converting_Model.html#general-conversion-parameters).
 
+## Model API
+
+The demo utilizes model wrappers, adapters and pipelines from [Python* Model API](../../common/python/openvino/model_zoo/model_api/README.md).
+
+The generalized interface of wrappers with its unified results representation provides the support of multiple different semantic segmentation model topologies in one demo.
+
 ## Preparing to Run
 
 For demo input image or video files, refer to the section **Media Files Available for Demos** in the [Open Model Zoo Demos Overview](../../README.md).


### PR DESCRIPTION
Apply few changes:

- Update the documentation for Python Model API demos: add section about Model API
- Add meaningful error when the model inference is called in the wrapper, but the model is not loaded to the device
-  Add `self.raise_error()` to Model Wrappers, which hides the call `raise WrapperError(self.__model__, message)` (to ease the readability of errors and remove repetitions) 