### PR TITLE
Fix imagecodecs version for py>=3.8

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -8,7 +8,7 @@ scikit-image>=0.17.2
 # there is issue with resolving versions for python3.6 and python3.7, pin to specific version of lib
 imagecodecs~=2020.5.30;python_version<"3.7"
 imagecodecs~=2021.11.20;python_version=="3.7"
-imagecodecs;python_version>="3.8"
+imagecodecs~=2022.2.22;python_version>="3.8"
 
 # reid
 # python3.6 dropped in v1.0


### PR DESCRIPTION
continuation of https://github.com/openvinotoolkit/open_model_zoo/pull/3408  
This helped to prevent dependency resolution issues that suddenly started to happen in OpenVINO precommits: https://openvino-ci.intel.com/job/private-ci/job/ie/job/e2e-tests-windows-pip-conflicts/26440