### PR TITLE
[AC]: Fix error on calculate ssim

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/metrics/image_quality_assessment.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/metrics/image_quality_assessment.py
@@ -41,8 +41,8 @@ def _ssim(annotation_image, prediction_image):
     var_x = np.var(prediction)
     var_y = np.var(ground_truth)
     sig_xy = np.mean((prediction - mu_x)*(ground_truth - mu_y))
-    c1 = (0.01 * 2**8-1)**2
-    c2 = (0.03 * 2**8-1)**2
+    c1 = (0.01 * (2**8-1))**2
+    c2 = (0.03 * (2**8-1))**2
     mssim = (2*mu_x*mu_y + c1)*(2*sig_xy + c2)/((mu_x**2 + mu_y**2 + c1)*(var_x + var_y + c2))
     return mssim
 


### PR DESCRIPTION
Now 
c1 = 2.4336
c2 = 44.6224

but on [formula](https://en.wikipedia.org/wiki/Structural_similarity)
c1 = (k1 * L)**2
c2 = (k2 * L)**2

And on [opencv.org](https://docs.opencv.org/4.x/d5/dc4/tutorial_video_input_psnr_ssim.html)
```
C1 = 6.5025
C2 = 58.5225
```
