### PR TITLE
Improve OMZ demos for launching REDOWA models out-of-the-box

### DIFF
--- a/demos/classification_benchmark_demo/cpp/README.md
+++ b/demos/classification_benchmark_demo/cpp/README.md
@@ -144,6 +144,9 @@ Options:
     -no_show                  Optional. Disable showing of processed images.
     -time "<integer>"         Optional. Time in seconds to execute program. Default is -1 (infinite time).
     -u                        Optional. List of monitors to show initially.
+    -reverse_input_channels   Optional. Switch the input channels order from BGR to RGB.
+    -mean_values              Optional. Normalize input by subtracting the mean values per channel. Example: "255.0 255.0 255.0"
+    -scale_values             Optional. Divide input by scale values per channel. Division is applied after mean values subtraction. Example: "255.0 255.0 255.0"
 ```
 
 The number of `InferRequest`s is specified by -nireq flag. Each `InferRequest` acts as a "buffer": it waits in queue before being filled with images and sent for inference, then after the inference completes, it waits in queue until its results are processed. Increasing the number of `InferRequest`s usually increases performance, because in that case multiple `InferRequest`s can be processed simultaneously if the device supports parallelization. However, big number of `InferRequest`s increases latency because each image still needs to wait in queue.

--- a/demos/classification_benchmark_demo/cpp/main.cpp
+++ b/demos/classification_benchmark_demo/cpp/main.cpp
@@ -60,6 +60,11 @@ static const char no_show_message[] = "Optional. Disable showing of processed im
 static const char execution_time_message[] = "Optional. Time in seconds to execute program. "
                                              "Default is -1 (infinite time).";
 static const char utilization_monitors_message[] = "Optional. List of monitors to show initially.";
+static const char reverse_input_channels_message[] = "Optional. Switch the input channels order from BGR to RGB.";
+static const char mean_values_message[] =
+    "Optional. Normalize input by subtracting the mean values per channel. Example: \"255.0 255.0 255.0\"";
+static const char scale_values_message[] = "Optional. Divide input by scale values per channel. Division is applied "
+                                           "after mean values subtraction. Example: \"255.0 255.0 255.0\"";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(i, "", image_message);
@@ -77,6 +82,9 @@ DEFINE_bool(auto_resize, false, input_resizable_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_uint32(time, std::numeric_limits<gflags::uint32>::max(), execution_time_message);
 DEFINE_string(u, "", utilization_monitors_message);
+DEFINE_bool(reverse_input_channels, false, reverse_input_channels_message);
+DEFINE_string(mean_values, "", mean_values_message);
+DEFINE_string(scale_values, "", scale_values_message);
 
 static void showUsage() {
     std::cout << std::endl;
@@ -99,6 +107,9 @@ static void showUsage() {
     std::cout << "    -no_show                  " << no_show_message << std::endl;
     std::cout << "    -time \"<integer>\"         " << execution_time_message << std::endl;
     std::cout << "    -u                        " << utilization_monitors_message << std::endl;
+    std::cout << "    -reverse_input_channels   " << reverse_input_channels_message << std::endl;
+    std::cout << "    -mean_values              " << mean_values_message << std::endl;
+    std::cout << "    -scale_values             " << scale_values_message << std::endl;
 }
 
 bool ParseAndCheckCommandLine(int argc, char* argv[]) {
@@ -219,7 +230,7 @@ int main(int argc, char* argv[]) {
         ov::Core core;
 
         std::unique_ptr<ClassificationModel> model(new ClassificationModel(FLAGS_m, FLAGS_nt, FLAGS_auto_resize, labels, FLAGS_layout));
-        model->setInputsPreprocessing(false, "127 127 127", "255 255 255");
+        model->setInputsPreprocessing(FLAGS_reverse_input_channels, FLAGS_mean_values, FLAGS_scale_values);
 
         AsyncPipeline pipeline(std::move(model),
                                ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),

--- a/demos/classification_benchmark_demo/cpp/main.cpp
+++ b/demos/classification_benchmark_demo/cpp/main.cpp
@@ -218,8 +218,10 @@ int main(int argc, char* argv[]) {
         slog::info << ov::get_openvino_version() << slog::endl;
         ov::Core core;
 
-        AsyncPipeline pipeline(std::unique_ptr<ModelBase>(
-                                   new ClassificationModel(FLAGS_m, FLAGS_nt, FLAGS_auto_resize, labels, FLAGS_layout)),
+        std::unique_ptr<ClassificationModel> model(new ClassificationModel(FLAGS_m, FLAGS_nt, FLAGS_auto_resize, labels, FLAGS_layout));
+        model->setInputsPreprocessing(false, "127 127 127", "255 255 255");
+
+        AsyncPipeline pipeline(std::move(model),
                                ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),
                                core);
 

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -110,7 +110,8 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     }
 
     ov::preprocess::PrePostProcessor ppp(model);
-    ppp.input().tensor().set_element_type(ov::element::u8).set_layout({"NHWC"});
+    ppp.input().tensor().set_element_type(ov::element::f32).set_layout({ "NHWC" });
+    //ppp.input().tensor().set_element_type(ov::element::u8).set_layout({"NHWC"});
 
     if (useAutoResize) {
         ppp.input().tensor().set_spatial_dynamic_shape();

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -110,8 +110,7 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     }
 
     ov::preprocess::PrePostProcessor ppp(model);
-    ppp.input().tensor().set_element_type(ov::element::f32).set_layout({ "NHWC" });
-    //ppp.input().tensor().set_element_type(ov::element::u8).set_layout({"NHWC"});
+    inputTransform.setPrecision(ppp, model->input().get_any_name());
 
     if (useAutoResize) {
         ppp.input().tensor().set_spatial_dynamic_shape();

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -111,6 +111,7 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
 
     ov::preprocess::PrePostProcessor ppp(model);
     inputTransform.setPrecision(ppp, model->input().get_any_name());
+    ppp.input().tensor().set_layout({ "NHWC" });
 
     if (useAutoResize) {
         ppp.input().tensor().set_spatial_dynamic_shape();
@@ -120,7 +121,6 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
             .convert_element_type(ov::element::f32)
             .resize(ov::preprocess::ResizeAlgorithm::RESIZE_LINEAR);
     }
-
     ppp.input().model().set_layout(inputLayout);
 
     // --------------------------- Prepare output  -----------------------------------------------------

--- a/demos/common/cpp/models/src/image_model.cpp
+++ b/demos/common/cpp/models/src/image_model.cpp
@@ -45,7 +45,9 @@ std::shared_ptr<InternalModelData> ImageModel::preprocess(const InputData& input
         const size_t height = tensorShape[ov::layout::height_idx(layout)];
         const size_t channels = tensorShape[ov::layout::channels_idx(layout)];
         if (static_cast<size_t>(img.channels()) != channels) {
-            throw std::runtime_error("The number of channels for model input and image must match");
+            throw std::runtime_error(std::string("The number of channels for model input: ") +
+                                     std::to_string(channels) + " and image: " +
+                                     std::to_string(static_cast<size_t>(img.channels())) + " - must match");
         }
         if (channels != 1 && channels != 3) {
             throw std::runtime_error("Unsupported number of channels");

--- a/demos/common/cpp/models/src/image_model.cpp
+++ b/demos/common/cpp/models/src/image_model.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<InternalModelData> ImageModel::preprocess(const InputData& input
         if (static_cast<size_t>(img.channels()) != channels) {
             throw std::runtime_error(std::string("The number of channels for model input: ") +
                                      std::to_string(channels) + " and image: " +
-                                     std::to_string(static_cast<size_t>(img.channels())) + " - must match");
+                                     std::to_string(img.channels()) + " - must match");
         }
         if (channels != 1 && channels != 3) {
             throw std::runtime_error("Unsupported number of channels");

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -117,8 +117,7 @@ std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infR
             reinterpret_cast<int32_t*>(predictions.data)[i] = int32_t(data[i]);
         }
         predictions.convertTo(result->resultImage, CV_8UC1);
-    }
-    else if (outTensor.get_element_type() == ov::element::f32) {
+    } else if (outTensor.get_element_type() == ov::element::f32) {
         const float* data = outTensor.data<float>();
         for (int rowId = 0; rowId < outHeight; ++rowId) {
             for (int colId = 0; colId < outWidth; ++colId) {
@@ -136,6 +135,7 @@ std::unique_ptr<ResultBase> SegmentationModel::postprocess(InferenceResult& infR
             }  // width
         }  // height
     }
+
     cv::resize(result->resultImage,
                result->resultImage,
                cv::Size(inputImgSize.inputImgWidth, inputImgSize.inputImgHeight),

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -70,6 +70,7 @@ void SegmentationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model) 
 
     ov::preprocess::PrePostProcessor ppp(model);
     inputTransform.setPrecision(ppp, model->input().get_any_name());
+    ppp.input().tensor().set_layout("NHWC");
 
     if (useAutoResize) {
         ppp.input().tensor().set_spatial_dynamic_shape();

--- a/demos/common/cpp/models/src/segmentation_model.cpp
+++ b/demos/common/cpp/models/src/segmentation_model.cpp
@@ -69,7 +69,7 @@ void SegmentationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model) 
     }
 
     ov::preprocess::PrePostProcessor ppp(model);
-    ppp.input().tensor().set_element_type(ov::element::f32).set_layout({"NHWC"});
+    inputTransform.setPrecision(ppp, model->input().get_any_name());
 
     if (useAutoResize) {
         ppp.input().tensor().set_spatial_dynamic_shape();

--- a/demos/common/cpp/models/src/super_resolution_model.cpp
+++ b/demos/common/cpp/models/src/super_resolution_model.cpp
@@ -88,7 +88,8 @@ void SuperResolutionModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& mode
 
     ov::preprocess::PrePostProcessor ppp(model);
     for (const auto& input : inputs) {
-        inputTransform.setPrecision(ppp, input().get_any_name());
+        inputTransform.setPrecision(ppp, input.get_any_name());
+        ppp.input(input.get_any_name()).tensor().set_layout("NHWC");
         ppp.input(input.get_any_name()).model().set_layout(inputLayout);
     }
 

--- a/demos/common/cpp/models/src/super_resolution_model.cpp
+++ b/demos/common/cpp/models/src/super_resolution_model.cpp
@@ -88,8 +88,7 @@ void SuperResolutionModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& mode
 
     ov::preprocess::PrePostProcessor ppp(model);
     for (const auto& input : inputs) {
-        ppp.input(input.get_any_name()).tensor().set_element_type(ov::element::f32).set_layout("NHWC");
-
+        inputTransform.setPrecision(ppp, input().get_any_name());
         ppp.input(input.get_any_name()).model().set_layout(inputLayout);
     }
 
@@ -146,11 +145,7 @@ void SuperResolutionModel::changeInputSize(std::shared_ptr<ov::Model>& model, in
 std::shared_ptr<InternalModelData> SuperResolutionModel::preprocess(const InputData& inputData,
                                                                     ov::InferRequest& request) {
     auto imgData = inputData.asRef<ImageInputData>();
-    //auto& img = imgData.inputImage;
-    cv::Mat rgbCopy;
-
-    cv::cvtColor(imgData.inputImage, rgbCopy, cv::COLOR_BGR2RGB);
-    auto img = inputTransform(rgbCopy);
+    auto img = inputTransform(imgData.inputImage);
 
     const ov::Tensor lrInputTensor = request.get_tensor(inputsNames[0]);
     const ov::Layout layout("NHWC");
@@ -165,13 +160,7 @@ std::shared_ptr<InternalModelData> SuperResolutionModel::preprocess(const InputD
     const size_t height = lrInputTensor.get_shape()[ov::layout::height_idx(layout)];
     const size_t width = lrInputTensor.get_shape()[ov::layout::width_idx(layout)];
     img = resizeImageExt(img, width, height);
-    auto ov_tensor = wrapMat2Tensor(img);
-    std::cout << ov_tensor.get_element_type() << std::endl;
-    for (int i = 0; i < 20; i++)
-    {
-        std::cout << (float)ov_tensor.data<float>()[i] << std::endl;
-    }
-    request.set_tensor(inputsNames[0], ov_tensor);
+    request.set_tensor(inputsNames[0], wrapMat2Tensor(img));
 
     if (inputsNames.size() == 2) {
         const ov::Tensor bicInputTensor = request.get_tensor(inputsNames[1]);
@@ -179,13 +168,7 @@ std::shared_ptr<InternalModelData> SuperResolutionModel::preprocess(const InputD
         const int w = static_cast<int>(bicInputTensor.get_shape()[ov::layout::width_idx(layout)]);
         cv::Mat resized;
         cv::resize(img, resized, cv::Size(w, h), 0, 0, cv::INTER_CUBIC);
-        auto ov_tensor_2 = wrapMat2Tensor(resized);
-        std::cout << ov_tensor_2.get_element_type() << std::endl;
-        for (int i = 0; i < 20; i++)
-        {
-            std::cout << (int)ov_tensor_2.data<uint8_t>()[i] << std::endl;
-        }
-        request.set_tensor(inputsNames[1], ov_tensor_2);
+        request.set_tensor(inputsNames[1], wrapMat2Tensor(resized));
     }
 
     return std::make_shared<InternalImageModelData>(img.cols, img.rows);

--- a/demos/common/cpp/utils/src/config_factory.cpp
+++ b/demos/common/cpp/utils/src/config_factory.cpp
@@ -65,6 +65,15 @@ ModelConfig ConfigFactory::getUserConfig(const std::string& flags_d,
                                                    ov::intel_gpu::hint::ThrottleLevel(1));
             }
         }
+        else if (device.find("VPU") != std::string::npos) {
+            config.compiledModelConfig.emplace(std::string("VPUX_COMPILER_TYPE"),
+                std::string("MLIR"));
+            std::cout << "VPUX_COMPILER_TYPE" << std::endl;
+            
+            config.compiledModelConfig.emplace(std::string("LOG_LEVEL"),
+                                               std::string("LOG_DEBUG"));
+             
+        }
     }
     return config;
 }

--- a/demos/common/cpp/utils/src/config_factory.cpp
+++ b/demos/common/cpp/utils/src/config_factory.cpp
@@ -65,15 +65,6 @@ ModelConfig ConfigFactory::getUserConfig(const std::string& flags_d,
                                                    ov::intel_gpu::hint::ThrottleLevel(1));
             }
         }
-        else if (device.find("VPU") != std::string::npos) {
-            config.compiledModelConfig.emplace(std::string("VPUX_COMPILER_TYPE"),
-                std::string("MLIR"));
-            std::cout << "VPUX_COMPILER_TYPE" << std::endl;
-            
-            config.compiledModelConfig.emplace(std::string("LOG_LEVEL"),
-                                               std::string("LOG_DEBUG"));
-             
-        }
     }
     return config;
 }

--- a/demos/image_processing_demo/cpp/README.md
+++ b/demos/image_processing_demo/cpp/README.md
@@ -102,6 +102,9 @@ Options:
     -output_resolution        Optional. Specify the maximum output window resolution in (width x height) format. Example: 1280x720. Input frame size used by default.
     -u                        Optional. List of monitors to show initially.
     -jc                       Optional. Flag of using compression for jpeg images. Default value if false. Only for jr architecture type.
+    -reverse_input_channels   Optional. Switch the input channels order from BGR to RGB.
+    -mean_values              Optional. Normalize input by subtracting the mean values per channel. Example: "255.0 255.0 255.0"
+    -scale_values             Optional. Divide input by scale values per channel. Division is applied after mean values subtraction. Example: "255.0 255.0 255.0"
 ```
 
 You can use the following command to enhance the resolution of the images captured by a camera using a pre-trained single-image-super-resolution-1033 network:

--- a/demos/image_processing_demo/cpp/main.cpp
+++ b/demos/image_processing_demo/cpp/main.cpp
@@ -80,6 +80,11 @@ static const char output_resolution_message[] =
     "in (width x height) format. Example: 1280x720. Input frame size used by default.";
 static const char jc_message[] = "Optional. Flag of using compression for jpeg images. "
                                  "Default value if false. Only for jr architecture type.";
+static const char reverse_input_channels_message[] = "Optional. Switch the input channels order from BGR to RGB.";
+static const char mean_values_message[] =
+    "Optional. Normalize input by subtracting the mean values per channel. Example: \"255.0 255.0 255.0\"";
+static const char scale_values_message[] = "Optional. Divide input by scale values per channel. Division is applied "
+                                           "after mean values subtraction. Example: \"255.0 255.0 255.0\"";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(at, "", at_message);
@@ -93,6 +98,9 @@ DEFINE_bool(no_show, false, no_show_processed_video);
 DEFINE_string(u, "", utilization_monitors_message);
 DEFINE_string(output_resolution, "", output_resolution_message);
 DEFINE_bool(jc, false, jc_message);
+DEFINE_bool(reverse_input_channels, false, reverse_input_channels_message);
+DEFINE_string(mean_values, "", mean_values_message);
+DEFINE_string(scale_values, "", scale_values_message);
 
 /**
  * \brief This function shows a help message
@@ -118,6 +126,9 @@ static void showUsage() {
     std::cout << "    -output_resolution        " << output_resolution_message << std::endl;
     std::cout << "    -u                        " << utilization_monitors_message << std::endl;
     std::cout << "    -jc                       " << jc_message << std::endl;
+    std::cout << "    -reverse_input_channels   " << reverse_input_channels_message << std::endl;
+    std::cout << "    -mean_values              " << mean_values_message << std::endl;
+    std::cout << "    -scale_values             " << scale_values_message << std::endl;
 }
 
 bool ParseAndCheckCommandLine(int argc, char* argv[]) {
@@ -184,9 +195,9 @@ int main(int argc, char* argv[]) {
         //------------------------------ Running ImageProcessing routines ----------------------------------------------
         slog::info << ov::get_openvino_version() << slog::endl;
         ov::Core core;
-        
+
         std::unique_ptr<ImageModel> model = getModel(cv::Size(curr_frame.cols, curr_frame.rows), FLAGS_at, FLAGS_jc);
-        model->setInputsPreprocessing(true, "0 0 0", "255 255 255");
+        model->setInputsPreprocessing(FLAGS_reverse_input_channels, FLAGS_mean_values, FLAGS_scale_values);
         AsyncPipeline pipeline(std::move(model),
                                ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),
                                core);

--- a/demos/image_processing_demo/cpp/main.cpp
+++ b/demos/image_processing_demo/cpp/main.cpp
@@ -184,8 +184,9 @@ int main(int argc, char* argv[]) {
         //------------------------------ Running ImageProcessing routines ----------------------------------------------
         slog::info << ov::get_openvino_version() << slog::endl;
         ov::Core core;
-
+        
         std::unique_ptr<ImageModel> model = getModel(cv::Size(curr_frame.cols, curr_frame.rows), FLAGS_at, FLAGS_jc);
+        model->setInputsPreprocessing(true, "0 0 0", "255 255 255");
         AsyncPipeline pipeline(std::move(model),
                                ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),
                                core);

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -287,8 +287,10 @@ int main(int argc, char* argv[]) {
         slog::info << ov::get_openvino_version() << slog::endl;
 
         ov::Core core;
+        std::unique_ptr<SegmentationModel> model(new SegmentationModel(FLAGS_m, FLAGS_auto_resize, FLAGS_layout));
+        model->setInputsPreprocessing(false, "127 127 127", "255 255 255");
         AsyncPipeline pipeline(
-            std::unique_ptr<SegmentationModel>(new SegmentationModel(FLAGS_m, FLAGS_auto_resize, FLAGS_layout)),
+            std::move(model),
             ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),
             core);
         Presenter presenter(FLAGS_u);

--- a/demos/segmentation_demo/cpp/main.cpp
+++ b/demos/segmentation_demo/cpp/main.cpp
@@ -76,6 +76,11 @@ static const char output_resolution_message[] =
     "Optional. Specify the maximum output window resolution "
     "in (width x height) format. Example: 1280x720. Input frame size used by default.";
 static const char only_masks_message[] = "Optional. Display only masks. Could be switched by TAB key.";
+static const char reverse_input_channels_message[] = "Optional. Switch the input channels order from BGR to RGB.";
+static const char mean_values_message[] =
+    "Optional. Normalize input by subtracting the mean values per channel. Example: \"255.0 255.0 255.0\"";
+static const char scale_values_message[] = "Optional. Divide input by scale values per channel. Division is applied "
+                                           "after mean values subtraction. Example: \"255.0 255.0 255.0\"";
 
 DEFINE_bool(h, false, help_message);
 DEFINE_string(m, "", model_message);
@@ -91,6 +96,9 @@ DEFINE_bool(no_show, false, no_show_message);
 DEFINE_string(u, "", utilization_monitors_message);
 DEFINE_string(output_resolution, "", output_resolution_message);
 DEFINE_bool(only_masks, false, only_masks_message);
+DEFINE_bool(reverse_input_channels, false, reverse_input_channels_message);
+DEFINE_string(mean_values, "", mean_values_message);
+DEFINE_string(scale_values, "", scale_values_message);
 
 /**
  * \brief This function shows a help message
@@ -118,6 +126,9 @@ static void showUsage() {
     std::cout << "    -output_resolution        " << output_resolution_message << std::endl;
     std::cout << "    -u                        " << utilization_monitors_message << std::endl;
     std::cout << "    -only_masks               " << only_masks_message << std::endl;
+    std::cout << "    -reverse_input_channels   " << reverse_input_channels_message << std::endl;
+    std::cout << "    -mean_values              " << mean_values_message << std::endl;
+    std::cout << "    -scale_values             " << scale_values_message << std::endl;
 }
 
 bool ParseAndCheckCommandLine(int argc, char* argv[]) {
@@ -288,7 +299,7 @@ int main(int argc, char* argv[]) {
 
         ov::Core core;
         std::unique_ptr<SegmentationModel> model(new SegmentationModel(FLAGS_m, FLAGS_auto_resize, FLAGS_layout));
-        model->setInputsPreprocessing(false, "127 127 127", "255 255 255");
+        model->setInputsPreprocessing(FLAGS_reverse_input_channels, FLAGS_mean_values, FLAGS_scale_values);
         AsyncPipeline pipeline(
             std::move(model),
             ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads),


### PR DESCRIPTION
1) Add `scale/normalization` for some demos in command arguments
2) Enforce segmentation model layout to NCHW conversion