### PR TITLE
fix deployment_tools in docs (#3364)

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -167,7 +167,7 @@ You can download the [Intel pre-trained models](../models/intel/index.md) or [pu
 ## Build the Demo Applications
 
 To build the demos, you need to source OpenVINO™ and OpenCV environment. You can install the OpenVINO™ toolkit using the installation package for [Intel® Distribution of OpenVINO™ toolkit](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit-download.html) or build the open-source version available in the [OpenVINO GitHub repository](https://github.com/openvinotoolkit/openvino) using the [build instructions](https://github.com/openvinotoolkit/openvino/wiki/BuildingCode).
-For the Intel® Distribution of OpenVINO™ toolkit installed to the `<INSTALL_DIR>` directory on your machine, run the following commands to download OpenCV and set environment variables before building the demos:
+For the Intel® Distribution of OpenVINO™ toolkit installed to the `<INSTALL_DIR>` directory on your machine, run the following commands to download prebuilt OpenCV and set environment variables before building the demos:
 
 ```sh
 <INSTALL_DIR>/extras/scripts/download_opencv.sh
@@ -236,10 +236,8 @@ for the debug configuration — in `<path_to_build_directory>/intel64/Debug/`.
 The recommended Windows* build environment is the following:
 
 - Microsoft Windows* 10
-- Microsoft Visual Studio* 2017, or 2019
-- CMake* version 3.10 or higher
-
-> **NOTE**: If you want to use Microsoft Visual Studio 2019, you are required to install CMake 3.14.
+- Microsoft Visual Studio* 2019
+- CMake* version 3.14 or higher
 
 To build the demo applications for Windows, go to the directory with the `build_demos_msvc.bat`
 batch file and run it:
@@ -250,13 +248,19 @@ build_demos_msvc.bat
 
 By default, the script automatically detects the highest Microsoft Visual Studio version installed on the machine and uses it to create and build
 a solution for a demo code. Optionally, you can also specify the preferred Microsoft Visual Studio version to be used by the script. Supported
-versions are: `VS2017`, `VS2019`. For example, to build the demos using the Microsoft Visual Studio 2017, use the following command:
+version is: `VS2019`. For example, to build the demos using the Microsoft Visual Studio 2019, use the following command:
 
 ```bat
-build_demos_msvc.bat VS2017
+build_demos_msvc.bat VS2019
 ```
 
-The demo applications binaries are in the `C:\Users\<username>\Documents\Intel\OpenVINO\omz_demos_build\intel64\Release` directory.
+By default, the demo applications binaries are build into the `C:\Users\<username>\Documents\Intel\OpenVINO\omz_demos_build\intel64\Release` directory.
+The default build folder can be changed with `-b` option. For example, following command will buid Open Model Zoo demos into `c:\temp\omz-demos-build` folder:
+
+```bat
+build_demos_msvc.bat -b c:\temp\omz-demos-build
+```
+
 
 You can also build a generated solution by yourself, for example, if you want to
 build binaries in Debug configuration. Run the appropriate version of the
@@ -415,7 +419,7 @@ For example, for the **Debug** configuration, go to the project's
 variable in the **Environment** field to the following:
 
 ```
-PATH=<INSTALL_DIR>\deployment_tools\inference_engine\bin\intel64\Debug;<INSTALL_DIR>\opencv\bin;%PATH%
+PATH=<INSTALL_DIR>\runtime\bin\intel64\Debug;<INSTALL_DIR>\extras\opencv\bin;%PATH%
 ```
 
 where `<INSTALL_DIR>` is the directory in which the OpenVINO toolkit is installed.

--- a/demos/security_barrier_camera_demo/cpp/README.md
+++ b/demos/security_barrier_camera_demo/cpp/README.md
@@ -125,7 +125,7 @@ For example, to run the sample on one Intel® Vision Accelerator Design with Int
 ./security_barrier_camera_demo -i <path_to_video>/inputVideo.mp4 -m <path_to_model>/vehicle-license-plate-detection-barrier-0106.xml -m_va <path_to_model>/vehicle-attributes-recognition-barrier-0039.xml -m_lpr <path_to_model>/license-plate-recognition-barrier-0001.xml -d HDDL -d_va HDDL -d_lpr HDDL -n_iqs 10 -n_wt 4 -nireq 10
 ```
 
-> **NOTE**: For the `-tag` option (HDDL plugin only), you must specify the number of VPUs for each network in the `hddl_service.config` file located in the `<INSTALL_DIR>/deployment_tools/inference_engine/external/hddl/config/` directory using the following tags:
+> **NOTE**: For the `-tag` option (HDDL plugin only), you must specify the number of VPUs for each network in the `hddl_service.config` file located in the `<INSTALL_DIR>/runtime/3rdparty/hddl/config/` directory using the following tags:
 > * `tagDetect` for the Vehicle and License Plate Detection network
 > * `tagAttr` for the Vehicle Attributes Recognition network
 > * `tagLPR` for the License Plate Recognition network

--- a/demos/social_distance_demo/cpp/README.md
+++ b/demos/social_distance_demo/cpp/README.md
@@ -118,7 +118,7 @@ For example, to run the sample on one Intel® Vision Accelerator Design with Int
 ./social_distance_demo -i <path_to_video>/inputVideo.mp4 -m_det <path_to_model>/person-detection-retail-0013.xml -m_reid <path_to_model>/person-reidentification-retail-0277.xml  -d_det HDDL -d_reid HDDL -n_iqs 10 -n_wt 4 -nireq 10
 ```
 
-> **NOTE**: For the `-tag` option (HDDL plugin only), you must specify the number of VPUs for each network in the `hddl_service.config` file located in the `<INSTALL_DIR>/deployment_tools/inference_engine/external/hddl/config/` directory using the following tags:
+> **NOTE**: For the `-tag` option (HDDL plugin only), you must specify the number of VPUs for each network in the `hddl_service.config` file located in the `<INSTALL_DIR>/runtime/3rdparty/hddl/config/` directory using the following tags:
 > * `tagDetect` for the Person Detection network
 > * `tagReId` for the Person Re-Identification network
 >

--- a/demos/speech_recognition_deepspeech_demo/python/README.md
+++ b/demos/speech_recognition_deepspeech_demo/python/README.md
@@ -127,7 +127,8 @@ To run in *simulated real-time mode* add command-line option `--realtime`.
 
 > **NOTE**: Only 16-bit, 16 kHz, mono-channel WAVE audio files are supported.
 
-Optional (but highly recommended) language model files, `deepspeech-0.8.2-models.kenlm` or `lm.binary` are part of corresponding model downloaded content and will be located in the Model Downloader output folder after model downloading and conversion. An example audio file can be taken from `<openvino_dir>/deployment_tools/demo/how_are_you_doing.wav`.
+Optional (but highly recommended) language model files, `deepspeech-0.8.2-models.kenlm` or `lm.binary` are part of corresponding model downloaded content and will be located in the Model Downloader output folder after model downloading and conversion.
+An example audio file can be taken from OpenVINO [test data](https://storage.openvinotoolkit.org/data/test_data/) folder.
 
 ## Demo Output
 

--- a/demos/speech_recognition_quartznet_demo/python/README.md
+++ b/demos/speech_recognition_quartznet_demo/python/README.md
@@ -57,7 +57,7 @@ python3 speech_recognition_quartznet_demo.py -m quartznet-15x5-en.xml -i audio.w
 
 > **NOTE**: Only 16-bit, 16 kHz, mono-channel WAVE audio files are supported.
 
-An example audio file can be taken from `<openvino_dir>/deployment_tools/demo/how_are_you_doing.wav`.
+An example audio file can be taken from OpenVINO [test data](https://storage.openvinotoolkit.org/data/test_data/) folder.
 
 ## Demo Output
 

--- a/demos/speech_recognition_wav2vec_demo/python/README.md
+++ b/demos/speech_recognition_wav2vec_demo/python/README.md
@@ -58,7 +58,7 @@ python3 speech_recognition_wav2vec_demo.py -m wav2vec2-base.xml -i audio.wav
 
 > **NOTE**: Only 16-bit, 16 kHz, mono-channel WAVE audio files are supported.
 
-An example audio file can be taken from `<openvino_dir>/deployment_tools/demo/how_are_you_doing.wav`.
+An example audio file can be taken from OpenVINO [test data](https://storage.openvinotoolkit.org/data/test_data/) folder.
 
 ## Demo Output
 

--- a/demos/tests/run_tests.py
+++ b/demos/tests/run_tests.py
@@ -24,7 +24,7 @@ For the tests to work, the test data directory must contain:
 * a "Image_Retrieval" subdirectory with image retrieval dataset (images, videos) (see https://github.com/19900531/test)
   and list of images (see https://github.com/openvinotoolkit/training_extensions/blob/089de2f/misc/tensorflow_toolkit/image_retrieval/data/gallery/gallery.txt)
 * a "msasl" subdirectory with the MS-ASL dataset (https://www.microsoft.com/en-us/research/project/ms-asl/)
-* a file how_are_you_doing.wav from <openvino_dir>/deployment_tools/demo/how_are_you_doing.wav
+* a file how_are_you_doing.wav from (https://storage.openvinotoolkit.org/data/test_data/)
 * a file stream_8_high.mp4 from https://storage.openvinotoolkit.org/data/test_data/videos/smartlab/stream_8_high.mp4
 * a file stream_8_top.mp4 from https://storage.openvinotoolkit.org/data/test_data/videos/smartlab/stream_8_top.mp4
 """

--- a/tools/accuracy_checker/configs/README.md
+++ b/tools/accuracy_checker/configs/README.md
@@ -78,9 +78,9 @@ See how to evaluate model with using predefined configuration file for [densenet
     ```sh
     OMZ_ROOT/tools/model_tools/downloader.py --name densenet-121-tf --output_dir MODEL_DIR
     ```
-3. Convert model in the Inference Engine IR format using Model Optimizer via [Model Converter](../../../tools/model_tools/README.md)
+3. Convert model in the OpenVINO IR format using Model Optimizer via [Model Converter](../../../tools/model_tools/README.md)
     ```sh
-    OMZ_ROOT/tools/model_tools/converter.py --name densenet-121-tf --download_dir MODEL_DIR --mo OPENVINO_DIR/deployment_tools/model_optimizer/mo.py
+    omz_converter --name densenet-121-tf --download_dir MODEL_DIR
     ```
 4. Run evaluation for model in FP32 precision using [Accuracy Checker](../README.md)
     ```sh


### PR DESCRIPTION
* remove old and deprecated deployment_tools path

* Apply suggestions from code review

Co-authored-by: Ekaterina Aidova <ekaterina.aidova@intel.com>

* restore auto-generated files

* rm VS2017

* restore DAV file

Co-authored-by: Ekaterina Aidova <ekaterina.aidova@intel.com>