### PR TITLE
Limit `scipy` to a secure version

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -30,7 +30,7 @@ pyclipper>=1.2.1
 # brain tumor segmentation
 nibabel>=3.2.1
 # nncf's upperbound: https://github.com/openvinotoolkit/nncf/blob/a8af39627647ddbb89ef33cf42ff42e9c048b981/setup.py#L106
-scipy >=1.5.4,<1.11
+scipy>=1.5.4
 
 # dicom images reading
 pydicom>=2.1.2

--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -30,7 +30,7 @@ pyclipper>=1.2.1
 # brain tumor segmentation
 nibabel>=3.2.1
 # nncf's upperbound: https://github.com/openvinotoolkit/nncf/blob/a8af39627647ddbb89ef33cf42ff42e9c048b981/setup.py#L106
-scipy>=1.5.4
+scipy>=1.11.1
 
 # dicom images reading
 pydicom>=2.1.2


### PR DESCRIPTION
Despite being lower bound only, this version still causes issues in OpenVINO pip-conflicts check at https://github.com/openvinotoolkit/openvino/pull/19458
One way or another, bumping `scipy` lower bound to lowest secure version is a good change.

Ticket: 117438