### PR TITLE
Add ssd_tf adapter

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/README.md
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/README.md
@@ -112,6 +112,10 @@ AccuracyChecker supports following set of adapters:
   * `labels_out` - name of output layer with labels or regular expression for it searching.
   * `scores_out`- name of output layer with scores or regular expression for it searching. Optional, can be not provided, if your model has concatenation of scores with box coordinates.
   * `bboxes_out` - name of output layer with bboxes or regular expression for it searching.
+* `ssd_tf` - converting output of SSD-based model from TensorFlow framework to `DetectionPrediction` representation.
+  * `labels_out` - name of output layer with labels or regular expression for it searching.
+  * `scores_out`- name of output layer with scores or regular expression for it searching.
+  * `bboxes_out` - name of output layer with bboxes or regular expression for it searching.
 * `tf_object_detection` - converting output of detection models from TensorFlow object detection API to `DetectionPrediction`.
   * `classes_out` - name of output layer with predicted classes.
   * `boxes_out` - name of output layer with predicted boxes coordinates in format [y0, x0, y1, x1].

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/__init__.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/__init__.py
@@ -70,7 +70,10 @@ from .detection_person_vehicle import (
     PersonVehicleDetectionRefinementAdapter
 )
 from .detection_head import HeadDetectionAdapter
-from .ssd import SSDAdapter, PyTorchSSDDecoder, FacePersonAdapter, SSDAdapterMxNet, SSDONNXAdapter, SSDMultiLabelAdapter
+from .ssd import (
+    SSDAdapter, PyTorchSSDDecoder, FacePersonAdapter, SSDMultiLabelAdapter,
+    SSDAdapterMxNet, SSDONNXAdapter, SSDAdapterTensorFlow
+)
 from .retinaface import RetinaFaceAdapter, RetinaFacePyTorchAdapter
 from .retinanet import RetinaNetAdapter, MultiOutRetinaNet, RetinaNetTF2
 from .yolo import (
@@ -174,6 +177,7 @@ __all__ = [
 
     'SSDAdapter',
     'SSDAdapterMxNet',
+    'SSDAdapterTensorFlow',
     'SSDONNXAdapter',
     'PyTorchSSDDecoder',
     'FacePersonAdapter',

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/ssd.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/adapters/ssd.py
@@ -327,7 +327,9 @@ class SSDONNXAdapter(Adapter):
                 'scores_out': StringField(
                     description='name (or regex for it) of output layer with scores', optional=True
                 ),
-                'bboxes_out': StringField(description='name (or regex for it) of output layer with bboxes')
+                'bboxes_out': StringField(description='name (or regex for it) of output layer with bboxes'),
+                'diff_coord_order': BoolField(optional=True, default=False,
+                    description='Ordering convention of coordinates differs from standard')
             }
         )
         return parameters
@@ -336,6 +338,7 @@ class SSDONNXAdapter(Adapter):
         self.labels_out = self.get_value_from_config('labels_out')
         self.scores_out = self.get_value_from_config('scores_out')
         self.bboxes_out = self.get_value_from_config('bboxes_out')
+        self.diff_coord_order = self.get_value_from_config('diff_coord_order')
         self.outputs_verified = False
 
     def process(self, raw, identifiers, frame_meta):
@@ -352,7 +355,10 @@ class SSDONNXAdapter(Adapter):
         )):
             if self.scores_out:
                 scores = raw_outputs[self.scores_out][idx]
-                x_mins, y_mins, x_maxs, y_maxs = bboxes.T
+                if self.diff_coord_order:
+                    y_mins, x_mins, y_maxs, x_maxs = bboxes.T
+                else:
+                    x_mins, y_mins, x_maxs, y_maxs = bboxes.T
             else:
                 x_mins, y_mins, x_maxs, y_maxs, scores = bboxes.T
             if labels.ndim > 1:


### PR DESCRIPTION
It's useful for ssdlite_mobilenet_v2 and ssd_mobilenet_v1_coco at least with AC on TF framework
For example:
```
  - name:  ssdlite_mobilenet_v2
    launchers:
      - framework: tf
        model: ssdlite_mobilenet_v2_coco_2018_05_09/model.ckpt.meta
        output_names:
          - detection_classes
          - detection_scores
          - detection_boxes
          - num_detections
        inputs:
          - name: image_tensor
            type: INPUT
            shape: 1,300,300,3
        adapter:
          type: ssd_onnx
          scores_out: detection_scores
          labels_out: detection_classes
          bboxes_out: detection_boxes
          diff_coord_order: True

    datasets:
      - name: ms_coco_detection_91_classes
        preprocessing:
          - type: bgr_to_rgb
          - type: resize
            size: 300
        postprocessing:
          - type: resize_prediction_boxes
        metrics:
          - type: coco_precision
```
It's strange to use "onnx" adapter for tf model, but looks like it's the simpliest way for now