### PR TITLE
Update dependencies for Python 3.11

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,6 +1,6 @@
 inflect>=5.3.0
-librosa>=0.8.0
-matplotlib>=3.3.4,<3.6
+librosa>=0.8.0;python_version < '3.11'
+matplotlib>=3.3.4,<3.8
 pyparsing<3.0
 motmetrics>=1.2.0
 nibabel>=3.2.1


### PR DESCRIPTION
There's no Python 3.11 release for `librosa` and `pandas<3.6` doesn't support Python 3.11. 