### PR TITLE
[E-103104] - Port G-API demos to API2.0 - part 1

### DIFF
--- a/demos/classification_benchmark_demo/cpp_gapi/classification_benchmark_demo_gapi.hpp
+++ b/demos/classification_benchmark_demo/cpp_gapi/classification_benchmark_demo_gapi.hpp
@@ -51,7 +51,7 @@ DEFINE_string(res, "1280x720", image_grid_resolution_message);
 DEFINE_bool(no_show, false, no_show_message);
 DEFINE_uint32(time, std::numeric_limits<gflags::uint32>::max(), execution_time_message);
 DEFINE_string(u, "", utilization_monitors_message);
-DEFINE_string(backend, "IE", backend_message);
+DEFINE_string(backend, "OV", backend_message);
 DEFINE_string(mean_values, "", mean_values_message);
 DEFINE_string(scale_values, "", scale_values_message);
 

--- a/demos/face_detection_mtcnn_demo/cpp_gapi/main.cpp
+++ b/demos/face_detection_mtcnn_demo/cpp_gapi/main.cpp
@@ -29,6 +29,7 @@
 #include <opencv2/gapi/imgproc.hpp>
 #include <opencv2/gapi/infer.hpp>
 #include <opencv2/gapi/infer/ie.hpp>
+#include <opencv2/gapi/infer/ov.hpp>
 #include <opencv2/gapi/render/render.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
@@ -191,7 +192,7 @@ int main(int argc, char* argv[]) {
         // MTCNN Refinement detection network
         // clang-format off
         auto mtcnnr_net =
-            cv::gapi::ie::Params<nets::MTCNNRefinement>{
+            cv::gapi::ov::Params<nets::MTCNNRefinement>{
                 FLAGS_m_r,  // path to topology IR
                 fileNameNoExt(FLAGS_m_r) + ".bin",  // path to weights
                 FLAGS_d_r,  // device specifier
@@ -200,7 +201,7 @@ int main(int argc, char* argv[]) {
 
         // MTCNN Output detection network
         auto mtcnno_net =
-            cv::gapi::ie::Params<nets::MTCNNOutput>{
+            cv::gapi::ov::Params<nets::MTCNNOutput>{
                 FLAGS_m_o,  // path to topology IR
                 fileNameNoExt(FLAGS_m_o) + ".bin",  // path to weights
                 FLAGS_d_o,  // device specifier
@@ -213,13 +214,13 @@ int main(int argc, char* argv[]) {
         for (int i = 0; i < pyramid_levels; ++i) {
             std::string net_id = get_pnet_level_name(level_size[i]);
             std::vector<size_t> reshape_dims = {1, 3, size_t(level_size[i].width), size_t(level_size[i].height)};
-            cv::gapi::ie::Params<cv::gapi::Generic> mtcnnp_net{
+            cv::gapi::ov::Params<cv::gapi::Generic> mtcnnp_net{
                 net_id,  // tag
                 FLAGS_m_p,  // path to topology IR
                 fileNameNoExt(FLAGS_m_p) + ".bin",  // path to weights
                 FLAGS_d_p,  // device specifier
             };
-            mtcnnp_net.cfgInputReshape("data", reshape_dims);
+            mtcnnp_net.cfgReshape(reshape_dims);
             networks_mtcnn += cv::gapi::networks(mtcnnp_net);
         }
 

--- a/demos/face_detection_mtcnn_demo/cpp_gapi/main.cpp
+++ b/demos/face_detection_mtcnn_demo/cpp_gapi/main.cpp
@@ -28,7 +28,6 @@
 #include <opencv2/gapi/gstreaming.hpp>
 #include <opencv2/gapi/imgproc.hpp>
 #include <opencv2/gapi/infer.hpp>
-#include <opencv2/gapi/infer/ie.hpp>
 #include <opencv2/gapi/infer/ov.hpp>
 #include <opencv2/gapi/render/render.hpp>
 #include <opencv2/highgui.hpp>

--- a/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
+++ b/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
@@ -38,7 +38,6 @@
 #include <opencv2/gapi/gproto.hpp>
 #include <opencv2/gapi/gstreaming.hpp>
 #include <opencv2/gapi/infer.hpp>
-#include <opencv2/gapi/infer/ie.hpp>
 #include <opencv2/gapi/infer/ov.hpp>
 #include <opencv2/gapi/infer/parsers.hpp>
 #include <opencv2/gapi/streaming/format.hpp>

--- a/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
+++ b/demos/interactive_face_detection_demo/cpp_gapi/main.cpp
@@ -39,6 +39,7 @@
 #include <opencv2/gapi/gstreaming.hpp>
 #include <opencv2/gapi/infer.hpp>
 #include <opencv2/gapi/infer/ie.hpp>
+#include <opencv2/gapi/infer/ov.hpp>
 #include <opencv2/gapi/infer/parsers.hpp>
 #include <opencv2/gapi/streaming/format.hpp>
 #include <opencv2/highgui.hpp>
@@ -469,7 +470,7 @@ int main(int argc, char* argv[]) {
     auto pipeline = cv::GComputation(cv::GIn(in), std::move(outs));
     /** ---------------- End of graph ---------------- **/
     /** Configure networks **/
-    auto det_net = cv::gapi::ie::Params<Faces>{
+    auto det_net = cv::gapi::ov::Params<Faces>{
         FLAGS_m,  // path to model
         fileNameNoExt(FLAGS_m) + ".bin",  // path to weights
         FLAGS_d  // device to use
@@ -478,7 +479,7 @@ int main(int argc, char* argv[]) {
 
     // clang-format off
     auto age_net =
-        cv::gapi::ie::Params<AgeGender>{
+        cv::gapi::ov::Params<AgeGender>{
             FLAGS_mag,  // path to model
             fileNameNoExt(FLAGS_mag) + ".bin",  // path to weights
             FLAGS_dag  // device to use
@@ -494,7 +495,7 @@ int main(int argc, char* argv[]) {
 
     // clang-format off
     auto hp_net =
-        cv::gapi::ie::Params<HeadPose>{
+        cv::gapi::ov::Params<HeadPose>{
             FLAGS_mhp,  // path to model
             fileNameNoExt(FLAGS_mhp) + ".bin",  // path to weights
             FLAGS_dhp  // device to use
@@ -510,7 +511,7 @@ int main(int argc, char* argv[]) {
 
     // clang-format off
     auto lm_net =
-        cv::gapi::ie::Params<FacialLandmark>{
+        cv::gapi::ov::Params<FacialLandmark>{
             FLAGS_mlm,  // path to model
             fileNameNoExt(FLAGS_mlm) + ".bin",  // path to weights
             FLAGS_dlm  // device to use
@@ -524,7 +525,7 @@ int main(int argc, char* argv[]) {
         slog::info << "Facial Landmarks Estimation DISABLED." << slog::endl;
     }
 
-    auto am_net = cv::gapi::ie::Params<ASpoof>{
+    auto am_net = cv::gapi::ov::Params<ASpoof>{
         FLAGS_mam,  // path to model
         fileNameNoExt(FLAGS_mam) + ".bin",  // path to weights
         FLAGS_dam  // device to use
@@ -535,7 +536,7 @@ int main(int argc, char* argv[]) {
         slog::info << "Anti Spoof DISABLED." << slog::endl;
     }
 
-    auto emo_net = cv::gapi::ie::Params<Emotions>{
+    auto emo_net = cv::gapi::ov::Params<Emotions>{
         FLAGS_mem,  // path to model
         fileNameNoExt(FLAGS_mem) + ".bin",  // path to weights
         FLAGS_dem  // device to use


### PR DESCRIPTION
### Tiket:
103104

### Description:
G-API Background Subtraction Demo, Classification Benchmark C++ G-API Demo, G-API Gaze Estimation Demo and other - fail on NPU with the following error: `dynamic shape issues`
```
get_shape was called on a descriptor::Tensor with dynamic shape
```

- OpenVINO is actively removing API 1.0 from their code
- Both G-API framework and G-API demos use API 1.0 --> which leads to disruption of certain functionality
Conclusion: We need to port the G-API demos to API2.0 to make them work.

### Affected demos:
Passing:
- [x] classification_benchmark_demo
- [x] face_detection_mtcnn_demo
- [x] interactive_face_detection_demo

### Related PRs:
Part 2: https://github.com/openvinotoolkit/open_model_zoo/pull/3887 - WIP