### PR TITLE
Disable installing `fast-ctc-decode` for Python 3.11

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -45,7 +45,7 @@ nltk>=3.5
 # DNA sequence matching
 parasail>=1.2.4;platform_system!="Windows"
 parasail~=1.2.4;platform_system=="Windows"
-fast-ctc-decode>=0.2.5
+fast-ctc-decode>=0.2.5;python_version<"3.11"
 
 # raw image formats processing
 rawpy>=0.16.0;python_version<"3.7"


### PR DESCRIPTION
`fast-ctc-decode` is not available for Python 3.11, it results in an error when trying to install dependencies on Python 3.11, which is currently being enabled in OpenVINO.

I see that that dependency is not being used anywhere in the code, maybe we could delete it altogether? Its last release was nearly a year ago: https://pypi.org/project/fast-ctc-decode/0.3.2/#history.

cc @eaidova 

