### PR TITLE
3d_segmentation_demo: fix ValueError

### DIFF
--- a/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
+++ b/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
@@ -367,7 +367,7 @@ def main():
     if args.output_nifti and is_nifti_data:
         for seg_res in list_seg_result:
             nii_filename = os.path.join(args.path_to_output, 'output_{}.nii.gz'.format(list_seg_result.index(seg_res)))
-            # Nifti1Image expects uit8, but brain-tumor-segmentation-0001 gives int64.
+            # Nifti1Image expects uint8, but brain-tumor-segmentation-0001 gives int64.
             # brain-tumor-segmentation-0002 gives uint8
             nib.save(nib.Nifti1Image(seg_res.astype(np.uint8), affine=affine), nii_filename)
             log.debug("Result nifti file was saved to {}".format(nii_filename))

--- a/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
+++ b/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
@@ -367,6 +367,8 @@ def main():
     if args.output_nifti and is_nifti_data:
         for seg_res in list_seg_result:
             nii_filename = os.path.join(args.path_to_output, 'output_{}.nii.gz'.format(list_seg_result.index(seg_res)))
+            # Nifti1Image expects uit8, but brain-tumor-segmentation-0001 gives int64.
+            # brain-tumor-segmentation-0002 gives uit8
             nib.save(nib.Nifti1Image(seg_res.astype(np.uint8), affine=affine), nii_filename)
             log.debug("Result nifti file was saved to {}".format(nii_filename))
 

--- a/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
+++ b/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
@@ -368,7 +368,7 @@ def main():
         for seg_res in list_seg_result:
             nii_filename = os.path.join(args.path_to_output, 'output_{}.nii.gz'.format(list_seg_result.index(seg_res)))
             # Nifti1Image expects uit8, but brain-tumor-segmentation-0001 gives int64.
-            # brain-tumor-segmentation-0002 gives uit8
+            # brain-tumor-segmentation-0002 gives uint8
             nib.save(nib.Nifti1Image(seg_res.astype(np.uint8), affine=affine), nii_filename)
             log.debug("Result nifti file was saved to {}".format(nii_filename))
 

--- a/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
+++ b/demos/3d_segmentation_demo/python/3d_segmentation_demo.py
@@ -367,7 +367,7 @@ def main():
     if args.output_nifti and is_nifti_data:
         for seg_res in list_seg_result:
             nii_filename = os.path.join(args.path_to_output, 'output_{}.nii.gz'.format(list_seg_result.index(seg_res)))
-            nib.save(nib.Nifti1Image(seg_res, affine=affine), nii_filename)
+            nib.save(nib.Nifti1Image(seg_res.astype(np.uint8), affine=affine), nii_filename)
             log.debug("Result nifti file was saved to {}".format(nii_filename))
 
 if __name__ == "__main__":

--- a/demos/multi_channel_common/cpp/graph.hpp
+++ b/demos/multi_channel_common/cpp/graph.hpp
@@ -32,7 +32,7 @@ static inline std::queue<ov::InferRequest> compile(std::shared_ptr<ov::Model>&& 
     core.set_property("CPU", ov::affinity(ov::Affinity::NONE));
     ov::CompiledModel compiled = core.compile_model(model, device, {
         {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},
-        {ov::hint::num_requests(performanceHintNumRequests)}});
+        {ov::hint::num_requests(4)}});
     unsigned maxRequests = compiled.get_property(ov::optimal_number_of_infer_requests) + 1;
     logCompiledModelInfo(compiled, modelPath, device);
     slog::info << "\tNumber of network inference requests: " << std::to_string(maxRequests) << slog::endl;

--- a/demos/multi_channel_common/cpp/graph.hpp
+++ b/demos/multi_channel_common/cpp/graph.hpp
@@ -32,7 +32,7 @@ static inline std::queue<ov::InferRequest> compile(std::shared_ptr<ov::Model>&& 
     core.set_property("CPU", ov::affinity(ov::Affinity::NONE));
     ov::CompiledModel compiled = core.compile_model(model, device, {
         {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},
-        {ov::hint::num_requests(4)}});
+        {ov::hint::num_requests(performanceHintNumRequests)}});
     unsigned maxRequests = compiled.get_property(ov::optimal_number_of_infer_requests) + 1;
     logCompiledModelInfo(compiled, modelPath, device);
     slog::info << "\tNumber of network inference requests: " << std::to_string(maxRequests) << slog::endl;


### PR DESCRIPTION
brain-tumor-segmentation-0001 produces int64 which triggers `ValueError: Image data has type int64, which may cause incompatibilities with other tools. To use this type, pass an explicit header or dtype argument to Nifti1Image()` We can't even convert in on precommits thus we don't observe the issue. brain-tumor-segmentation-0002 gives uint8.

Ticket 111903