### PR TITLE
less restricted tokenizers version

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -12,7 +12,8 @@ scikit-learn~=0.24.1
 scipy~=1.5.4
 sympy>=1.8
 tensorboardX>=2.1
-tokenizers~=0.10.1
+tokenizers~=0.10.1;python_version<"3.7"
+tokenizers>=0.10.1;python_version>="3.7"
 tqdm>=4.54.1
 -r common/python/requirements.txt
 -r common/python/requirements_ovms.txt

--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -30,8 +30,11 @@ pydicom>=2.1.2
 
 # nlp, tokenization
 sentencepiece>=0.1.95
-tokenizers~=0.10.1
-transformers>=4.5
+tokenizers~=0.10.1;python_version<"3.7"
+tokenizers>=0.10.1;python_version>="3.7"
+transformers>=4.5,<4.17;python_version<"3.7"
+transformers>=4.5;python_version>="3.7"
+
 nltk>=3.5
 
 # DNA sequence matching


### PR DESCRIPTION
updated requirements to stay compatible with new transformers lib
tokenizers version was pinned globally in this PR https://github.com/openvinotoolkit/open_model_zoo/pull/3123
due to lack of wheels for win and mac for python3.6 in newer versions.
With transformers 4.17, we can not use such old tokenizers version 