### PR TITLE
Fix `mobilenet-v3-large-1.0-224-tf` conversion

### DIFF
--- a/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
@@ -30,7 +30,7 @@ input_info:
     layout: NHWC
 model_optimizer_args:
   - --reverse_input_channels
-  - --output=StatefulPartitionedCall/MobilenetV3large/Predictions/Softmax
+  - --output=Predictions
   - --saved_model_dir=$conv_dir/mobilenet_v3_large_224_1.0_float.savedmodel
 framework: tf
 quantizable: true

--- a/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v3-large-1.0-224-tf/model.yml
@@ -30,7 +30,6 @@ input_info:
     layout: NHWC
 model_optimizer_args:
   - --reverse_input_channels
-  - --output=Predictions
   - --saved_model_dir=$conv_dir/mobilenet_v3_large_224_1.0_float.savedmodel
 framework: tf
 quantizable: true

--- a/models/public/mobilenet-v3-small-1.0-224-tf/model.yml
+++ b/models/public/mobilenet-v3-small-1.0-224-tf/model.yml
@@ -30,7 +30,6 @@ input_info:
     layout: NHWC
 model_optimizer_args:
   - --reverse_input_channels
-  - --output=StatefulPartitionedCall/MobilenetV3small/Predictions/Softmax
   - --saved_model_dir=$conv_dir/mobilenet_v3_small_224_1.0_float.savedmodel
 framework: tf
 quantizable: true


### PR DESCRIPTION
OpenVINO 2023.0 just got released. `model_api` precommit fails to convert `mobilenet-v3-large-1.0-224-tf` with new OpenVINO