### PR TITLE
Python Model API: update docstrings for Model, ImageModel, DetectionModel wrappers

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
@@ -35,7 +35,7 @@ class ModelAdapter(metaclass=abc.ABCMeta):
 
         - Reading the model from disk or other place
         - Loading the model to the device
-        - Accessing the information about input/output layers
+        - Accessing the information about inputs/outputs
         - The model reshaping
         - Synchronous model inference
         - Asynchronous model inference
@@ -58,30 +58,32 @@ class ModelAdapter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_input_layers(self):
         '''
-        Gets the names of model input layers and for each layer creates the Metadata structure,
-           which contains the information about the layer shape, blob precision in OpenVINO format, meta (optional)
+        Gets the names of model inputs and for each one creates the Metadata structure,
+           which contains the information about the input shape, layout, precision
+           in OpenVINO format, meta (optional)
 
         Returns:
-            - the dict containing Metadata for all input layers
+            - the dict containing Metadata for all inputs
         '''
 
     @abc.abstractmethod
     def get_output_layers(self):
         '''
-        Gets the names of model output layers and for each layer creates the Metadata structure,
-           which contains the information about the layer shape, blob precision in OpenVINO format, meta (optional)
+        Gets the names of model outputs and for each one creates the Metadata structure,
+           which contains the information about the output shape, layout, precision
+           in OpenVINO format, meta (optional)
 
         Returns:
-            - the dict containing Metadata for all output layers
+            - the dict containing Metadata for all outputs
         '''
 
     @abc.abstractmethod
     def reshape_model(self, new_shape):
         '''
-        Reshapes the model input layers to fit the new input shape.
+        Reshapes the model inputs to fit the new input shape.
 
         Args:
-            - new_shape (dict): the dictionary with input layers names as keys and
+            - new_shape (dict): the dictionary with inputs names as keys and
                 list of new shape as values in the following format:
                 {
                     'input_layer_name_1': [1, 128, 128, 3],

--- a/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/model_adapter.py
@@ -81,11 +81,11 @@ class ModelAdapter(metaclass=abc.ABCMeta):
         Reshapes the model input layers to fit the new input shape.
 
         Args:
-            - new_shape(dict): the dictionary with input layers as keys and
+            - new_shape (dict): the dictionary with input layers names as keys and
                 list of new shape as values in the following format:
                 {
-                    'input_layer_1': [1, 128, 128, 3],
-                    'input_layer_2': [1, 128, 128, 3],
+                    'input_layer_name_1': [1, 128, 128, 3],
+                    'input_layer_name_2': [1, 128, 128, 3],
                     ...
                 }
         '''
@@ -98,16 +98,16 @@ class ModelAdapter(metaclass=abc.ABCMeta):
         Args:
             - dict_data: it's submitted to the model for inference and has the following format:
                 {
-                    'input_layer_1': data_1,
-                    'input_layer_2': data_2,
+                    'input_layer_name_1': data_1,
+                    'input_layer_name_2': data_2,
                     ...
                 }
 
         Returns:
-            - raw result(dict) - model raw output in the following format:
+            - raw result (dict) - model raw output in the following format:
                 {
-                    'output_layer_1': raw_result_1,
-                    'output_layer_2': raw_result_2,
+                    'output_layer_name_1': raw_result_1,
+                    'output_layer_name_2': raw_result_2,
                     ...
                 }
         '''
@@ -123,8 +123,8 @@ class ModelAdapter(metaclass=abc.ABCMeta):
         Args:
             - dict_data: it's submitted to the model for inference and has the following format:
                 {
-                    'input_layer_1': data_1,
-                    'input_layer_2': data_2,
+                    'input_layer_name_1': data_1,
+                    'input_layer_name_2': data_2,
                     ...
                 }
             - callback_fn: the callback function, which is defined outside the adapter

--- a/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/openvino_adapter.py
@@ -38,9 +38,9 @@ def create_core():
 
 
 class OpenvinoAdapter(ModelAdapter):
-    """
+    '''
     Works with OpenVINO model
-    """
+    '''
 
     def __init__(self, core, model_path, weights_path=None, model_parameters = {}, device='CPU', plugin_config=None, max_num_requests=0):
         self.core = core

--- a/demos/common/python/openvino/model_zoo/model_api/adapters/ovms_adapter.py
+++ b/demos/common/python/openvino/model_zoo/model_api/adapters/ovms_adapter.py
@@ -28,9 +28,9 @@ from .utils import Layout
 
 
 class OVMSAdapter(ModelAdapter):
-    """
+    '''
     Class that allows working with models served by the OpenVINO Model Server
-    """
+    '''
 
     tf2ov_precision = {
         "DT_INT64": "I64",

--- a/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
@@ -19,30 +19,31 @@ from .utils import load_labels, clip_detections
 
 
 class DetectionModel(ImageModel):
-    '''An abstract detection model class
+    '''An abstract wrapper for object detection model
 
-    This class supports detection models. The Detection Model must have single image input.
+    The DetectionModel must have a single image input.
+    It inherits `preprocess` from `ImageModel` wrapper. Also, it defines `_resize_detections` method,
+    which should be used in `postprocess`, to clip bounding boxes and resize ones to original image shape.
 
-    Attributes:
-        labels(List[str]): list of labels for classes (could be None)
-        threshold(float): threshold for detection filtering, any detection with confidence less than this value
-            should be omitted in ``posptrocess`` method (0<=thresold<=1.0 for most models)
-        iou_threshold(float): threshold for NMS detection filtering
+    The `postprocess` method must be implemented in a specific inherited wrapper.
     '''
 
     def __init__(self, model_adapter, configuration=None, preload=False):
-        '''The Detection Model constructor
+        '''Detection Model constructor
 
-        Calls the ``ImageModel`` construtor first.
+        It extends the `ImageModel` construtor.
 
         Args:
-            labels(Iterable[str], str, Path): list of labels for detection classes or path to file with them
-            threshold(float): threshold for detections filtering by confidence
-            iou_threshold(float): threshold for NMS filtering
+            model_adapter (ModelAdapter): allows working with the specified executor
+            configuration (dict, optional): it contains values for parameters accepted by specific
+              wrapper (`confidence_threshold`, `labels` etc.) which are set as wrapper attributes
+            preload (bool, optional): a flag whether the model is loaded to device while wrapper
+              initialization. If `preload=False`, the model must be loaded via `load` method before inference
 
         Raises:
-            WrapperError: If loaded model has more than one image inputs
+            WrapperError: if the model has more than 1 image inputs
         '''
+
         super().__init__(model_adapter, configuration, preload)
 
         if not self.image_blob_name:
@@ -66,25 +67,25 @@ class DetectionModel(ImageModel):
         return parameters
 
     def _resize_detections(self, detections, meta):
-        '''Resizes detection bounding boxes according to initial image size
+        '''Resizes detection bounding boxes according to initial image shape.
 
-        Implements resize operations for different image resize types (see ``ImageModel`` class for details).
-        Applies clipping bounding box to original image size.
+        It implements image resizing depending on the set `resize_type`(see `ImageModel` for details).
+        Next, it applies bounding boxes clipping.
 
         Args:
-            detections(List[Detection]): list of detections with coordinates in normalized form
-            meta: meta information with fields `resized_shape` and `original_shape`
+            detections (List[Detection]): list of detections with coordinates in normalized form
+            meta (dict): the input metadata obtained from `preprocess` method
 
         Returns:
-            List of detections fit to initial image (resized and clipped)
+            - list of detections with resized and clipped coordinates fit to initial image
 
         Raises:
-            WrapperError: If model uses custom resize or `resize_type` not set
+            WrapperError: If the model uses custom resize or `resize_type` is not set
         '''
         resized_shape = meta['resized_shape']
         original_shape = meta['original_shape']
 
-        if self.resize_type=='fit_to_window_letterbox':
+        if self.resize_type == 'fit_to_window_letterbox':
             detections = resize_detections_letterbox(detections, original_shape[1::-1], resized_shape[1::-1])
         elif self.resize_type == 'fit_to_window':
             detections = resize_detections_with_aspect_ratio(detections, original_shape[1::-1], resized_shape[1::-1], (self.w, self.h))

--- a/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/detection_model.py
@@ -36,8 +36,8 @@ class DetectionModel(ImageModel):
         Args:
             model_adapter (ModelAdapter): allows working with the specified executor
             configuration (dict, optional): it contains values for parameters accepted by specific
-              wrapper (`confidence_threshold`, `labels` etc.) which are set as wrapper attributes
-            preload (bool, optional): a flag whether the model is loaded to device while wrapper
+              wrapper (`confidence_threshold`, `labels` etc.) which are set as data attributes
+            preload (bool, optional): a flag whether the model is loaded to device while
               initialization. If `preload=False`, the model must be loaded via `load` method before inference
 
         Raises:

--- a/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
@@ -22,25 +22,38 @@ from .utils import RESIZE_TYPES, pad_image, InputTransform
 class ImageModel(Model):
     '''An abstract wrapper for an image-based model
 
-    An image-based model is a model which has one or more inputs with image - 4D tensors with NHWC or NCHW layout.
-    Also it may support additional inputs - 2D tensor.
-    Implements basic preprocessing for image: resizing and aligning to model input.
+    The ImageModel has 1 or more inputs with images - 4D tensors with NHWC or NCHW layout.
+    It may support additional inputs - 2D tensors.
+
+    The ImageModel implements basic preprocessing for an image provided as model input.
+    See `preprocess` description.
+
+    The `postprocess` method must be implemented in a specific inherited wrapper.
 
     Attributes:
-        resize_type(str): one of the preimplemented resize types
-        image_blob_names(List[str]): names of all image-like inputs (4D tensors)
-        image_info_blob_names(List[str]): names of all secondary inputs (2D tensors)
-        image_blob_name(str): name of image input (None, if they are many)
+        image_blob_names (List[str]): names of all image-like inputs (4D tensors)
+        image_info_blob_names (List[str]): names of all secondary inputs (2D tensors)
+        image_blob_name (str): name of the first image input
+        nchw_layout (bool): a flag whether the model input layer has NCHW layout
+        resize_type (str): the type for image resizing (see `RESIZE_TYPE` for info)
+        resize (function): resizing function corresponding to the `resize_type`
+        input_transform (InputTransform): instance of the `InputTransform` for image normalization
     '''
 
     def __init__(self, model_adapter, configuration=None, preload=False):
         '''Image model constructor
 
-        Calls the `Model` constructor first
+        It extends the `Model` constructor.
 
         Args:
-            model_adapter(ModelAdapter): allows working with the specified executor
-            resize_type(str): sets the type for image resizing (see ``RESIZE_TYPE`` for info)
+            model_adapter (ModelAdapter): allows working with the specified executor
+            configuration (dict, optional): it contains values for parameters accepted by specific
+              wrapper (`confidence_threshold`, `labels` etc.) which are set as wrapper attributes
+            preload (bool, optional): a flag whether the model is loaded to device while wrapper
+              initialization. If `preload=False`, the model must be loaded via `load` method before inference
+
+        Raises:
+            WrapperError: if the wrapper failed to define appropriate model input layers for images
         '''
         super().__init__(model_adapter, configuration, preload)
         self.image_blob_names, self.image_info_blob_names = self._get_inputs()
@@ -75,6 +88,15 @@ class ImageModel(Model):
         return parameters
 
     def _get_inputs(self):
+        '''Defines the model input layers for images and additional info.
+
+        Raises:
+            WrapperError: if the wrapper failed to define appropriate model input layers for images
+
+        Returns:
+            - list of input layers names for images
+            - list of input layers names for additional info
+        '''
         image_blob_names, image_info_blob_names = [], []
         for name, metadata in self.inputs.items():
             if len(metadata.shape) == 4:
@@ -90,24 +112,27 @@ class ImageModel(Model):
     def preprocess(self, inputs):
         '''Data preprocess method
 
-        Performs some basic preprocessing with single image:
-        - resizing to net input size
-        - applying tranform orerations: mean and scale values, BGR-RGB conversions
-        - changing layout according to net input layout
+        It performs basic preprocessing of a single image:
+            - Resizes the image to fit the model input size via the defined resize type
+            - Normalizes the image: subtracts means, divides by scales, switch channels BGR-RGB
+            - Changes the image layout according to the model input layout
 
-        Adds the size of initial image and after resizing to metadata as `original_shape` and `resized_shape`
-        correspondenly.
+        Also, it keeps the size of original image and resized one as `original_shape` and `resized_shape`
+        in the metadata dictionary.
 
         Note:
-            This method supports only models with single image input. If model has more image inputs
-            or has additional support inputs, their preprocessing should be implemented in concrete class
+            It supports only models with single image input. If the model has more image inputs or has
+            additional supported inputs, the `preprocess` should be overloaded in a specific model wrapper
 
         Args:
-            inputs: single image as 3D array in HWC layout
+            inputs (ndarray): a single image as 3D array in HWC layout
 
         Returns:
-            - the dict with preprocessed image data
-            - The dict with metadata
+            - the preprocessed image in the following format:
+                {
+                    'input_layer_name': preprocessed_image
+                }
+            - the input metadata, which might be used in `postprocess` method
         '''
         image = inputs
         meta = {'original_shape': image.shape}
@@ -121,8 +146,16 @@ class ImageModel(Model):
         return dict_inputs, meta
 
     def _change_layout(self, image):
+        '''Changes the input image layout to fit the layout of the model input layer.
+
+        Args:
+            inputs (ndarray): a single image as 3D array in HWC layout
+
+        Returns:
+            - the image with layout aligned with the model layout
+        '''
         if self.nchw_layout:
-            image = image.transpose((2, 0, 1))  # Change data layout from HWC to CHW
+            image = image.transpose((2, 0, 1))  # Change layout from HWC to CHW
             image = image.reshape((1, self.c, self.h, self.w))
         else:
             image = image.reshape((1, self.h, self.w, self.c))

--- a/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
@@ -122,7 +122,7 @@ class ImageModel(Model):
 
         Note:
             It supports only models with single image input. If the model has more image inputs or has
-            additional supported inputs, the `preprocess` should be overloaded in a specific model wrapper
+            additional supported inputs, the `preprocess` should be overloaded in a specific model wrapper.
 
         Args:
             inputs (ndarray): a single image as 3D array in HWC layout

--- a/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/image_model.py
@@ -48,12 +48,12 @@ class ImageModel(Model):
         Args:
             model_adapter (ModelAdapter): allows working with the specified executor
             configuration (dict, optional): it contains values for parameters accepted by specific
-              wrapper (`confidence_threshold`, `labels` etc.) which are set as wrapper attributes
-            preload (bool, optional): a flag whether the model is loaded to device while wrapper
+              wrapper (`confidence_threshold`, `labels` etc.) which are set as data attributes
+            preload (bool, optional): a flag whether the model is loaded to device while
               initialization. If `preload=False`, the model must be loaded via `load` method before inference
 
         Raises:
-            WrapperError: if the wrapper failed to define appropriate model input layers for images
+            WrapperError: if the wrapper failed to define appropriate inputs for images
         '''
         super().__init__(model_adapter, configuration, preload)
         self.image_blob_names, self.image_info_blob_names = self._get_inputs()
@@ -88,14 +88,14 @@ class ImageModel(Model):
         return parameters
 
     def _get_inputs(self):
-        '''Defines the model input layers for images and additional info.
+        '''Defines the model inputs for images and additional info.
 
         Raises:
-            WrapperError: if the wrapper failed to define appropriate model input layers for images
+            WrapperError: if the wrapper failed to define appropriate inputs for images
 
         Returns:
-            - list of input layers names for images
-            - list of input layers names for additional info
+            - list of inputs names for images
+            - list of inputs names for additional info
         '''
         image_blob_names, image_info_blob_names = [], []
         for name, metadata in self.inputs.items():
@@ -122,7 +122,7 @@ class ImageModel(Model):
 
         Note:
             It supports only models with single image input. If the model has more image inputs or has
-            additional supported inputs, the `preprocess` should be overloaded in a specific model wrapper.
+            additional supported inputs, the `preprocess` should be overloaded in a specific wrapper.
 
         Args:
             inputs (ndarray): a single image as 3D array in HWC layout
@@ -155,7 +155,7 @@ class ImageModel(Model):
             - the image with layout aligned with the model layout
         '''
         if self.nchw_layout:
-            image = image.transpose((2, 0, 1))  # Change layout from HWC to CHW
+            image = image.transpose((2, 0, 1))  # HWC->CHW
             image = image.reshape((1, self.c, self.h, self.w))
         else:
             image = image.reshape((1, self.h, self.w, self.c))

--- a/demos/common/python/openvino/model_zoo/model_api/models/model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/model.py
@@ -27,7 +27,7 @@ class Model:
     '''An abstract model wrapper
 
     The abstract model wrapper is free from any executor dependencies.
-    It sets the `ModelAdapter` instance with the model read from disk or other place
+    It sets the `ModelAdapter` instance with the provided model
     and defines model inputs/outputs.
 
     Next, it loads the provided configuration variables and sets it as wrapper attributes.
@@ -109,7 +109,7 @@ class Model:
     def parameters(cls):
         '''Defines the description and type of configurable data parameters for the wrapper.
 
-        See `types.py` to observe available types of the data parameter. For each parameter
+        See `types.py` to find available types of the data parameter. For each parameter
         the type, default value and description must be provided.
 
         The example of possible data parameter:
@@ -127,7 +127,7 @@ class Model:
 
     def _load_config(self, config):
         '''Reads the configuration and creates data attributes
-           by filling the wrapper parameters by values from configuration.
+           by setting the wrapper parameters with values from configuration.
 
         Args:
             config (dict): the dictionary with keys to be set as data attributes
@@ -200,7 +200,7 @@ class Model:
             meta (dict): the input metadata obtained from `preprocess` method
 
         Returns:
-            - post-processed data in the format defined by wrapper
+            - postprocessed data in the format defined by wrapper
         '''
         raise NotImplementedError
 
@@ -250,7 +250,7 @@ class Model:
             inputs: raw input data, the data type is defined by wrapper
 
         Returns:
-            - post-processed data in the format defined by wrapper
+            - postprocessed data in the format defined by wrapper
             - the input metadata obtained from `preprocess` method
         '''
         dict_data, input_meta = self.preprocess(inputs)

--- a/demos/common/python/openvino/model_zoo/model_api/models/model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/model.py
@@ -28,7 +28,7 @@ class Model:
 
     The abstract model wrapper is free from any executor dependencies.
     It sets the `ModelAdapter` instance with the model read from disk or other place
-    and defines model input/output layers.
+    and defines model inputs/outputs.
 
     Next, it loads the provided configuration variables and sets it as wrapper attributes.
     The keys of the configuration dictionary should be presented in the `parameters` method.
@@ -44,8 +44,8 @@ class Model:
     Attributes:
         logger (Logger): instance of the Logger
         model_adapter (ModelAdapter): allows working with the specified executor
-        inputs (dict): keeps the model input layers names and `Metadata` structure for each one
-        outputs (dict): keeps the model output layers names and `Metadata` structure for each one
+        inputs (dict): keeps the model inputs names and `Metadata` structure for each one
+        outputs (dict): keeps the model outputs names and `Metadata` structure for each one
         model_loaded (bool): a flag whether the model is loaded to device
     '''
 
@@ -57,8 +57,8 @@ class Model:
         Args:
             model_adapter (ModelAdapter): allows working with the specified executor
             configuration (dict, optional): it contains values for parameters accepted by specific
-              wrapper (`confidence_threshold`, `labels` etc.) which are set as wrapper attributes
-            preload (bool, optional): a flag whether the model is loaded to device while wrapper
+              wrapper (`confidence_threshold`, `labels` etc.) which are set as data attributes
+            preload (bool, optional): a flag whether the model is loaded to device while
               initialization. If `preload=False`, the model must be loaded via `load` method before inference
 
         Raises:
@@ -205,17 +205,16 @@ class Model:
         raise NotImplementedError
 
     def _check_io_number(self, number_of_inputs, number_of_outputs):
-        '''Checks whether the number of input/output model layers is matched
-           with supported one by wrapper.
+        '''Checks whether the number of model inputs/outputs is supported.
 
         Args:
-            number_of_inputs (int, Tuple(int)): number of input layers supported by wrapper.
+            number_of_inputs (int, Tuple(int)): number of inputs supported by wrapper.
               Use -1 to omit the check
-            number_of_outputs (int, Tuple(int)): number of output layers supported by wrapper.
+            number_of_outputs (int, Tuple(int)): number of outputs supported by wrapper.
               Use -1 to omit the check
 
         Raises:
-            WrapperError: if the model has unsupported by wrapper number of input/output layers
+            WrapperError: if the model has unsupported number of inputs/outputs
         '''
         if not isinstance(number_of_inputs, tuple):
             if len(self.inputs) != number_of_inputs and number_of_inputs != -1:
@@ -294,7 +293,7 @@ class Model:
         self.model_adapter.await_any()
 
     def log_layers_info(self):
-        '''Prints the shape, precision and layout for all model input/output layers.
+        '''Prints the shape, precision and layout for all model inputs/outputs.
         '''
         for name, metadata in self.inputs.items():
             self.logger.info('\tInput layer: {}, shape: {}, precision: {}, layout: {}'.format(

--- a/demos/common/python/openvino/model_zoo/model_api/models/model.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/model.py
@@ -254,9 +254,9 @@ class Model:
             - post-processed data in the format defined by wrapper
             - the input metadata obtained from `preprocess` method
         '''
-        dict_data, meta = self.preprocess(inputs)
+        dict_data, input_meta = self.preprocess(inputs)
         raw_result = self.infer_sync(dict_data)
-        return self.postprocess(raw_result, meta), meta
+        return self.postprocess(raw_result, input_meta), input_meta
 
     def load(self, force=False):
         if not self.model_loaded or force:
@@ -294,7 +294,7 @@ class Model:
         self.model_adapter.await_any()
 
     def log_layers_info(self):
-        '''Prints for all model input/output layers the shape, precision and layout.
+        '''Prints the shape, precision and layout for all model input/output layers.
         '''
         for name, metadata in self.inputs.items():
             self.logger.info('\tInput layer: {}, shape: {}, precision: {}, layout: {}'.format(


### PR DESCRIPTION
Update the outdated docstrings for abstract classes in Python Model API with the latest state of wrappers. 
Docstrings might be useful for online documentation as well as someone uses `help()` in Python