### PR TITLE
Enable postprocessing of SQuADv2 datasets with impossible answers

### DIFF
--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/README.md
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/README.md
@@ -83,6 +83,8 @@ Accuracy Checker supports following set of postprocessors:
 * `extract_answers_tokens` - extract predicted sequence of tokens from annotation text. Supported representations: `QuestionAnsweringAnnotation`, `QuestionAnsweringPrediction`.
   * `max_answer` - maximum answer length (Optional, default value is 30).
   * `n_best_size` - total number of n-best prediction size for the answer (Optional, default value is 20).
+  * `v2_with_no_answers` - boolean value, if true indicates use of SQuADv2 dataset with some questions impossible to answer.
+  * `no_answer_score_threshold` - threshold value below which SQuADv2 predictions are ignored (prediction with no answer).
 * `bidaf_extract_answers_tokens` - extract predicted sequence of tokens from annotation text. Supported representations: `QuestionAnsweringBiDAFAnnotation`, `QuestionAnsweringPrediction`.
 * `translate_3d_poses` - translating 3D poses. Supported representations: `PoseEstimation3dAnnotation`, `PoseEstimation3dPrediction`. Shifts 3D coordinates of each predicted poses on corresponding translation vector.
 * `resize_super_resolution` - resizing super resolution predicted image. Supported representations: `SuperResolutionAnotation`, `SuperResolutionPrediction`.

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/extract_answers_tokens.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/extract_answers_tokens.py
@@ -53,7 +53,8 @@ class ExtractSQUADPrediction(Postprocessor):
                 optional=True, default=False, description="The SQuADv2 dataset with questions impossible to answer."
             ),
             'no_answer_score_threshold': NumberField(
-                optional=True, value_type=float, default=0.0, description="No answer for prediction scores below threshold for SQuADv2."
+                optional=True, value_type=float, default=0.0, 
+                description="No answer for prediction scores below threshold for SQuADv2."
             )
         })
         return parameters
@@ -268,4 +269,3 @@ class ExtractSQUADPredictionBiDAF(Postprocessor):
             prediction_.tokens = tokens
 
         return annotation, prediction
-

--- a/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/extract_answers_tokens.py
+++ b/tools/accuracy_checker/openvino/tools/accuracy_checker/postprocessor/extract_answers_tokens.py
@@ -53,7 +53,7 @@ class ExtractSQUADPrediction(Postprocessor):
                 optional=True, default=False, description="The SQuADv2 dataset with questions impossible to answer."
             ),
             'no_answer_score_threshold': NumberField(
-                optional=True, value_type=float, default=0.0, 
+                optional=True, value_type=float, default=0.0,
                 description="No answer for prediction scores below threshold for SQuADv2."
             )
         })


### PR DESCRIPTION
Adds 2 parameters for SQuADv2 datasets:
- v2_with_no_answers - enables processing of SQuADv2 dataset questions impossible to answer using no_answer_score_threshold.
- no_answer_score_threshold - gives no answer for sum of start_logit and end_logit predictions below threshold