### PR TITLE
Bump ONNX to 1.12

### DIFF
--- a/ci/requirements-openvino-dev.in
+++ b/ci/requirements-openvino-dev.in
@@ -30,9 +30,9 @@ numpy (<1.20,>=1.16.6) ; extra == 'kaldi'
 numpy (<1.20,>=1.16.6) ; extra == 'mxnet'
 numpy (<1.20,>=1.16.6) ; extra == 'onnx'
 numpy (<1.20,>=1.16.6) ; extra == 'tensorflow2'
-onnx (<1.12,>=1.8.1) ; extra == 'caffe2'
-onnx (<1.12,>=1.8.1) ; extra == 'onnx'
-onnx (<1.12,>=1.8.1) ; extra == 'pytorch'
+onnx (<=1.12,>=1.8.1) ; extra == 'caffe2'
+onnx (<=1.12,>=1.8.1) ; extra == 'onnx'
+onnx (<=1.12,>=1.8.1) ; extra == 'pytorch'
 opencv-python (==4.5.*)
 openvino (==2021.4.2)
 pandas (~=1.1.5)

--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -1,4 +1,4 @@
-onnx<1.12,>=1.8.1
+onnx<=1.12,>=1.8.1
 scipy~=1.5.4           # via torchvision
 torch==1.8.1
 torchvision==0.9.1


### PR DESCRIPTION
OMZ is a thirdparty dependency of OpenVINO. We are currently working on upgrading ONNX to 1.12, which causes the following dependency conflict when building the project:
`The conflict is caused by:
openvino-dev[caffe,kaldi,mxnet,onnx,pytorch,tensorflow2] 2022.3.0.dev20220909 depends on onnx<1.12 and >=1.8.1; extra == "pytorch"
openvino-dev[caffe,kaldi,mxnet,onnx,pytorch,tensorflow2] 2022.3.0.dev20220909 depends on onnx==1.12.0; python_version >= "3.7" and extra == "onnx"`