### PR TITLE
Update scikit-learn in preparation for Python 3.11

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -15,7 +15,7 @@ imagecodecs~=2021.11.20;python_version=="3.7"
 imagecodecs~=2022.2.22;python_version>="3.8"
 
 # reid
-scikit-learn~=1.2.0
+scikit-learn>=1.2.0
 
 # cpu extension usage
 py-cpuinfo>=7.0.0

--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -15,8 +15,7 @@ imagecodecs~=2021.11.20;python_version=="3.7"
 imagecodecs~=2022.2.22;python_version>="3.8"
 
 # reid
-# python3.6 dropped in v1.0
-scikit-learn~=0.24.1
+scikit-learn~=1.2.0
 
 # cpu extension usage
 py-cpuinfo>=7.0.0


### PR DESCRIPTION
### Details:
 - Update requirements to version which supports Python 3.11 according to PyPI

### Tickets:
 - 96724