### PR TITLE
Fix scikit-image versions

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -3,7 +3,8 @@ tqdm>=4.54.1
 
 # image reading and preprocessing
 # note: python 3.6 wheels is not available since 0.18
-scikit-image>=0.17.2
+scikit-image~=0.17.2;python_version<"3.7"
+scikit-image>=0.19.2;python_version>="3.7"
 
 # there is issue with resolving versions for python3.6 and python3.7, pin to specific version of lib
 imagecodecs~=2020.5.30;python_version<"3.7"


### PR DESCRIPTION
forgot to test it for python 3.9, so previous changes were not enough =(  
continuation of https://github.com/openvinotoolkit/open_model_zoo/pull/3413  
passed run: https://openvino-ci.intel.com/job/private-ci/job/ie/job/e2e-tests-windows-pip-conflicts/26626/console