### PR TITLE
Fixed parse_partial_shape() to work with aligned shape format.

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/utils.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/utils.py
@@ -910,6 +910,8 @@ def end_telemetry(tm):
 
 def parse_partial_shape(partial_shape):
     ps = str(partial_shape)
+    if ps[0] == '[' and ps[-1] == ']':
+        ps = ps[1:-1]
     preprocessed = ps.replace('{', '(').replace('}', ')').replace('?', '-1')
     if '[' not in preprocessed:
         preprocessed = preprocessed.replace('(', '').replace(')', '')


### PR DESCRIPTION
In this PR https://github.com/openvinotoolkit/openvino/pull/13613 PartialShape to string methods are aligned to return shape of unified format. This format has square brackets. Example:
"[1,3,100,100]"

parse_partial_shape() works only with old format without square brackets. Example:
"1,3,100,100"

In this PR I fix parse_partial_shape() to work with both formats.

Ticket 89901