### PR TITLE
Limit `pyparsing` module

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,6 +1,7 @@
 inflect>=5.3.0
 librosa>=0.8.0
 matplotlib>=3.3.4
+pyparsing<3.0
 motmetrics>=1.2.0
 nibabel>=3.2.1
 numpy>=1.16.6,<=1.23.1


### PR DESCRIPTION
There is a failing check on Python 3.10 CI at https://github.com/openvinotoolkit/openvino/pull/12578 (e2e-tests-linux-ubuntu20-pip-conflicts).

After a lengthy investigation and reproducing the issue locally, we found that `matplotlib` package is dependent on `pyparsing` and it installs `pyparsing==3.0.9` (through a `pyparsing>=2.2.1` requirement), which is incompatible with other project dependencies.