### PR TITLE
Bump AC version remove deprecated frameworks

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/__init__.py
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.9.6"
+__version__ = "0.10.6"

--- a/tools/model_tools/src/omz_tools/_common.py
+++ b/tools/model_tools/src/omz_tools/_common.py
@@ -34,11 +34,8 @@ if not MODEL_ROOT.exists() or not DATASET_DEFINITIONS.exists():
 
 # make sure to update the documentation if you modify these
 KNOWN_FRAMEWORKS = {
-    'caffe': None,
     'dldt': None,
-    'mxnet': None,
     'onnx': None,
-    'paddle': None,
     'pytorch': 'pytorch_to_onnx.py',
     'tf': None,
 }


### PR DESCRIPTION
I'm not going to enforse inclusion of these changes into 24.0, but it's good to have it awnyway