### PR TITLE
Try to unlimit pyparsing to fix CVS-128637

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,7 +1,7 @@
 inflect>=5.3.0
 librosa>=0.8.0;python_version < '3.11'
 matplotlib>=3.3.4,<3.8
-pyparsing<3.0
+pyparsing
 motmetrics>=1.2.0
 nibabel>=3.2.1
 numpy>=1.16.6


### PR DESCRIPTION
After a fresh pydot module release https://pypi.org/project/pydot/2.0.0 there are failures in precommit pip-conflicts stage:
`install 3.11_pip_23.1.2 nncf ERROR: error: pyparsing 2.4.7 is installed but pyparsing>=3 is required by {'pydot'}`