### PR TITLE
Work around Layout == str issue (#3358)

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/adapters/ovms_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/ovms_adapter.py
@@ -125,7 +125,7 @@ class OVMSAdapter(ModelAdapter):
         inputs = {}
         for name, meta in self.metadata["inputs"].items():
             input_layout = Layout.from_shape(meta["shape"])
-            inputs[name] = Metadata(set(name), meta["shape"], input_layout.layout, self.tf2ov_precision.get(meta["dtype"], meta["dtype"]))
+            inputs[name] = Metadata(set(name), meta["shape"], input_layout, self.tf2ov_precision.get(meta["dtype"], meta["dtype"]))
         return inputs
 
     def get_output_layers(self):


### PR DESCRIPTION
The Layout utility datatype was recently introduced. However, it seems
to be polymorphic depending on the way it was constructed: sometimes
it's just a string, sometimes it has a data member called "layout".

This is just a fix to make OVMSAdapter work with the most common use
case. There is a bigger fix needed to patch all code paths in
OVMSAdapter and OpenvinoAdapter.