### PR TITLE
Fix NaN issue for exp() in softmax function (for master)

### DIFF
--- a/demos/common/python/openvino/model_zoo/model_api/models/utils.py
+++ b/demos/common/python/openvino/model_zoo/model_api/models/utils.py
@@ -209,5 +209,5 @@ def nms(x1, y1, x2, y2, scores, thresh, include_boundaries=False, keep_top_k=Non
 
 
 def softmax(logits, axis=None, keepdims=False):
-    exp = np.exp(logits)
+    exp = np.exp(logits - np.max(logits))
     return exp / np.sum(exp, axis=axis, keepdims=keepdims)


### PR DESCRIPTION
* Improve numerical stability of softmax function implemented by numpy exp().
* Same fix with #3489 which is targeting releases/2022/SCv1.1