### PR TITLE
Set ONNX to 1.12 explicitly

### DIFF
--- a/ci/requirements-conversion.txt
+++ b/ci/requirements-conversion.txt
@@ -81,7 +81,7 @@ numpy==1.19.5
     #   torchvision
 oauthlib==3.1.1
     # via requests-oauthlib
-onnx==1.10.1
+onnx==1.12.0
     # via
     #   -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_onnx.txt
     #   -r tools/model_tools/requirements-pytorch.in

--- a/ci/requirements-openvino-dev.in
+++ b/ci/requirements-openvino-dev.in
@@ -30,9 +30,9 @@ numpy (<1.20,>=1.16.6) ; extra == 'kaldi'
 numpy (<1.20,>=1.16.6) ; extra == 'mxnet'
 numpy (<1.20,>=1.16.6) ; extra == 'onnx'
 numpy (<1.20,>=1.16.6) ; extra == 'tensorflow2'
-onnx (<=1.12,>=1.8.1) ; extra == 'caffe2'
-onnx (<=1.12,>=1.8.1) ; extra == 'onnx'
-onnx (<=1.12,>=1.8.1) ; extra == 'pytorch'
+onnx (==1.12.0) ; extra == 'caffe2'
+onnx (==1.12.0) ; extra == 'onnx'
+onnx (==1.12.0) ; extra == 'pytorch'
 opencv-python (==4.5.*)
 openvino (==2021.4.2)
 pandas (~=1.1.5)

--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -1,4 +1,4 @@
-onnx<=1.12,>=1.8.1
+onnx==1.12.0
 scipy~=1.5.4           # via torchvision
 torch==1.8.1
 torchvision==0.9.1


### PR DESCRIPTION
During some OpenVINO CI runs on Jenkins ONNX is being installed in 1.11 version. We believe it might be due to loose version constraints in OMZ. 

ONNX 1.8.1 has been released on January 30, 2021 and we probably should not have have such an old version as a dependency anyway.