### PR TITLE
Restrict paddle for Python > 3.10

### DIFF
--- a/tools/model_tools/requirements-paddle.in
+++ b/tools/model_tools/requirements-paddle.in
@@ -1,1 +1,1 @@
-paddlepaddle>=2.2.0
+paddlepaddle>=2.2.0;python_version<"3.11"  # ticket 95904


### PR DESCRIPTION
Paddlepaddle is not available for Python 3.11. This causes issues when enabling it in OpenVINO. It has been agreed to temporarily suppress pdpd (see ticket 95904).