### PR TITLE
action_recognition_demo.py: use AsyncInferQueue

### DIFF
--- a/demos/action_recognition_demo/python/action_recognition_demo/models.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/models.py
@@ -115,10 +115,8 @@ class IEModel:
 
     def wait_request(self, req_id):
         self.infer_queue.wait_all()
-        try:
-            return self.outputs.pop(req_id)
-        except KeyError:
-            return None
+        return self.outputs.pop(req_id, None)
+
 
 class DummyDecoder:
     def __init__(self, num_requests=2):

--- a/demos/action_recognition_demo/python/action_recognition_demo/models.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/models.py
@@ -114,7 +114,7 @@ class IEModel:
         self.infer_queue.start_async(input_data, req_id)
 
     def wait_request(self, req_id):
-        self.infer_queue.wait_all()
+        self.infer_queue[req_id].wait()
         return self.outputs.pop(req_id, None)
 
 

--- a/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
@@ -57,16 +57,6 @@ class PipelineStep:
 
     def join(self):
         self.input_queue.put(Signal.STOP)
-        # print("\n")
-        # print("\n")
-        # print("thread")
-        # print("\n")
-        # print("\n")
-        # print(self._thread)
-        # print("\n")
-        # print("\n")
-        #if self._thread is not None:
-            #print("not None")
         self._thread.join()
         self._thread = None
         self.working = False

--- a/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
@@ -57,8 +57,17 @@ class PipelineStep:
 
     def join(self):
         self.input_queue.put(Signal.STOP)
-        if self._thread is not None:
-            self._thread.join()
+        # print("\n")
+        # print("\n")
+        # print("thread")
+        # print("\n")
+        # print("\n")
+        # print(self._thread)
+        # print("\n")
+        # print("\n")
+        #if self._thread is not None:
+            #print("not None")
+        self._thread.join()
         self._thread = None
         self.working = False
 

--- a/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
@@ -57,7 +57,7 @@ class PipelineStep:
 
     def join(self):
         self.input_queue.put(Signal.STOP)
-        if(self._thread!=None):
+        if(self._thread is not None):
             self._thread.join()
         self._thread = None
         self.working = False

--- a/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
@@ -57,7 +57,8 @@ class PipelineStep:
 
     def join(self):
         self.input_queue.put(Signal.STOP)
-        self._thread.join()
+        if(self._thread!=None):
+            self._thread.join()
         self._thread = None
         self.working = False
 

--- a/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/pipeline.py
@@ -57,7 +57,7 @@ class PipelineStep:
 
     def join(self):
         self.input_queue.put(Signal.STOP)
-        if(self._thread is not None):
+        if self._thread is not None:
             self._thread.join()
         self._thread = None
         self.working = False

--- a/demos/action_recognition_demo/python/action_recognition_demo/steps.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/steps.py
@@ -37,7 +37,7 @@ def run_pipeline(capture, model_type, model, render_fn, raw_output, seq_size=16,
         pipeline.add_step("I3DRGB", I3DRGBModelStep(model[0], seq_size, 256, 224), parallel=False)
 
     pipeline.add_step("Render", RenderStep(render_fn, raw_output, fps=fps), parallel=True)
-    
+
     pipeline.run()
     pipeline.close()
     pipeline.print_statistics()

--- a/demos/action_recognition_demo/python/action_recognition_demo/steps.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/steps.py
@@ -102,7 +102,8 @@ class EncoderStep(PipelineStep):
         self.async_model = AsyncWrapper(self.encoder, self.encoder.num_requests)
 
     def __del__(self):
-        self.encoder.infer_queue[0].cancel()
+        for ireq in self.encoder.infer_queue:
+            ireq.cancel()
 
     def process(self, frame):
         preprocessed = preprocess_frame(frame)
@@ -125,7 +126,8 @@ class DecoderStep(PipelineStep):
         self._embeddings = deque(maxlen=self.sequence_size)
 
     def __del__(self):
-        self.decoder.infer_queue[0].cancel()
+        for ireq in self.decoder.infer_queue:
+            ireq.cancel()
 
     def process(self, item):
         if item is None:

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo/common.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo/common.py
@@ -80,7 +80,4 @@ class IEModel:  # pylint: disable=too-few-public-methods
     def wait_request(self, req_id):
         """Waits for the model output by the specified request ID"""
         self.infer_queue.wait_all()
-        try:
-            return self.outputs.pop(req_id)
-        except KeyError:
-            return None
+        return self.outputs.pop(req_id, None)

--- a/demos/gesture_recognition_demo/python/gesture_recognition_demo/common.py
+++ b/demos/gesture_recognition_demo/python/gesture_recognition_demo/common.py
@@ -68,8 +68,9 @@ class IEModel:  # pylint: disable=too-few-public-methods
     def infer(self, data):
         """Runs model on the specified input"""
 
-        self.async_infer(data, 0)
-        return self.wait_request(0)
+        input_data = {self.input_tensor_name: data}
+        self.infer_queue[0].infer(input_data)
+        return self.infer_queue[0].get_tensor(self.output_tensor_name).data[:]
 
     def async_infer(self, data, req_id):
         """Requests model inference for the specified input"""
@@ -79,5 +80,5 @@ class IEModel:  # pylint: disable=too-few-public-methods
 
     def wait_request(self, req_id):
         """Waits for the model output by the specified request ID"""
-        self.infer_queue.wait_all()
+        self.infer_queue[req_id].wait()
         return self.outputs.pop(req_id, None)


### PR DESCRIPTION
The PR fixes two separate issues with action_recognition_demo:
- The usage of AsyncInferQueue instead of list of inference requests prevents the demo hanging for both CPU and GPU devices
- Adds the cancelation of all encoder and decoder infer requests before the demo ends. It helps to avoid accidental crashes on CI, when the demo has already finished inference