### PR TITLE
fix truth value of of numpy array

### DIFF
--- a/demos/face_recognition_demo/python/face_recognition_demo.py
+++ b/demos/face_recognition_demo/python/face_recognition_demo.py
@@ -228,7 +228,7 @@ def main():
             if frame_num == 0:
                 raise ValueError("Can't read an image from the input")
             break
-        if input_crop:
+        if input_crop it not None:
             frame = center_crop(frame, input_crop)
         if frame_num == 0:
             output_transform = OutputTransform(frame.shape[:2], args.output_resolution)


### PR DESCRIPTION
when --input_crop arg is given, it is throwing error with "truth value of an array with more than on element ambiguous". since already there is check for crop_size>0 I I guess .any() should be sufficient.