### PR TITLE
DOCS-sort public models alphabetically-to-22.1

### DIFF
--- a/models/intel/index.md
+++ b/models/intel/index.md
@@ -6,110 +6,21 @@
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Device Support
 
    omz_models_intel_device_support
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Action Recognition Models
-
    omz_models_model_action_recognition_0001
+   omz_models_model_age_gender_recognition_retail_0013
    omz_models_model_asl_recognition_0004
+   omz_models_model_bert_large_uncased_whole_word_masking_squad_0001
+   omz_models_model_bert_large_uncased_whole_word_masking_squad_emb_0001
+   omz_models_model_bert_large_uncased_whole_word_masking_squad_int8_0001
+   omz_models_model_bert_small_uncased_whole_word_masking_squad_0001
+   omz_models_model_bert_small_uncased_whole_word_masking_squad_0002
+   omz_models_model_bert_small_uncased_whole_word_masking_squad_emb_int8_0001
+   omz_models_model_bert_small_uncased_whole_word_masking_squad_int8_0002
    omz_models_model_common_sign_language_0002
    omz_models_model_driver_action_recognition_adas_0002
-   omz_models_model_smartlab_sequence_modelling_0001
-   omz_models_model_weld_porosity_detection_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Classification Models
-
-   omz_models_model_resnet18_xnor_binary_onnx_0001
-   omz_models_model_resnet50_binary_0001
-
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Head Pose Estimation Models
-
-   omz_models_model_head_pose_estimation_adas_0001
-
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Human Pose Estimation Models
-
-   omz_models_model_human_pose_estimation_0001
-   omz_models_model_human_pose_estimation_0005
-   omz_models_model_human_pose_estimation_0006
-   omz_models_model_human_pose_estimation_0007
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Image Processing Models
-
-   omz_models_model_single_image_super_resolution_1032
-   omz_models_model_single_image_super_resolution_1033
-   omz_models_model_text_image_super_resolution_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Instance Segmentation Models
-
-   omz_models_model_instance_segmentation_person_0007
-   omz_models_model_instance_segmentation_security_0002
-   omz_models_model_instance_segmentation_security_0091
-   omz_models_model_instance_segmentation_security_0228
-   omz_models_model_instance_segmentation_security_1039
-   omz_models_model_instance_segmentation_security_1040
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Machine Translation Models
-
-   omz_models_model_machine_translation_nar_de_en_0002
-   omz_models_model_machine_translation_nar_en_de_0002
-   omz_models_model_machine_translation_nar_en_ru_0002
-   omz_models_model_machine_translation_nar_ru_en_0002
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Noise Suppression Models
-
-   omz_models_model_noise_suppression_poconetlike_0001
-   omz_models_model_noise_suppression_denseunet_ll_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Object Attribute Recognition Models
-
-   omz_models_model_age_gender_recognition_retail_0013
    omz_models_model_emotions_recognition_retail_0003
-   omz_models_model_facial_landmarks_35_adas_0002
-   omz_models_model_facial_landmarks_98_detection_0001
-   omz_models_model_gaze_estimation_adas_0002
-   omz_models_model_landmarks_regression_retail_0009
-   omz_models_model_person_attributes_recognition_crossroad_0230
-   omz_models_model_person_attributes_recognition_crossroad_0234
-   omz_models_model_person_attributes_recognition_crossroad_0238
-   omz_models_model_vehicle_attributes_recognition_barrier_0039
-   omz_models_model_vehicle_attributes_recognition_barrier_0042
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Object Detection Models
-
    omz_models_model_face_detection_0200
    omz_models_model_face_detection_0202
    omz_models_model_face_detection_0204
@@ -118,9 +29,46 @@
    omz_models_model_face_detection_adas_0001
    omz_models_model_face_detection_retail_0004
    omz_models_model_face_detection_retail_0005
+   omz_models_model_face_reidentification_retail_0095
+   omz_models_model_facial_landmarks_35_adas_0002
+   omz_models_model_facial_landmarks_98_detection_0001
    omz_models_model_faster_rcnn_resnet101_coco_sparse_60_0001
+   omz_models_model_formula_recognition_medium_scan_0001
+   omz_models_model_formula_recognition_polynomials_handwritten_0001
+   omz_models_model_gaze_estimation_adas_0002
+   omz_models_model_handwritten_english_recognition_0001
+   omz_models_model_handwritten_japanese_recognition_0001
+   omz_models_model_handwritten_score_recognition_0003
+   omz_models_model_handwritten_simplified_chinese_recognition_0001
+   omz_models_model_head_pose_estimation_adas_0001
+   omz_models_model_horizontal_text_detection_0001
+   omz_models_model_human_pose_estimation_0001
+   omz_models_model_human_pose_estimation_0005
+   omz_models_model_human_pose_estimation_0006
+   omz_models_model_human_pose_estimation_0007
+   omz_models_model_icnet_camvid_ava_0001
+   omz_models_model_icnet_camvid_ava_sparse_30_0001
+   omz_models_model_icnet_camvid_ava_sparse_60_0001
+   omz_models_model_image_retrieval_0001
+   omz_models_model_instance_segmentation_person_0007
+   omz_models_model_instance_segmentation_security_0002
+   omz_models_model_instance_segmentation_security_0091
+   omz_models_model_instance_segmentation_security_0228
+   omz_models_model_instance_segmentation_security_1039
+   omz_models_model_instance_segmentation_security_1040
+   omz_models_model_landmarks_regression_retail_0009
+   omz_models_model_license_plate_recognition_barrier_0001
+   omz_models_model_machine_translation_nar_de_en_0002
+   omz_models_model_machine_translation_nar_en_de_0002
+   omz_models_model_machine_translation_nar_en_ru_0002
+   omz_models_model_machine_translation_nar_ru_en_0002
+   omz_models_model_noise_suppression_denseunet_ll_0001
+   omz_models_model_noise_suppression_poconetlike_0001
    omz_models_model_pedestrian_and_vehicle_detector_adas_0001
    omz_models_model_pedestrian_detection_adas_0002
+   omz_models_model_person_attributes_recognition_crossroad_0230
+   omz_models_model_person_attributes_recognition_crossroad_0234
+   omz_models_model_person_attributes_recognition_crossroad_0238
    omz_models_model_person_detection_0106
    omz_models_model_person_detection_0200
    omz_models_model_person_detection_0201
@@ -136,6 +84,10 @@
    omz_models_model_person_detection_raisinghand_recognition_0001
    omz_models_model_person_detection_retail_0002
    omz_models_model_person_detection_retail_0013
+   omz_models_model_person_reidentification_retail_0277
+   omz_models_model_person_reidentification_retail_0286
+   omz_models_model_person_reidentification_retail_0287
+   omz_models_model_person_reidentification_retail_0288
    omz_models_model_person_vehicle_bike_detection_2000
    omz_models_model_person_vehicle_bike_detection_2001
    omz_models_model_person_vehicle_bike_detection_2002
@@ -145,15 +97,37 @@
    omz_models_model_person_vehicle_bike_detection_crossroad_1016
    omz_models_model_person_vehicle_bike_detection_crossroad_yolov3_1020
    omz_models_model_product_detection_0001
+   omz_models_model_resnet18_xnor_binary_onnx_0001
+   omz_models_model_resnet50_binary_0001
+   omz_models_model_road_segmentation_adas_0001
+   omz_models_model_semantic_segmentation_adas_0001
+   omz_models_model_single_image_super_resolution_1032
+   omz_models_model_single_image_super_resolution_1033
    omz_models_model_smartlab_object_detection_0001
    omz_models_model_smartlab_object_detection_0002
    omz_models_model_smartlab_object_detection_0003
    omz_models_model_smartlab_object_detection_0004
+   omz_models_model_smartlab_sequence_modelling_0001
+   omz_models_model_text_detection_0003
+   omz_models_model_text_detection_0004
+   omz_models_model_text_image_super_resolution_0001
+   omz_models_model_text_recognition_0012
+   omz_models_model_text_recognition_0014
+   omz_models_model_text_recognition_0015
+   omz_models_model_text_recognition_0016
+   omz_models_model_text_spotting_0005
+   omz_models_model_text_to_speech_en_0001
+   omz_models_model_text_to_speech_en_multi_0001
+   omz_models_model_time_series_forecasting_electricity_0001
+   omz_models_model_unet_camvid_onnx_0001
+   omz_models_model_vehicle_attributes_recognition_barrier_0039
+   omz_models_model_vehicle_attributes_recognition_barrier_0042
    omz_models_model_vehicle_detection_0200
    omz_models_model_vehicle_detection_0201
    omz_models_model_vehicle_detection_0202
    omz_models_model_vehicle_detection_adas_0002
    omz_models_model_vehicle_license_plate_detection_barrier_0106
+   omz_models_model_weld_porosity_detection_0001
    omz_models_model_yolo_v2_ava_0001
    omz_models_model_yolo_v2_ava_sparse_35_0001
    omz_models_model_yolo_v2_ava_sparse_70_0001
@@ -161,91 +135,7 @@
    omz_models_model_yolo_v2_tiny_ava_sparse_30_0001
    omz_models_model_yolo_v2_tiny_ava_sparse_60_0001
    omz_models_model_yolo_v2_tiny_vehicle_detection_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Reidentification Models
-
-   omz_models_model_face_reidentification_retail_0095
-   omz_models_model_person_reidentification_retail_0277
-   omz_models_model_person_reidentification_retail_0286
-   omz_models_model_person_reidentification_retail_0287
-   omz_models_model_person_reidentification_retail_0288
-   omz_models_model_image_retrieval_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Question Answering Models
-
-   omz_models_model_bert_large_uncased_whole_word_masking_squad_0001
-   omz_models_model_bert_large_uncased_whole_word_masking_squad_emb_0001
-   omz_models_model_bert_large_uncased_whole_word_masking_squad_int8_0001
-   omz_models_model_bert_small_uncased_whole_word_masking_squad_0001
-   omz_models_model_bert_small_uncased_whole_word_masking_squad_0002
-   omz_models_model_bert_small_uncased_whole_word_masking_squad_emb_int8_0001
-   omz_models_model_bert_small_uncased_whole_word_masking_squad_int8_0002
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Semantic Segmentation Models
-
-   omz_models_model_icnet_camvid_ava_0001
-   omz_models_model_icnet_camvid_ava_sparse_30_0001
-   omz_models_model_icnet_camvid_ava_sparse_60_0001
-   omz_models_model_road_segmentation_adas_0001
-   omz_models_model_semantic_segmentation_adas_0001
-   omz_models_model_unet_camvid_onnx_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text-to-speech Models
-
-   omz_models_model_text_to_speech_en_0001
-   omz_models_model_text_to_speech_en_multi_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Time Series Models
-
-   omz_models_model_time_series_forecasting_electricity_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text Detection Models
-
-   omz_models_model_horizontal_text_detection_0001
-   omz_models_model_text_detection_0003
-   omz_models_model_text_detection_0004
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text Recognition Models
-
-   omz_models_model_formula_recognition_medium_scan_0001
-   omz_models_model_formula_recognition_polynomials_handwritten_0001
-   omz_models_model_handwritten_english_recognition_0001
-   omz_models_model_handwritten_japanese_recognition_0001
-   omz_models_model_handwritten_score_recognition_0003
-   omz_models_model_handwritten_simplified_chinese_recognition_0001
-   omz_models_model_license_plate_recognition_barrier_0001
-   omz_models_model_text_recognition_0012
-   omz_models_model_text_recognition_0014
-   omz_models_model_text_recognition_0015
-   omz_models_model_text_recognition_0016
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text Spotting Models
-
-   omz_models_model_text_spotting_0005
+   
 
 .. raw:: html
 

--- a/models/public/index.md
+++ b/models/public/index.md
@@ -9,47 +9,49 @@
    :caption: Device Support
 
    omz_models_public_device_support
-
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: 3D Semantic Segmentation Models
-
-   omz_models_model_brain_tumor_segmentation_0001
-   omz_models_model_brain_tumor_segmentation_0002
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Action Recognition Models
-
-   omz_models_model_common_sign_language_0001
-   omz_models_model_i3d_rgb_tf
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Background Matting Models
-
-   omz_models_model_background_matting_mobilenetv2
-   omz_models_model_robust_video_matting_mobilenetv3
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Classification Models
-
+   omz_models_model_aclnet
+   omz_models_model_aclnet_int8
    omz_models_model_alexnet
    omz_models_model_anti_spoof_mn3
+   omz_models_model_background_matting_mobilenetv2
+   omz_models_model_bert_base_ner
+   omz_models_model_brain_tumor_segmentation_0001
+   omz_models_model_brain_tumor_segmentation_0002
    omz_models_model_caffenet
+   omz_models_model_cocosnet
+   omz_models_model_colorization_siggraph
+   omz_models_model_colorization_v2
+   omz_models_model_common_sign_language_0001
+   omz_models_model_convnext_tiny
+   omz_models_model_ctdet_coco_dlav0_512
+   omz_models_model_ctpn
+   omz_models_model_deblurgan_v2
+   omz_models_model_deeplabv3
    omz_models_model_densenet_121
    omz_models_model_densenet_121_tf
+   omz_models_model_detr_resnet50
    omz_models_model_dla_34
+   omz_models_model_drn_d_38
+   omz_models_model_efficientdet_d0_tf
+   omz_models_model_efficientdet_d1_tf
    omz_models_model_efficientnet_b0
    omz_models_model_efficientnet_b0_pytorch
    omz_models_model_efficientnet_v2_b0
    omz_models_model_efficientnet_v2_s
+   omz_models_model_f3net
+   omz_models_model_face_detection_retail_0044
+   omz_models_model_face_recognition_resnet100_arcface_onnx
+   omz_models_model_faceboxes_pytorch
+   omz_models_model_facenet_20180408_102900
+   omz_models_model_fast_neural_style_mosaic_onnx
+   omz_models_model_faster_rcnn_inception_resnet_v2_atrous_coco
+   omz_models_model_faster_rcnn_resnet50_coco
+   omz_models_model_fastseg_large
+   omz_models_model_fastseg_small
+   omz_models_model_fbcnn
+   omz_models_model_fcrn_dp_nyu_depth_v2_tf
+   omz_models_model_forward_tacotron
+   omz_models_model_gmcnn_places2_tf
    omz_models_model_googlenet_v1
    omz_models_model_googlenet_v1_tf
    omz_models_model_googlenet_v2
@@ -57,10 +59,23 @@
    omz_models_model_googlenet_v3
    omz_models_model_googlenet_v3_pytorch
    omz_models_model_googlenet_v4_tf
+   omz_models_model_gpt_2
    omz_models_model_hbonet_0_25
    omz_models_model_hbonet_1_0
+   omz_models_model_higher_hrnet_w32_human_pose_estimation
+   omz_models_model_hrnet_v2_c1_segmentation
+   omz_models_model_human_pose_estimation_3d_0001
+   omz_models_model_hybrid_cs_model_mri
+   omz_models_model_i3d_rgb_tf
    omz_models_model_inception_resnet_v2_tf
+   omz_models_model_levit_128s
+   omz_models_model_license_plate_recognition_barrier_0007
+   omz_models_model_mask_rcnn_inception_resnet_v2_atrous_coco
+   omz_models_model_mask_rcnn_resnet50_atrous_coco
+   omz_models_model_midasnet
    omz_models_model_mixnet_l
+   omz_models_model_mobilefacedet_v1_mxnet
+   omz_models_model_mobilenet_ssd
    omz_models_model_mobilenet_v1_0_25_128
    omz_models_model_mobilenet_v1_1_0_224
    omz_models_model_mobilenet_v1_1_0_224_tf
@@ -68,11 +83,26 @@
    omz_models_model_mobilenet_v2_1_0_224
    omz_models_model_mobilenet_v2_1_4_224
    omz_models_model_mobilenet_v2_pytorch
+   omz_models_model_mobilenet_v3_large_1_0_224_paddle
    omz_models_model_mobilenet_v3_large_1_0_224_tf
+   omz_models_model_mobilenet_v3_small_1_0_224_paddle
    omz_models_model_mobilenet_v3_small_1_0_224_tf
+   omz_models_model_mobilenet_yolo_v4_syg
+   omz_models_model_modnet_photographic_portrait_matting
+   omz_models_model_modnet_webcam_portrait_matting
+   omz_models_model_mozilla_deepspeech_0_6_1
+   omz_models_model_mozilla_deepspeech_0_8_2
+   omz_models_model_mtcnn
+   omz_models_model_nanodet_m_1_5x_416
+   omz_models_model_nanodet_plus_m_1_5x_416
+   omz_models_model_netvlad_tf
    omz_models_model_nfnet_f0
+   omz_models_model_ocrnet_hrnet_w48_paddle
    omz_models_model_octave_resnet_26_0_25
    omz_models_model_open_closed_eye_0001
+   omz_models_model_pelee_coco
+   omz_models_model_pspnet_pytorch
+   omz_models_model_quartznet_15x5_en
    omz_models_model_regnetx_3_2gf
    omz_models_model_repvgg_a0
    omz_models_model_repvgg_b1
@@ -82,129 +112,39 @@
    omz_models_model_resnet_34_pytorch
    omz_models_model_resnet_50_pytorch
    omz_models_model_resnet_50_tf
+   omz_models_model_retinaface_resnet50_pytorch
+   omz_models_model_retinanet_tf
    omz_models_model_rexnet_v1_x1_0
+   omz_models_model_rfcn_resnet101_coco_tf
+   omz_models_model_robust_video_matting_mobilenetv3
    omz_models_model_se_inception
    omz_models_model_se_resnet_50
    omz_models_model_se_resnext_50
    omz_models_model_shufflenet_v2_x0_5
    omz_models_model_shufflenet_v2_x1_0
+   omz_models_model_single_human_pose_estimation_0001
+   omz_models_model_Sphereface
    omz_models_model_squeezenet1_0
    omz_models_model_squeezenet1_1
-   omz_models_model_swin_tiny_patch4_window7_224
-   omz_models_model_t2t_vit_14
-   omz_models_model_vgg16
-   omz_models_model_vgg19
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Colorization Models
-
-   omz_models_model_colorization_siggraph
-   omz_models_model_colorization_v2
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Deblurring Models
-
-   omz_models_model_deblurgan_v2
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Face Recognition Models
-
-   omz_models_model_face_recognition_resnet100_arcface_onnx
-   omz_models_model_facenet_20180408_102900
-   omz_models_model_Sphereface
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Human Pose Estimation Models
-
-   omz_models_model_higher_hrnet_w32_human_pose_estimation
-   omz_models_model_human_pose_estimation_3d_0001
-   omz_models_model_single_human_pose_estimation_0001
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Image Inpainting Models
-
-   omz_models_model_gmcnn_places2_tf
-   omz_models_model_hybrid_cs_model_mri
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Image Translation Models
-
-   omz_models_model_cocosnet
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Instance Segmentation Models
-
-   omz_models_model_mask_rcnn_inception_resnet_v2_atrous_coco
-   omz_models_model_mask_rcnn_resnet50_atrous_coco
-   omz_models_model_yolact_resnet50_fpn_pytorch
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: JPEG Artifacts Removal Models
-
-   omz_models_model_fbcnn
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Monocular Depth Estimation Models
-
-   omz_models_model_fcrn_dp_nyu_depth_v2_tf
-   omz_models_model_midasnet
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Named Entity Recognition Models
-
-   omz_models_model_bert_base_ner
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Object Detection Models
-
-   omz_models_model_ctdet_coco_dlav0_512
-   omz_models_model_ctpn
-   omz_models_model_detr_resnet50
-   omz_models_model_efficientdet_d0_tf
-   omz_models_model_efficientdet_d1_tf
-   omz_models_model_face_detection_retail_0044
-   omz_models_model_faceboxes_pytorch
-   omz_models_model_faster_rcnn_inception_resnet_v2_atrous_coco
-   omz_models_model_faster_rcnn_resnet50_coco
-   omz_models_model_mobilefacedet_v1_mxnet
-   omz_models_model_mobilenet_ssd
-   omz_models_model_mobilenet_yolo_v4_syg
-   omz_models_model_mtcnn
-   omz_models_model_pelee_coco
-   omz_models_model_retinaface_resnet50_pytorch
-   omz_models_model_retinanet_tf
-   omz_models_model_rfcn_resnet101_coco_tf
+   omz_models_model_ssd_mobilenet_v1_coco
+   omz_models_model_ssd_mobilenet_v1_fpn_coco
    omz_models_model_ssd_resnet34_1200_onnx
    omz_models_model_ssd300
    omz_models_model_ssd512
-   omz_models_model_ssd_mobilenet_v1_coco
-   omz_models_model_ssd_mobilenet_v1_fpn_coco
    omz_models_model_ssdlite_mobilenet_v2
+   omz_models_model_swin_tiny_patch4_window7_224
+   omz_models_model_t2t_vit_14
+   omz_models_model_text_recognition_resnet_fc
    omz_models_model_ultra_lightweight_face_detection_rfb_320
    omz_models_model_ultra_lightweight_face_detection_slim_320
    omz_models_model_vehicle_license_plate_detection_barrier_0123
+   omz_models_model_vehicle_reid_0001
+   omz_models_model_vgg16
+   omz_models_model_vgg19
+   omz_models_model_vitstr_small_patch16_224
+   omz_models_model_wav2vec2_base
+   omz_models_model_wavernn
+   omz_models_model_yolact_resnet50_fpn_pytorch
    omz_models_model_yolo_v1_tiny_tf
    omz_models_model_yolo_v2_tf
    omz_models_model_yolo_v2_tiny_tf
@@ -216,95 +156,6 @@
    omz_models_model_yolo_v4_tiny_tf
    omz_models_model_yolof
    omz_models_model_yolox_tiny
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Optical Character Recognition Models
-
-   omz_models_model_license_plate_recognition_barrier_0007
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Place Recognition Models
-
-   omz_models_model_netvlad_tf
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Salient Object Detection Models
-
-   omz_models_model_f3net
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Semantic Segmentation Models
-
-   omz_models_model_deeplabv3
-   omz_models_model_drn_d_38
-   omz_models_model_fastseg_large
-   omz_models_model_fastseg_small
-   omz_models_model_hrnet_v2_c1_segmentation
-   omz_models_model_pspnet_pytorch
-   omz_models_model_ocrnet_hrnet_w48_paddle
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Sound Classification Models
-
-   omz_models_model_aclnet
-   omz_models_model_aclnet_int8
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Speech Recognition Models
-
-   omz_models_model_mozilla_deepspeech_0_6_1
-   omz_models_model_mozilla_deepspeech_0_8_2
-   omz_models_model_quartznet_15x5_en
-   omz_models_model_wav2vec2_base
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Style Transfer Models
-
-   omz_models_model_fast_neural_style_mosaic_onnx
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text Prediction Models
-
-   omz_models_model_gpt_2
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text Recognition Models
-
-   omz_models_model_text_recognition_resnet_fc
-   omz_models_model_vitstr_small_patch16_224
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Text to Speech Models
-
-   omz_models_model_forward_tacotron
-   omz_models_model_wavernn
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-   :caption: Vehicle Reidentification Models
-
-   omz_models_model_vehicle_reid_0001
 
 
 .. raw:: html
@@ -330,9 +181,10 @@ You can download models and convert them into OpenVINO™ IR format (\*.xml + \*
 | AlexNet                     | Caffe\*                            | [alexnet](./alexnet/README.md)   | 56.598%/79.812% | 1.5 | 60.965 |
 | AntiSpoofNet                | PyTorch\*                          | [anti-spoof-mn3](./anti-spoof-mn3/README.md) | 3.81% | 0.15 | 3.02 |
 | CaffeNet                    | Caffe\*                            | [caffenet](./caffenet/README.md)  | 56.714%/79.916% | 1.5 | 60.965 |
+| ConvNeXt Tiny               | PyTorch\*                          | [convnext-tiny](./convnext-tiny/README.md) | 82.05%/95.86% | 8.9419 | 28.5892 |
 | DenseNet 121                | Caffe\*<br>TensorFlow\*| [densenet-121](./densenet-121/README.md)<br>[densenet-121-tf](./densenet-121-tf/README.md)| 74.42%/92.136%<br>74.46%/92.13%| 5.723~5.7287 | 7.971 |
 | DLA 34                      | PyTorch\*                          | [dla-34](./dla-34/README.md) | 74.64%/92.06% | 6.1368 | 15.7344 |
-| EfficientNet B0             | TensorFlow\*<br>PyTorch\*          | [efficientnet-b0](./efficientnet-b0/README.md)<br>[efficientnet-b0-pytorch](./efficientnet-b0-pytorch/README.md) | 75.70%/92.76%<br>76.91%/93.21% | 0.819 | 5.268 |
+| EfficientNet B0             | TensorFlow\*<br>PyTorch\*          | [efficientnet-b0](./efficientnet-b0/README.md)<br>[efficientnet-b0-pytorch](./efficientnet-b0-pytorch/README.md) | 75.70%/92.76%<br>77.70%/93.52% | 0.819 | 5.268 |
 | EfficientNet V2 B0          | PyTorch\*                          | [efficientnet-v2-b0](./efficientnet-v2-b0/README.md) | 78.36%/94.02% | 1.4641 | 7.1094 |
 | EfficientNet V2 Small       | PyTorch\*                          | [efficientnet-v2-s](./efficientnet-v2-s/README.md) | 84.29%/97.26% | 16.9406  | 21.3816  |
 | HBONet 1.0                  | PyTorch\*                          | [hbonet-1.0](./hbonet-1.0/README.md)  | 73.1%/91.0% | 0.6208 | 4.5443 |
@@ -342,13 +194,14 @@ You can download models and convert them into OpenVINO™ IR format (\*.xml + \*
 | Inception (GoogleNet) V3    | TensorFlow\*<br>PyTorch\*          | [googlenet-v3](./googlenet-v3/README.md) <br> [googlenet-v3-pytorch](./googlenet-v3-pytorch/README.md) | 77.904%/93.808%<br>77.69%/93.7% | 11.469 | 23.817 |
 | Inception (GoogleNet) V4    | TensorFlow\*                       | [googlenet-v4-tf](./googlenet-v4-tf/README.md) | 80.204%/95.21% | 24.584 | 42.648 |
 | Inception-ResNet V2         | TensorFlow\*                       | [inception-resnet-v2-tf](./inception-resnet-v2-tf/README.md) | 77.82%/94.03% | 22.227 | 30.223 |
+| LeViT 128S                  | PyTorch\*                          | [levit-128s](./levit-128s/README.md) | 76.54%/92.85% | 0.6177 | 8.2199 |
 | MixNet L                    | TensorFlow\*                       | [mixnet-l](./mixnet-l/README.md)  | 78.30%/93.91% | 0.565 | 7.3 |
 | MobileNet V1 0.25 128       | Caffe\*                            | [mobilenet-v1-0.25-128](./mobilenet-v1-0.25-128/README.md)  | 40.54%/65% | 0.028 | 0.468 |
 | MobileNet V1 1.0 224        | Caffe\*<br>TensorFlow\*            | [mobilenet-v1-1.0-224](./mobilenet-v1-1.0-224/README.md)<br>[mobilenet-v1-1.0-224-tf](./mobilenet-v1-1.0-224-tf/README.md)| 69.496%/89.224%<br>71.03%/89.94% | 1.148 | 4.221 |
 | MobileNet V2 1.0 224        | Caffe\*<br>TensorFlow\*<br>PyTorch\*| [mobilenet-v2](./mobilenet-v2/README.md) <br>[mobilenet-v2-1.0-224](./mobilenet-v2-1.0-224/README.md)<br>[mobilenet-v2-pytorch](./mobilenet-v2-pytorch/README.md) | 71.218%/90.178%<br>71.85%/90.69%<br>71.81%/90.396% | 0.615~0.876 | 3.489 |
 | MobileNet V2 1.4 224        | TensorFlow\*                       | [mobilenet-v2-1.4-224](./mobilenet-v2-1.4-224/README.md) | 74.09%/91.97% | 1.183  | 6.087 |
-| MobileNet V3 Small 1.0      | TensorFlow\*                       | [mobilenet-v3-small-1.0-224-tf](./mobilenet-v3-small-1.0-224-tf/README.md) | 67.36%/87.44% | 0.1168 | 2.537 |
-| MobileNet V3 Large 1.0      | TensorFlow\*                       | [mobilenet-v3-large-1.0-224-tf](./mobilenet-v3-large-1.0-224-tf/README.md) | 75.30%/92.62% | 0.4450 | 5.4721 |
+| MobileNet V3 Small 1.0      | TensorFlow\*<br>Paddle\* | [mobilenet-v3-small-1.0-224-tf](./mobilenet-v3-small-1.0-224-tf/README.md) <br> [mobilenet-v3-small-1.0-paddle](./mobilenet-v3-small-1.0-224-paddle/README.md) | 67.36%/87.44%<br>68.21%/88.04% | 0.1168<br>0.1269 | 2.537<br>2.9339 |
+| MobileNet V3 Large 1.0      | TensorFlow\*<br>Paddle\*                   | [mobilenet-v3-large-1.0-224-tf](./mobilenet-v3-large-1.0-224-tf/README.md)<br>[mobilenet-v3-large-1.0-224-paddle](./mobilenet-v3-large-1.0-224-paddle/README.md) | 75.30%/92.62%<br>75.248%/92.32% | 0.4450<br>0.4565 | 5.4721<br>5.468 |
 | NFNet F0                    | PyTorch\*                          | [nfnet-f0](./nfnet-f0/README.md) | 83.34%/96.56% | 24.8053 | 71.4444 |
 | RegNetX-3.2GF               | PyTorch\*                          | [regnetx-3.2gf](./regnetx-3.2gf/README.md) | 78.17%/94.08% | 6.3893 | 15.2653 |
 | ResNet 26, alpha=0.25       | MXNet\*                            | [octave-resnet-26-0.25](./octave-resnet-26-0.25/README.md)     | 76.076%/92.584%| 3.768 | 15.99 |
@@ -433,6 +286,8 @@ SSD-based and provide reasonable accuracy/performance trade-offs.
 | MobileFace Detection V1              | MXNet\*                  | [mobilefacedet-v1-mxnet](./mobilefacedet-v1-mxnet/README.md)| 	78.7488%| 3.5456 | 7.6828 |
 | Mobilenet-yolo-v4-syg                | Keras\*                  | [mobilenet-yolo-v4-syg](./mobilenet-yolo-v4-syg/README.md)| 	86.35%| 65.981 | 61.922 |
 | MTCNN                                | Caffe\*                  | [mtcnn](./mtcnn/README.md):<br>mtcnn-p <br>mtcnn-r <br>mtcnn-o| 48.1308%/62.2625% | <br>3.3715<br>0.0031<br>0.0263|<br>0.0066<br>0.1002<br>0.3890|
+| NanoDet with ShuffleNetV2 1.5x, size=416 | PyTorch\*            | [nanodet-m-1.5x-416](./nanodet-m-1.5x-416/README.md) | 27.38%/26.63% | 2.3895 | 2.0534 |
+| NanoDet Plus with ShuffleNetV2 1.5x, size=416 | PyTorch\*       | [nanodet-plus-m-1.5x-416](./nanodet-plus-m-1.5x-416/README.md) | 34.53%/33.77% | 3.0147 | 2.4614 |
 | Pelee                                | Caffe\*                  | [pelee-coco](./pelee-coco/README.md) | 21.9761% | 1.290 | 5.98 |
 | RetinaFace with ResNet 50            | PyTorch\*                | [retinaface-resnet50-pytorch](./retinaface-resnet50-pytorch/README.md) | 91.78% | 88.8627 | 27.2646 |
 | RetinaNet with Resnet 50             | TensorFlow\*             | [retinanet-tf](./retinanet-tf/README.md) | 33.15% | 238.9469 | 64.9706 |
@@ -644,6 +499,8 @@ or mixed pixels. This distinguishes background matting from segmentation approac
 | Model Name     | Implementation | OMZ Model Name                                         | Accuracy | GFlops  | mParams  |
 | -------------- | -------------- | ------------------------------------------------------ | -------- | ------- | -------- |
 | background-matting-mobilenetv2 | PyTorch\* | [background-matting-mobilenetv2](./background-matting-mobilenetv2/README.md) | 4.32/1.0/2.48/2.7 | 6.7419 | 5.052 |
+| modnet-photographic-portrait-matting | PyTorch\* | [modnet-photographic-portrait-matting](./modnet-photographic-portrait-matting/README.md) | 5.21/727.95 | 31.1564 | 6.4597 |
+| modnet-webcam-portrait-matting | PyTorch\* | [modnet-webcam-portrait-matting](./modnet-webcam-portrait-matting/README.md) | 5.66/762.52 | 31.1564 | 6.4597 |
 | robust-video-matting-mobilenetv3 | PyTorch\* | [robust-video-matting-mobilenetv3](./robust-video-matting-mobilenetv3/README.md) | 20.8/15.1/4.42/4.05 | 9.3892 | 3.7363 |
 
 ## See Also


### PR DESCRIPTION
In the 'public models' and "Intel models' menu sections no additional grouping is necessary, so the models should be sorted alphabetically.