### PR TITLE
Disable paddlepaddle

### DIFF
--- a/tools/model_tools/requirements-paddle.in
+++ b/tools/model_tools/requirements-paddle.in
@@ -1,1 +1,2 @@
-paddlepaddle>=2.2.0;python_version<"3.11"  # ticket 95904
+# ticket 95904 - disabled due to incompatible required protobuf version
+#paddlepaddle>=2.2.0


### PR DESCRIPTION
Paddlepaddle has to be disabled at all because even for lower Python versions its installation results in pip conflicts due to incompatible protobuf version