### PR TITLE
Fix ModelAPI setup.py

### DIFF
--- a/demos/common/python/setup.py
+++ b/demos/common/python/setup.py
@@ -34,6 +34,7 @@ with open(SETUP_DIR / 'requirements_ovms.txt') as f:
     ovms_required = f.read().splitlines()
 
 packages = find_packages(str(SETUP_DIR))
+packages.remove('visualizers')
 package_dir = {'openvino': str(SETUP_DIR / 'openvino')}
 
 setup(
@@ -43,6 +44,7 @@ setup(
     license='OSI Approved :: Apache Software License',
     url='https://github.com/openvinotoolkit/open_model_zoo/tree/develop/demos/common/python/openvino',
     description='Model API: model wrappers and pipelines from Open Model Zoo',
+    python_requires = ">=3.7",
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I have checked what it takes to create a PyPi package. We already have setup.py which can generate needed artifacts. We only need to rearrange the folders structure to remove the openvino folder. So if OTX changes their mind and refuses to use OMZ as a submodule, we should be able to publish ModelAPI to PyPi. But I guess we will need to use my personal account instead of Intel’s one for publishing since we won’t follow common processes.