### PR TITLE
quartznet update onnx export command for preserving dynamic shapes

### DIFF
--- a/models/public/quartznet-15x5-en/model.yml
+++ b/models/public/quartznet-15x5-en/model.yml
@@ -101,6 +101,7 @@ conversion_to_onnx_args:
   - --model-param=decoder_weights=r"$dl_dir/models/.nemo_tmp/JasperDecoderForCTC.pt"
   - --input-names=audio_signal
   - --output-names=output
+  - '--conversion-param=dynamic_axes={"audio_signal": {0: "batch_size, 2: "wave_len"}, {"output: {0: "batch_size", 2: "wave_len"}}'
 input_info:
   - name: audio_signal
     shape: [1, 64, 128]


### PR DESCRIPTION
for torch 1.13 model become unreshapable in OV, so convert it to onnx with dynamic axes