### PR TITLE
Add Model API to requirements.txt

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -293,10 +293,6 @@ The dependencies for Python demos must be installed before running. It can be ac
 python -mpip install --user -r <omz_dir>/demos/requirements.txt
 ```
 
-### <a name="python_model_api"></a>Python\* model API package
-
-To run Python demo applications, you need to install the Python* Model API package. Refer to the [Python Model API documentation](https://github.com/openvinotoolkit/open_model_zoo/blob/master/demos/common/python/openvino/model_zoo/model_api/README.md#installing-python-model-api-package)) to learn about its installation.
-
 ### <a name="build_python_extensions"></a>Build the Native Python\* Extension Modules
 
 Some of the Python demo applications require native Python extension modules to be built before they can be run.

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -14,5 +14,6 @@ tensorboardX>=2.1
 tokenizers~=0.10.1;python_version<"3.7"
 tokenizers>=0.10.1;python_version>="3.7"
 tqdm>=4.54.1
+git+https://github.com/openvinotoolkit/open_model_zoo.git#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 -r common/python/requirements.txt
 -r common/python/requirements_ovms.txt


### PR DESCRIPTION
This PR adds Model API to demo requirements.txt, so users do not need to install Model API manually anymore (which requires going to a different page and following not-trivial instructions).