### PR TITLE
Simplify `pytest` version across the project

### DIFF
--- a/tools/accuracy_checker/requirements-test.in
+++ b/tools/accuracy_checker/requirements-test.in
@@ -1,5 +1,5 @@
 pytest~=7.2.0
-pytest-mock~=2.0
+pytest-mock~=3.10.0
 
 # pytest depends on atomicwrites, but only on Windows.
 # This means that if we use pip-compile on Linux, the resulting requirements.txt

--- a/tools/accuracy_checker/requirements-test.in
+++ b/tools/accuracy_checker/requirements-test.in
@@ -1,5 +1,4 @@
-pytest>=5.0,<=7.0.1; python_version < '3.10'
-pytest==7.2.0; python_version >= '3.10'
+pytest~=7.2.0
 pytest-mock~=2.0
 
 # pytest depends on atomicwrites, but only on Windows.


### PR DESCRIPTION
This PR addresses two issues:

- Wide range of `pytest` is causing some issues in CI related to dependency conflicts (ticket 100986)
- There is an ongoing effort to simplify package requirements (ticket 98878)

**Currently in testing since it's a cross-repository change**