### PR TITLE
Parameterize model device for demo and tests

### DIFF
--- a/demos/action_recognition_demo/python/action_recognition_demo.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo.py
@@ -90,6 +90,7 @@ def main():
     decoder_target_device = 'CPU'
     if args.device != 'CPU':
         encoder_target_device = args.device
+        decoder_target_device = args.device
     else:
         encoder_target_device = decoder_target_device
 

--- a/demos/tests/cases.py
+++ b/demos/tests/cases.py
@@ -251,7 +251,7 @@ DEMOS = [
 
     CppDemo(name='gaze_estimation_demo', implementation='cpp_gapi',
             model_keys=['-m', '-m_fd', '-m_hp', '-m_lm', '-m_es'],
-            device_keys=['-d', '-d_fd', '-d_hp', '-d_lm'],
+            device_keys=['-d', '-d_fd', '-d_hp', '-d_lm', '-d_es'],
             test_cases=combine_cases(
         TestCase(options={'-no_show': None,
             **MONITORS,
@@ -443,7 +443,7 @@ DEMOS = [
 
     CppDemo(name='gaze_estimation_demo',
             model_keys=['-m', '-m_fd', '-m_hp', '-m_lm', '-m_es'],
-            device_keys=['-d', '-d_fd', '-d_hp', '-d_lm'],
+            device_keys=['-d', '-d_fd', '-d_hp', '-d_lm', '-d_es'],
             test_cases=combine_cases(
         TestCase(options={'-no_show': None,
             **MONITORS,
@@ -1239,7 +1239,7 @@ DEMOS = [
             ModelArg('instance-segmentation-security-1040')),
     )),
 
-    PythonDemo(name='machine_translation_demo', device_keys=[], test_cases=combine_cases(
+    PythonDemo(name='machine_translation_demo', device_keys=['-d'], test_cases=combine_cases(
         [
             TestCase(options={
                 '-m': ModelArg('machine-translation-nar-de-en-0002'),


### PR DESCRIPTION
This PR aims to parameterize model device and enable demo tests to run with device other than CPU. 

Scope of impact as below:
- Demo
   - `action_recognition_demo.py`  - `encoder_target_device`
- Demo tests
   - `gaze_estimation_demo` (both 'cpp_gapi' and 'cpp') - `-d_es`, duplicated PR: #3865
   -  `machine_translation_demo` ('python') - `-d`, duplicated PR: #3874