### PR TITLE
G-API: Background subtraction. Small fix for camera usage.

### DIFF
--- a/demos/background_subtraction_demo/cpp_gapi/main.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/main.cpp
@@ -150,6 +150,7 @@ int main(int argc, char* argv[]) {
                                                                stringToSize(FLAGS_res));
         const auto tmp = cap->read();
         cv::Size frame_size = cv::Size{tmp.cols, tmp.rows};
+        cap.reset();
         // NB: oneVPL source rounds up frame size by 16
         // so size might be different from what ImagesCapture reads.
         if (FLAGS_use_onevpl) {


### PR DESCRIPTION
Problem:
This PR fixes a bug with multiple call to the camera:
```
$: ./background_subtraction_demo_gapi -i 0 <other ...>
[ WARN:0@1.229] global cap_v4l.cpp:982 open VIDEOIO(V4L2:/dev/video0): can't open camera by index
[ERROR:0@1.229] global obsensor_uvc_stream_channel.cpp:156 getStreamChannelGroup Camera index out of range
[ ERROR ] Can't open the camera from 0

```
Solution:
Added reset() for the `ImagesCapture` pointer used to get the size of the first frame.
