### PR TITLE
Fix incorrect rendering metric in case of processing 1 frame

### DIFF
--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -383,11 +383,13 @@ int main(int argc, char* argv[]) {
         for (; framesProcessed <= frameNum; framesProcessed++) {
             result = pipeline.getResult();
             if (result != nullptr) {
+                auto renderingStart = std::chrono::steady_clock::now();
                 cv::Mat outFrame = renderSegmentationData(result->asRef<ImageResult>(), outputTransform, only_masks);
                 //--- Showing results and device information
                 if (FLAGS_r) {
                     printRawResults(result->asRef<ImageResult>(), labels);
                 }
+                renderMetrics.update(renderingStart);
                 presenter.drawGraphs(outFrame);
                 metrics.update(result->metaData->asRef<ImageMetaData>().timeStamp,
                                outFrame,


### PR DESCRIPTION
This PR fixes the case where we get `Rendering:      nan(snan) ms` for 1 frame which is rather confusing. With properly updating render metric for leftover frames we get the correct number of frames in `getTotal()` function thus correct metric (`Rendering:      0.6 ms`).