### PR TITLE
 Fix NaN issue for exp() in softmax function

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/models/utils.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/utils.py
@@ -209,5 +209,5 @@ def nms(x1, y1, x2, y2, scores, thresh, include_boundaries=False, keep_top_k=Non
 
 
 def softmax(logits, axis=None):
-    exp = np.exp(logits)
+    exp = np.exp(logits - np.max(logits))
     return exp / np.sum(exp, axis=axis)


### PR DESCRIPTION
Fixing a issue regarding 86756.
This change would enhance numerical stability by preventing NaN output from softmax by shifting input range of exp() input.