### PR TITLE
Relax numpy

### DIFF
--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -4,4 +4,3 @@ scipy>=1.5.4
 torch>=1.8.1
 torchvision>=0.9.1
 yacs>=0.1.8
-numpy<1.24  # quartznet-15x5-en

--- a/tools/model_tools/requirements-tensorflow.in
+++ b/tools/model_tools/requirements-tensorflow.in
@@ -1,2 +1,1 @@
 tensorflow>=2.5,<2.15.0
-numpy<1.24  # hybrid-cs-model-mri


### PR DESCRIPTION
Having that constraint causes openvino pip-conflicts_* jobs to compile numpy 1.19.3 and fail. Ci ignores requirements-pytorch.in, so it’s possible to keep the constraint here, but I think it’s better not to rely on openvino’s imperfections