### PR TITLE
Bump `scipy` to a higher version

### DIFF
--- a/demos/common/python/requirements.txt
+++ b/demos/common/python/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.16.6,<=1.23.1
 opencv-python
-scipy~=1.5.4
+scipy~=1.7.3; python_version == '3.7'
+scipy~=1.8.0; python_version >= '3.8'

--- a/demos/common/python/requirements.txt
+++ b/demos/common/python/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.16.6,<=1.23.1
 opencv-python
-scipy~=1.7.3; python_version == '3.7'
-scipy~=1.8.0; python_version >= '3.8'
+scipy>=1.5.4,<1.9.0

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -8,8 +8,7 @@ opencv-python
 pillow>=8.1.2
 pyyaml>=5.4.1
 scikit-learn~=0.24.1
-scipy~=1.7.3; python_version == '3.7'
-scipy~=1.8.0; python_version >= '3.8'
+scipy>=1.5.4,<1.9.0
 sympy>=1.8
 tensorboardX>=2.1
 tokenizers~=0.10.1;python_version<"3.7"

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -8,7 +8,8 @@ opencv-python
 pillow>=8.1.2
 pyyaml>=5.4.1
 scikit-learn~=0.24.1
-scipy~=1.5.4
+scipy~=1.7.3; python_version == '3.7'
+scipy~=1.8.0; python_version >= '3.8'
 sympy>=1.8
 tensorboardX>=2.1
 tokenizers~=0.10.1;python_version<"3.7"

--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -1,6 +1,5 @@
 onnx<=1.12,>=1.8.1
-scipy~=1.7.3; python_version == '3.7'
-scipy~=1.8.0; python_version >= '3.8'
+scipy>=1.5.4,<1.9.0
 torch>=1.8.1,<=1.13.0
 torchvision>=0.9.1,<=0.14.0
 yacs>=0.1.8

--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -1,5 +1,6 @@
 onnx<=1.12,>=1.8.1
-scipy~=1.5.4           # via torchvision
+scipy~=1.7.3; python_version == '3.7'
+scipy~=1.8.0; python_version >= '3.8'
 torch>=1.8.1,<=1.13.0
 torchvision>=0.9.1,<=0.14.0
 yacs>=0.1.8


### PR DESCRIPTION
There is a mismatch between `scipy` version in OpenVINO and OMZ, which causes pip conflicts in the CI pipelines. We would be thankful for a quick review. 

`scipy==1.5.4` has been released on November 5, 2020.