### PR TITLE
AC: fix extend import error for soundfile

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/data_readers/audio_readers.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/data_readers/audio_readers.py
@@ -25,7 +25,7 @@ from ..utils import contains_any, UnsupportedPackage
 
 try:
     import soundfile as sf
-except ImportError as import_error:
+except (ImportError, OSError) as import_error:
     sf = UnsupportedPackage('soundfile', import_error.msg)
 
 


### PR DESCRIPTION
update error catching for soundfile

on ubuntu, soundfile requires install additional lib and failed with oserror if not installed