### PR TITLE
Relax scikit-learn version requirement for Python3.7

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -15,7 +15,8 @@ imagecodecs~=2021.11.20;python_version=="3.7"
 imagecodecs~=2022.2.22;python_version>="3.8"
 
 # reid
-scikit-learn>=1.2.0
+scikit-learn>=0.24.1;python_version<"3.11"
+scikit-learn>=1.2.0;python_version>="3.11"
 
 # cpu extension usage
 py-cpuinfo>=7.0.0


### PR DESCRIPTION
The latest available scikit-learn verion for Python3.7 is 1.0.2.

To satisfy Python 3.11 keep scikit-learn>=1.2.0 for Python3.11. See https://github.com/openvinotoolkit/open_model_zoo/pull/3663