### PR TITLE
AC: Handle delayed model loading in get_model_file_type

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
@@ -931,10 +931,10 @@ class DLSDKLauncher(Launcher):
         self.disable_resize_to_input = preprocess.ie_processor.has_resize()
 
     def get_model_file_type(self):
-        if self._delayed_model_loading:
-            return None
-        else:
+        if hasattr(self, '_model'):
             return self._model.suffix
+        else:
+            return None
 
     def input_shape(self, input_name):
         if input_name in self._partial_shapes:

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/dlsdk_launcher.py
@@ -931,7 +931,10 @@ class DLSDKLauncher(Launcher):
         self.disable_resize_to_input = preprocess.ie_processor.has_resize()
 
     def get_model_file_type(self):
-        return self._model.suffix
+        if self._delayed_model_loading:
+            return None
+        else:
+            return self._model.suffix
 
     def input_shape(self, input_name):
         if input_name in self._partial_shapes:

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher.py
@@ -967,10 +967,10 @@ class OpenVINOLauncher(Launcher):
         self.disable_resize_to_input = preprocess.ie_processor.has_resize()
 
     def get_model_file_type(self):
-        if self._delayed_model_loading:
-            return None
-        else:
+        if hasattr(self, '_model'):
             return self._model.suffix
+        else:
+            return None
 
     def get_infer_queue(self, log=True):
         if self.config.get('num_requests', 'AUTO') == 'AUTO':

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/launcher/openvino_launcher.py
@@ -967,7 +967,10 @@ class OpenVINOLauncher(Launcher):
         self.disable_resize_to_input = preprocess.ie_processor.has_resize()
 
     def get_model_file_type(self):
-        return self._model.suffix
+        if self._delayed_model_loading:
+            return None
+        else:
+            return self._model.suffix
 
     def get_infer_queue(self, log=True):
         if self.config.get('num_requests', 'AUTO') == 'AUTO':


### PR DESCRIPTION
AC fails with `AttributeError: 'OpenVINOLauncher' object has no attribute '_model'` when running in delayed model loading mode, e.g. when restoring from stored predictions.