### PR TITLE
action_recognition_demo.py: call cancel for infer requests in IEModel

### DIFF
--- a/demos/action_recognition_demo/python/action_recognition_demo/models.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/models.py
@@ -117,6 +117,10 @@ class IEModel:
         self.infer_queue[req_id].wait()
         return self.outputs.pop(req_id, None)
 
+    def cancel(self):
+        for ireq in self.infer_queue:
+            ireq.cancel()
+
 
 class DummyDecoder:
     def __init__(self, num_requests=2):
@@ -133,3 +137,6 @@ class DummyDecoder:
     def wait_request(self, req_id):
         assert req_id in self.requests
         return self.requests.pop(req_id)
+
+    def cancel(self):
+        pass

--- a/demos/action_recognition_demo/python/action_recognition_demo/steps.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/steps.py
@@ -102,8 +102,7 @@ class EncoderStep(PipelineStep):
         self.async_model = AsyncWrapper(self.encoder, self.encoder.num_requests)
 
     def __del__(self):
-        for ireq in self.encoder.infer_queue:
-            ireq.cancel()
+        self.encoder.cancel()
 
     def process(self, frame):
         preprocessed = preprocess_frame(frame)
@@ -126,8 +125,7 @@ class DecoderStep(PipelineStep):
         self._embeddings = deque(maxlen=self.sequence_size)
 
     def __del__(self):
-        for ireq in self.decoder.infer_queue:
-            ireq.cancel()
+        self.decoder.cancel()
 
     def process(self, item):
         if item is None:


### PR DESCRIPTION
Fixes `AttributeError: 'DummyDecoder' object has no attribute 'infer_queue'`