### PR TITLE
requirements: workaround networkx issue

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -2,6 +2,9 @@
 tqdm>=4.54.1
 
 # image reading and preprocessing
+# networkx version upperbound in scikit-image is conflicted
+networkx~=2.5;python_version<"3.7"
+networkx<2.8.1;python_version>="3.7"
 # note: python 3.6 wheels is not available since 0.18
 scikit-image~=0.17.2;python_version<"3.7"
 scikit-image>=0.19.2;python_version>="3.7"


### PR DESCRIPTION
there is pip conflict between common OV networkx requirements and upper bound in scikit-image, until it is not solved, explicitly set desired networkx version