### PR TITLE
Bump SciPy version requirement in accuracy checker

### DIFF
--- a/tools/accuracy_checker/requirements.in
+++ b/tools/accuracy_checker/requirements.in
@@ -27,7 +27,7 @@ pyclipper>=1.2.1
 
 # brain tumor segmentation
 nibabel>=3.2.1
-scipy~=1.5.4
+scipy >=1.5.4,<=1.8.0
 
 # dicom images reading
 pydicom>=2.1.2


### PR DESCRIPTION
Accuracy checker is one of the modules in OpenVINO `openvino_dev` package. We are currently working on enabling Python 3.10, which requires a higher version of `SciPy`. Without this change building an `openvino_dev` wheel throws dependency conflict errors.

Motivation:
- `SciPy 1.5.4` has been released on November 04, 2020
- Low `SciPy` version has been mentioned in issues https://github.com/openvinotoolkit/openvino/issues/12735 and https://github.com/openvinotoolkit/openvino/issues/11532
- More about enabling Python 3.10 can be discussed through internal channels