### PR TITLE
Fix demos build on armv7

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -61,7 +61,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
   set(ARM ON)
 endif()
 if(ARM AND NOT CMAKE_CROSSCOMPILING)
-    add_compile_options(-march=armv7-a)
+    add_compile_options(-march=armv7-a+fp)
 endif()
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
On gcc-11 and higher armv7 architecture native build fails on demos compilation with the following error:
```
cc1plus: error: ‘-mfloat-abi=hard’: selected architecture lacks an FPU
```
This patch is intended to fix this issue.
Related patch in OpenVINO: https://github.com/openvinotoolkit/openvino/pull/14832
