### PR TITLE
Fixing headers and links in Datasets.

### DIFF
--- a/data/datasets.md
+++ b/data/datasets.md
@@ -11,18 +11,18 @@ More detailed information about using predefined configuration files you can fin
 
 ## ImageNet
 
-### How download dataset
+### Download dataset
 
-To download images from ImageNet, you need to have an account and agree to the Terms of Access. Follow the steps below:
-1. Go to the [ImageNet](http://www.image-net.org/) homepage
-2. If you have an account, click `Login`. Otherwise, click `Signup` in the right upper corner, provide your data, and wait for a confirmation email
-3. Log in after receiving the confirmation email and go to the `Download` tab
-4. Select `Download Original Images`
-5. You will be redirected to the Terms of Access page. If you agree to the Terms, continue by clicking Agree and Sign
-6. Click one of the links in the `Download as one tar file` section to select it
-7. Unpack archive
+To download images from ImageNet, you need to have an account and agree to the Terms of Access.
+1. Go to the [ImageNet home page](http://www.image-net.org/).
+2. If you have an account, click `Login`. Otherwise, click `Signup` in the right upper corner, provide your data, and wait for a confirmation email.
+3. Log in after receiving the confirmation email and go to the `Download` tab.
+4. Select `Download Original Images`.
+5. You will be redirected to the Terms of Access page. If you agree to the Terms, continue by clicking Agree and Sign.
+6. Click one of the links in the `Download as one tar file` section to select it.
+7. Unpack archive.
 
-To download annotation files, you need to follow the steps below:
+To download annotation files:
 * `val.txt`
   1. Download [archive](http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz)
   2. Unpack `val.txt` from the archive `caffe_ilsvrc12.tar.gz`
@@ -45,11 +45,12 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## Common Objects in Context (COCO)
 
-### How download dataset
+### Download dataset
 
-To download COCO dataset, you need to follow the steps below:
-1. Download [2017 Val images](http://images.cocodataset.org/zips/val2017.zip) and [2017 Train/Val annotations](http://images.cocodataset.org/annotations/annotations_trainval2017.zip)
-2. Unpack archives
+1. Go to the [COCO home page](https://cocodataset.org/#home).
+2. Click `Dataset` in the menu and select `Download`.
+3. Download [2017 Val images](http://images.cocodataset.org/zips/val2017.zip) and [2017 Train/Val annotations](http://images.cocodataset.org/annotations/annotations_trainval2017.zip).
+4. Unpack archives.
 
 ### Files layout
 
@@ -70,14 +71,13 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## WIDER FACE
 
-### How download dataset
+### Download dataset
 
-To download WIDER Face dataset, you need to follow the steps below:
-1. Go to the [WIDER FACE](http://shuoyang1213.me/WIDERFACE/) website
-2. Go to the `Download` section
-3. Select `WIDER Face Validation images` and download them from [Google Drive](https://drive.google.com/file/d/0B6eKvaijfFUDd3dIRmpvSk8tLUk/view) or [Tencent Drive](https://share.weiyun.com/5ot9Qv1)
-4. Select and download `Face annotations`
-5. Unpack archives
+1. Go to the [WIDER FACE home page](http://shuoyang1213.me/WIDERFACE/).
+2. Go to the `Download` section.
+3. Select `WIDER Face Validation images` and download them from [Google Drive](https://drive.google.com/file/d/0B6eKvaijfFUDd3dIRmpvSk8tLUk/view) or [Tencent Drive](https://share.weiyun.com/5ot9Qv1).
+4. Select and download `Face annotations`.
+5. Unpack archives.
 
 ### Files layout
 
@@ -92,15 +92,14 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 * `wider` used for evaluation models on WIDER Face dataset where the face is the first class. (model example: [mtcnn](../models/public/mtcnn/README.md))
 * `wider_without_bkgr` used for evaluation models on WIDER Face dataset where the face is class zero. (model examples: [mobilefacedet-v1-mxnet](../models/public/mobilefacedet-v1-mxnet/README.md))
 
-## [Visual Object Classes Challenge 2012 (VOC2012)](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/)
+## Visual Object Classes Challenge 2012 (VOC2012)
 
-### How download dataset
+### Download dataset
 
-To download VOC2012 dataset, you need to follow the steps below:
-1. Go to the [VOC2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) website
-2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/#devkit) section
-3. Select [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar) and download archive
-4. Unpack archive
+1. Go to the [VOC2012 home page](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/).
+2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/#devkit) section.
+3. Click [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar) to download archive.
+4. Unpack archive.
 
 ### Files layout
 
@@ -121,13 +120,12 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## Visual Object Classes Challenge 2007 (VOC2007)
 
-### How download dataset
+### Download dataset
 
-To download VOC2007 dataset, you need to follow the steps below:
-1. Go to the [VOC2007](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/) website
-2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/#devkit) section
-3. Select [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar) and download archive
-4. Unpack archive
+1. Go to the [VOC2007 website](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/).
+2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/#devkit) section.
+3. Click [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar) to download archive.
+4. Unpack archive.
 
 ### Files layout
 
@@ -145,15 +143,15 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## SYGData0829
 
-### How download dataset
+### Download dataset
 
-To download SYGData0829 dataset, you need to follow the steps below:
-1. Go to the [github repo](https://github.com/ermubuzhiming/OMZ-files-download/releases/tag/v1-ly)
-2. Select [SYGData0829.z01](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z01)
-Select ['SYGData0829.z02'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z02)
-Select ['SYGData0829.z03'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z03)
-Select ['SYGData0829.zip'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.zip)
-3. Unpack archive
+1. Go to the [SYGData0829 Github repository](https://github.com/ermubuzhiming/OMZ-files-download/releases/tag/v1-ly).
+2. Select:
+    - [SYGData0829.z01](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z01),
+    - ['SYGData0829.z02'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z02),
+    - ['SYGData0829.z03'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z03),
+    - ['SYGData0829.zip'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.zip).
+3. Unpack archive.
 
 ### Files layout
 * `SYGData0829/dataset_format_VOC2007` - directory containing annotations, images and image sets files directories
@@ -167,11 +165,12 @@ Select ['SYGData0829.zip'](https://github.com/ermubuzhiming/OMZ-files-download/r
 
 ## PASCAL-S
 
-### How download dataset
+### Download dataset
 
-To download PASCAL-S dataset, you need to follow the steps below:
-1. Download [archive](http://cbs.ic.gatech.edu/salobj/download/salObj.zip) from the [The Secrets of Salient Object Segmentation](http://cbs.ic.gatech.edu/salobj/) website
-2. Unpack archive
+1. Go to the [The Secrets of Salient Object Segmentation home page](http://cbs.ic.gatech.edu/salobj/).
+2. Go to the `Download` section.
+3. Click [Dataset & Code](http://cbs.ic.gatech.edu/salobj/download/salObj.zip) to download archive.
+4. Unpack archive.
 
 ### Files layout
 
@@ -186,11 +185,12 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## CoNLL2003 Named Entity Recognition
 
-### How download dataset
+See the [CoNLL2003 Named Entity Recognition website](https://www.aclweb.org/anthology/W03-0419/).
 
-To download CoNLL2003 dataset, you need to follow the steps below:
-1. Download [archive](https://data.deepai.org/conll2003.zip) from the [CoNLL 2003 (English) Dataset](https://deepai.org/dataset/conll-2003-english) page in the [DeepAI Datasets](https://deepai.org/datasets) website
-2. Unpack archive
+### Download dataset
+
+1. Download [archive](https://data.deepai.org/conll2003.zip) from the [CoNLL 2003 (English) Dataset](https://deepai.org/dataset/conll-2003-english) page in the [DeepAI Datasets](https://deepai.org/datasets) website.
+2. Unpack archive.
 
 ### Files layout
 
@@ -203,11 +203,11 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## MRL Eye
 
-### How download dataset
+### Download dataset
 
-To download MRL Eye dataset, you need to follow the steps below:
-1. Download [archive](http://mrl.cs.vsb.cz/data/eyedataset/mrlEyes_2018_01.zip) from the [MRL Eye Dataset](http://mrl.cs.vsb.cz/eyedataset) website
-2. Unpack archive
+1. Go to the [MRL Eye Dataset website](http://mrl.cs.vsb.cz/eyedataset).
+2. Download [archive](http://mrl.cs.vsb.cz/data/eyedataset/mrlEyes_2018_01.zip).
+3. Unpack archive.
 
 ### Files layout
 
@@ -220,16 +220,15 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## Labeled Faces in the Wild (LFW)
 
-### How download dataset
+### Download dataset
 
-To download LFW dataset, you need to follow the steps below:
-1. Go to the [Labeled Faces in the Wild](http://vis-www.cs.umass.edu/lfw/) website
-2. Go to the `Download the database` section
-3. Select `All images as gzipped tar file` and download archive
-4. Unpack archive
-5. Go to the `Training, Validation, and Testing` section
-6. Select `pairs.txt` and download pairs file
-7. Download [lfw_landmark](https://raw.githubusercontent.com/clcarwin/sphereface_pytorch/master/data/lfw_landmark.txt) file
+1. Go to the [Labeled Faces in the Wild home page](http://vis-www.cs.umass.edu/lfw/).
+2. Go to the `Download the database` section.
+3. Click `All images as gzipped tar file` to download archive.
+4. Unpack archive.
+5. Go to the `Training, Validation, and Testing` section.
+6. Select `pairs.txt` and download pairs file.
+7. Download [lfw_landmark](https://raw.githubusercontent.com/clcarwin/sphereface_pytorch/master/data/lfw_landmark.txt) file.
 
 ### Files layout
 
@@ -246,11 +245,13 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ## NYU Depth Dataset V2
 
-### How download dataset
+See the the [NYU Depth Dataset V2 website](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html).
 
-To download NYU Depth Dataset V2 preprocessed data stored in HDF5 format, you need to follow the steps below:
-1. Download [archive](http://datasets.lids.mit.edu/fastdepth/data/nyudepthv2.tar.gz) from the [website](http://datasets.lids.mit.edu/fastdepth/data/)
-2. Unpack archive
+### Download dataset
+
+To download NYU Depth Dataset V2 preprocessed data stored in HDF5 format:
+1. Download [archive](http://datasets.lids.mit.edu/fastdepth/data/nyudepthv2.tar.gz) from the [website](http://datasets.lids.mit.edu/fastdepth/data/).
+2. Unpack archive.
 
 ### Files layout
 
@@ -262,7 +263,7 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
         * `images` - directory with converted images
         * `depth` -  directory with depth maps
 
-Note: If dataset is used in the first time, please set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use `convert_annotation` command line interface:
+Note: If dataset is used in the first time, set `allow_convert_data: True` in annotation conversion parameters for this dataset in `dataset_definitions.yml`  or use `convert_annotation` command line interface:
 
 ```sh
 convert_annotation nyu_depth_v2 --data_dir <DATASET_DIR>/nyudepthv2/val/official --allow_convert_data True

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -9,7 +9,7 @@ Each dataset description consists of the following sections:
 
 More detailed information about using predefined configuration files you can find [here](../tools/accuracy_checker/configs/README.md).
 
-## [ImageNet](http://image-net.org)
+## ImageNet
 
 ### How download dataset
 
@@ -39,16 +39,16 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 * `val15.txt` - annotation file used for ILSVRC 2015
 
 ### Datasets in dataset_definitions.yml
-* `imagenet_1000_classes` used for evaluation models trained on ILSVRC 2012 dataset with 1000 classes. (model examples: [`alexnet`](../models/public/alexnet/README.md), [`vgg16`](../models/public/vgg16/README.md))
-* `imagenet_1000_classes_2015` used for evaluation models trained on ILSVRC 2015 dataset with 1000 classes. (model examples: [`se-resnet-50`](../models/public/se-resnet-50/README.md), [`se-resnext-50`](../models/public/se-resnext-50/README.md))
-* `imagenet_1001_classes` used for evaluation models trained on ILSVRC 2012 dataset with 1001 classes (background label + original labels). (model examples: [`googlenet-v2-tf`](../models/public/googlenet-v2-tf/README.md), [`resnet-50-tf`](../models/public/resnet-50-tf/README.md))
+* `imagenet_1000_classes` used for evaluation models trained on ILSVRC 2012 dataset with 1000 classes. (model examples: [alexnet](../models/public/alexnet/README.md), [vgg16](../models/public/vgg16/README.md))
+* `imagenet_1000_classes_2015` used for evaluation models trained on ILSVRC 2015 dataset with 1000 classes. (model examples: [se-resnet-50](../models/public/se-resnet-50/README.md), [se-resnext-50](../models/public/se-resnext-50/README.md))
+* `imagenet_1001_classes` used for evaluation models trained on ILSVRC 2012 dataset with 1001 classes (background label + original labels). (model examples: [googlenet-v2-tf](../models/public/googlenet-v2-tf/README.md), [resnet-50-tf](../models/public/resnet-50-tf/README.md))
 
-## [Common Objects in Context (COCO)](https://cocodataset.org/#home)
+## Common Objects in Context (COCO)
 
 ### How download dataset
 
 To download COCO dataset, you need to follow the steps below:
-1. Download [`2017 Val images`](http://images.cocodataset.org/zips/val2017.zip) and [`2017 Train/Val annotations`](http://images.cocodataset.org/annotations/annotations_trainval2017.zip)
+1. Download [2017 Val images](http://images.cocodataset.org/zips/val2017.zip) and [2017 Train/Val annotations](http://images.cocodataset.org/annotations/annotations_trainval2017.zip)
 2. Unpack archives
 
 ### Files layout
@@ -62,13 +62,13 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ### Datasets in dataset_definitions.yml
 * `ms_coco_mask_rcnn` used for evaluation models trained on COCO dataset for object detection and instance segmentation tasks. Background label + label map with 80 public available object categories are used. Annotations are saved in order of ascending image ID.
-* `ms_coco_detection_91_classes` used for evaluation models trained on COCO dataset for object detection tasks. Background label + label map with 80 public available object categories are used (original indexing to 91 categories is preserved. You can find more information about object categories labels [here](https://tech.amikelive.com/node-718/what-object-categories-labels-are-in-coco-dataset/)). Annotations are saved in order of ascending image ID. (model examples: [`faster_rcnn_resnet50_coco`](../models/public/faster_rcnn_resnet50_coco/README.md), [`ssd_mobilenet_v1_coco`](../models/public/ssd_mobilenet_v1_coco/README.md))
-* `ms_coco_detection_80_class_with_background` used for evaluation models trained on COCO dataset for object detection tasks. Background label + label map with 80 public available object categories are used. Annotations are saved in order of ascending image ID. (model examples: [`faster-rcnn-resnet101-coco-sparse-60-0001`](../models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/README.md), [`ssd-resnet34-1200-onnx`](../models/public/ssd-resnet34-1200-onnx/README.md))
-* `ms_coco_detection_80_class_without_background` used for evaluation models trained on COCO dataset for object detection tasks. Label map with 80 public available object categories is used. Annotations are saved in order of ascending image ID. (model examples: [`ctdet_coco_dlav0_512`](../models/public/ctdet_coco_dlav0_512/README.md), [`yolo-v3-tf`](../models/public/yolo-v3-tf/README.md))
-* `ms_coco_keypoints` used for evaluation models trained on COCO dataset for human pose estimation tasks. Each annotation stores multiple keypoints for one image. (model examples: [`human-pose-estimation-0001`](../models/intel/human-pose-estimation-0001/README.md))
-* `ms_coco_single_keypoints` used for evaluation models trained on COCO dataset for human pose estimation tasks. Each annotation stores single keypoints for image, so several annotation can be associated to one image. (model examples: [`single-human-pose-estimation-0001`](../models/public/single-human-pose-estimation-0001/README.md))
+* `ms_coco_detection_91_classes` used for evaluation models trained on COCO dataset for object detection tasks. Background label + label map with 80 public available object categories are used (original indexing to 91 categories is preserved. You can find more information about object categories labels [here](https://tech.amikelive.com/node-718/what-object-categories-labels-are-in-coco-dataset/)). Annotations are saved in order of ascending image ID. (model examples: [faster_rcnn_resnet50_coco](../models/public/faster_rcnn_resnet50_coco/README.md), [ssd_mobilenet_v1_coco](../models/public/ssd_mobilenet_v1_coco/README.md))
+* `ms_coco_detection_80_class_with_background` used for evaluation models trained on COCO dataset for object detection tasks. Background label + label map with 80 public available object categories are used. Annotations are saved in order of ascending image ID. (model examples: [faster-rcnn-resnet101-coco-sparse-60-0001](../models/intel/faster-rcnn-resnet101-coco-sparse-60-0001/README.md), [ssd-resnet34-1200-onnx](../models/public/ssd-resnet34-1200-onnx/README.md))
+* `ms_coco_detection_80_class_without_background` used for evaluation models trained on COCO dataset for object detection tasks. Label map with 80 public available object categories is used. Annotations are saved in order of ascending image ID. (model examples: [ctdet_coco_dlav0_512](../models/public/ctdet_coco_dlav0_512/README.md), [yolo-v3-tf](../models/public/yolo-v3-tf/README.md))
+* `ms_coco_keypoints` used for evaluation models trained on COCO dataset for human pose estimation tasks. Each annotation stores multiple keypoints for one image. (model examples: [human-pose-estimation-0001](../models/intel/human-pose-estimation-0001/README.md))
+* `ms_coco_single_keypoints` used for evaluation models trained on COCO dataset for human pose estimation tasks. Each annotation stores single keypoints for image, so several annotation can be associated to one image. (model examples: [single-human-pose-estimation-0001](../models/public/single-human-pose-estimation-0001/README.md))
 
-## [WIDER FACE](http://shuoyang1213.me/WIDERFACE/)
+## WIDER FACE
 
 ### How download dataset
 
@@ -89,8 +89,8 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
     * `wider_face_val_bbx_gt.txt` - annotation file
 
 ### Datasets in dataset_definitions.yml
-* `wider` used for evaluation models on WIDER Face dataset where the face is the first class. (model example: [`mtcnn`](../models/public/mtcnn/README.md))
-* `wider_without_bkgr` used for evaluation models on WIDER Face dataset where the face is class zero. (model examples: [`mobilefacedet-v1-mxnet`](../models/public/mobilefacedet-v1-mxnet/README.md))
+* `wider` used for evaluation models on WIDER Face dataset where the face is the first class. (model example: [mtcnn](../models/public/mtcnn/README.md))
+* `wider_without_bkgr` used for evaluation models on WIDER Face dataset where the face is class zero. (model examples: [mobilefacedet-v1-mxnet](../models/public/mobilefacedet-v1-mxnet/README.md))
 
 ## [Visual Object Classes Challenge 2012 (VOC2012)](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/)
 
@@ -98,8 +98,8 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 To download VOC2012 dataset, you need to follow the steps below:
 1. Go to the [VOC2012](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) website
-2. Go to the [`Development Kit`](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/#devkit) section
-3. Select [`Download the training/validation data`](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar) and download archive
+2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/#devkit) section
+3. Select [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar) and download archive
 4. Unpack archive
 
 ### Files layout
@@ -116,17 +116,17 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ### Datasets in dataset_definitions.yml
 * `VOC2012` used for evaluation models on VOC2012 dataset for object detection task. Background label + label map with 20 object categories are used.
-* `VOC2012_without_background` used for evaluation models on VOC2012 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [`yolo-v2-ava-0001`](../models/intel/yolo-v2-ava-0001/README.md), [`yolo-v2-tiny-ava-0001`](../models/intel/yolo-v2-tiny-ava-0001/README.md))
-* `VOC2012_Segmentation` used for evaluation models on VOC2012 dataset for segmentation tasks. Background label + label map with 20 object categories are used.(model examples: [`deeplabv3`](../models/public/deeplabv3/README.md))
+* `VOC2012_without_background` used for evaluation models on VOC2012 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [yolo-v2-ava-0001](../models/intel/yolo-v2-ava-0001/README.md), [yolo-v2-tiny-ava-0001](../models/intel/yolo-v2-tiny-ava-0001/README.md))
+* `VOC2012_Segmentation` used for evaluation models on VOC2012 dataset for segmentation tasks. Background label + label map with 20 object categories are used.(model examples: [deeplabv3](../models/public/deeplabv3/README.md))
 
-## [Visual Object Classes Challenge 2007 (VOC2007)](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/)
+## Visual Object Classes Challenge 2007 (VOC2007)
 
 ### How download dataset
 
 To download VOC2007 dataset, you need to follow the steps below:
 1. Go to the [VOC2007](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/) website
-2. Go to the [`Development Kit`](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/#devkit) section
-3. Select [`Download the training/validation data`](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar) and download archive
+2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/#devkit) section
+3. Select [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar) and download archive
 4. Unpack archive
 
 ### Files layout
@@ -140,16 +140,16 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
         * `Main/test.txt` - image sets file for detection tasks
 
 ### Datasets in dataset_definitions.yml
-* `VOC2007_detection` used for evaluation models on VOC2007 dataset for object detection task. Background label + label map with 20 object categories are used. (model examples: [`mobilenet-ssd`](../models/public/mobilenet-ssd/README.md), [`ssd300`](../models/public/ssd300/README.md))
-* `VOC2007_detection_no_bkgr` used for evaluation models on VOC2007 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [`yolo-v1-tiny-tf`](../models/public/yolo-v1-tiny-tf/README.md))
+* `VOC2007_detection` used for evaluation models on VOC2007 dataset for object detection task. Background label + label map with 20 object categories are used. (model examples: [mobilenet-ssd](../models/public/mobilenet-ssd/README.md), [ssd300](../models/public/ssd300/README.md))
+* `VOC2007_detection_no_bkgr` used for evaluation models on VOC2007 dataset for object detection tasks. Label map with 20 object categories is used.(model examples: [yolo-v1-tiny-tf](../models/public/yolo-v1-tiny-tf/README.md))
 
-## [SYGData0829](https://github.com/ermubuzhiming/OMZ-files-download/releases/tag/v1-ly)
+## SYGData0829
 
 ### How download dataset
 
 To download SYGData0829 dataset, you need to follow the steps below:
 1. Go to the [github repo](https://github.com/ermubuzhiming/OMZ-files-download/releases/tag/v1-ly)
-2. Select [`SYGData0829.z01`](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z01)
+2. Select [SYGData0829.z01](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z01)
 Select ['SYGData0829.z02'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z02)
 Select ['SYGData0829.z03'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.z03)
 Select ['SYGData0829.zip'](https://github.com/ermubuzhiming/OMZ-files-download/releases/download/v1-ly/SYGData0829.zip)
@@ -163,9 +163,9 @@ Select ['SYGData0829.zip'](https://github.com/ermubuzhiming/OMZ-files-download/r
 		* `Main/val.txt` - image sets file for validation of detection tasks
 
 ### Datasets in dataset_definitions.yml
-* `SYGData0829` used for evaluation models on SYGData0829 dataset for object detection task. Label map with 4 object categories are used. (model examples: [`mobilenet-yolo-v4-syg`](../models/public/mobilenet-yolo-v4-syg/README.md))
+* `SYGData0829` used for evaluation models on SYGData0829 dataset for object detection task. Label map with 4 object categories are used. (model examples: [mobilenet-yolo-v4-syg](../models/public/mobilenet-yolo-v4-syg/README.md))
 
-## [PASCAL-S](http://cbs.ic.gatech.edu/salobj/)
+## PASCAL-S
 
 ### How download dataset
 
@@ -182,9 +182,9 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
     * `mask` - directory containing the PASCAL-S salient region masks from the directory `datasets/masks/pascal` in the unpacked archive
 
 ### Datasets in dataset_definitions.yml
-* `PASCAL-S` used for evaluation models on PASCAL-S dataset for salient object detection task. (model examples: [`f3net`](../models/public/f3net/README.md))
+* `PASCAL-S` used for evaluation models on PASCAL-S dataset for salient object detection task. (model examples: [f3net](../models/public/f3net/README.md))
 
-## [CoNLL2003 Named Entity Recognition](https://www.aclweb.org/anthology/W03-0419/)
+## CoNLL2003 Named Entity Recognition
 
 ### How download dataset
 
@@ -199,9 +199,9 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
     * `valid.txt` - annotation file for CoNLL2003 validation set
 
 ### Datasets in dataset_definitions.yml
-* `CONLL2003_bert_cased` used for evaluation models on CoNLL2003 dataset for named entity recognition task. (model examples: [`bert-base-ner`](../models/public/bert-base-ner/README.md))
+* `CONLL2003_bert_cased` used for evaluation models on CoNLL2003 dataset for named entity recognition task. (model examples: [bert-base-ner](../models/public/bert-base-ner/README.md))
 
-## [MRL Eye](http://mrl.cs.vsb.cz/eyedataset)
+## MRL Eye
 
 ### How download dataset
 
@@ -216,9 +216,9 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 * `mrlEyes_2018_01` - directory containing subdirectories with dataset images
 
 ### Datasets in dataset_definitions.yml
-* `mrlEyes_2018_01` used for evaluation models on MRL Eye dataset for recognition of eye state. (model examples: [`open-closed-eye-0001`](../models/public/open-closed-eye-0001/README.md))
+* `mrlEyes_2018_01` used for evaluation models on MRL Eye dataset for recognition of eye state. (model examples: [open-closed-eye-0001](../models/public/open-closed-eye-0001/README.md))
 
-## [Labeled Faces in the Wild (LFW)](http://vis-www.cs.umass.edu/lfw/)
+## Labeled Faces in the Wild (LFW)
 
 ### How download dataset
 
@@ -229,7 +229,7 @@ To download LFW dataset, you need to follow the steps below:
 4. Unpack archive
 5. Go to the `Training, Validation, and Testing` section
 6. Select `pairs.txt` and download pairs file
-7. Download [`lfw_landmark`](https://raw.githubusercontent.com/clcarwin/sphereface_pytorch/master/data/lfw_landmark.txt) file
+7. Download [lfw_landmark](https://raw.githubusercontent.com/clcarwin/sphereface_pytorch/master/data/lfw_landmark.txt) file
 
 ### Files layout
 
@@ -242,9 +242,9 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
         * `lfw_landmark.txt` - file with facial landmarks coordinates for annotation images of LFW dataset
 
 ### Datasets in dataset_definitions.yml
-* `lfw` used for evaluation models on LFW dataset for face recognition task. (model examples: [`Sphereface`](../models/public/Sphereface/README.md))
+* `lfw` used for evaluation models on LFW dataset for face recognition task. (model examples: [Sphereface](../models/public/Sphereface/README.md))
 
-## [NYU Depth Dataset V2](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html)
+## NYU Depth Dataset V2
 
 ### How download dataset
 
@@ -269,4 +269,4 @@ convert_annotation nyu_depth_v2 --data_dir <DATASET_DIR>/nyudepthv2/val/official
 ```
 
 ### Datasets in dataset_definitions.yml
-* `NYU_Depth_V2` used for evaluation models on NYU Depth Dataset V2 for monocular depth estimation task. (model examples: [`fcrn-dp-nyu-depth-v2-tf`](../models/public/fcrn-dp-nyu-depth-v2-tf/README.md))
+* `NYU_Depth_V2` used for evaluation models on NYU Depth Dataset V2 for monocular depth estimation task. (model examples: [fcrn-dp-nyu-depth-v2-tf](../models/public/fcrn-dp-nyu-depth-v2-tf/README.md))

--- a/data/datasets.md
+++ b/data/datasets.md
@@ -96,7 +96,7 @@ To use this dataset with OMZ tools, make sure `<DATASET_DIR>` contains the follo
 
 ### Download dataset
 
-1. Go to the [VOC2012 home page](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/).
+1. Go to the [VOC2012 website](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/).
 2. Go to the [Development Kit](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/#devkit) section.
 3. Click [Download the training/validation data](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar) to download archive.
 4. Unpack archive.


### PR DESCRIPTION
This PR addresses CVS-86927.

Hyperlinks are not rendered when used as a sole text in headers. 
Additionally, it appears that using nested markdown (backquotes within square brackets in hyperlinks) also is problematic

![image](https://user-images.githubusercontent.com/101244613/178663608-4b5e73b0-8758-4f4f-817d-bb4d1ed88861.png)

