### PR TITLE
Port G-API demos to API2.0 - background_subtraction_demo/cpp_gapi

### DIFF
--- a/demos/background_subtraction_demo/cpp_gapi/main.cpp
+++ b/demos/background_subtraction_demo/cpp_gapi/main.cpp
@@ -27,7 +27,7 @@
 #include <opencv2/gapi/gstreaming.hpp>
 #include <opencv2/gapi/imgproc.hpp>
 #include <opencv2/gapi/infer.hpp>
-#include <opencv2/gapi/infer/ie.hpp>
+#include <opencv2/gapi/infer/ov.hpp>
 #include <opencv2/gapi/own/assert.hpp>
 #include <opencv2/gapi/streaming/source.hpp>
 #include <opencv2/gapi/util/optional.hpp>
@@ -147,13 +147,13 @@ int main(int argc, char* argv[]) {
         auto config = ConfigFactory::getUserConfig(FLAGS_d, FLAGS_nireq, FLAGS_nstreams, FLAGS_nthreads);
         // clang-format off
         const auto net =
-            cv::gapi::ie::Params<cv::gapi::Generic>{
+            cv::gapi::ov::Params<cv::gapi::Generic>{
                 model->getName(),
                 FLAGS_m,  // path to topology IR
                 fileNameNoExt(FLAGS_m) + ".bin",  // path to weights
                 FLAGS_d  // device specifier
             }.cfgNumRequests(config.maxAsyncRequests)
-             .pluginConfig(config.getLegacyConfig());
+             .cfgPluginConfig(config.getLegacyConfig());
         // clang-format on
 
         slog::info << "The background matting model " << FLAGS_m << " is loaded to " << FLAGS_d << " device."


### PR DESCRIPTION
### Ticket:
103104

### Description:
G-API Background Subtraction Demo, Classification Benchmark C++ G-API Demo, G-API Gaze Estimation Demo and other - fail on NPU with the following error: `dynamic shape issues`
```
get_shape was called on a descriptor::Tensor with dynamic shape
```

- OpenVINO is actively removing API 1.0 from their code
- Both G-API framework and G-API demos use API 1.0 --> which leads to disruption of certain functionality
Conclusion: We need to port the G-API demos to API2.0 to make them work.

### Affected demos:
- [ ] background_subtraction_demo
[ ERROR ] OpenCV(4.8.0-dev) ..\modules\gapi\src\backends\ov\govbackend.cpp:799: error: (-215:Assertion failed) cv::util::holds_alternative<cv::GMatDesc>(input_meta) in function 'cv::gimpl::ov::PrePostProcWrapper::cfgPreProcessing' - WIP

Also needs the following change to be merge to OpenCV repo:
- [ ] https://github.com/opencv/opencv/pull/24938