### PR TITLE
Restrict scipy module version for Accuracy Checker extras

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -29,7 +29,8 @@ pyclipper>=1.2.1
 
 # brain tumor segmentation
 nibabel>=3.2.1
-scipy >=1.5.4
+# nncf's upperbound: https://github.com/openvinotoolkit/nncf/blob/a8af39627647ddbb89ef33cf42ff42e9c048b981/setup.py#L106
+scipy >=1.5.4,<1.11
 
 # dicom images reading
 pydicom>=2.1.2


### PR DESCRIPTION
To comply with NNCF's upperbound: https://github.com/openvinotoolkit/nncf/blob/a8af39627647ddbb89ef33cf42ff42e9c048b981/setup.py#L106. Pip conflicts checks are failing after the recent Scipy release: https://pypi.org/project/scipy/1.11.0