### PR TITLE
Restrict numpy for unsupported Python versions

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -4,7 +4,8 @@ matplotlib>=3.3.4,<3.8
 pyparsing<3.0
 motmetrics>=1.2.0
 nibabel>=3.2.1
-numpy>=1.16.6
+numpy>=1.16.6,<1.25; python_version<'3.9'
+numpy>=1.16.6; python_version>='3.9'
 opencv-python
 pillow>=8.1.2
 pyyaml>=5.4.1

--- a/tools/accuracy_checker/requirements-core.in
+++ b/tools/accuracy_checker/requirements-core.in
@@ -1,6 +1,7 @@
 # core components
 defusedxml>=0.7.1
-numpy>=1.16.6
+numpy>=1.16.6,<1.25; python_version<'3.9'
+numpy>=1.16.6; python_version>='3.9'
 openvino-telemetry>=2022.1.0
 PyYAML>=5.4.1
 pillow>=8.1.2


### PR DESCRIPTION
## Details

- pip resolver is sporadically choosing numpy==1.25.0rc1 for unsupported Python versions, causing random CI fails
- the PR is currently a draft because of a **discussion in the ticket** - I recommend waiting to see if there are more reproductions before merging, but it's a subject to change and discuss

Ticket: 112557