### PR TITLE
Fix for missing model_zoo package.

### DIFF
--- a/demos/common/python/model_zoo/__init__.py
+++ b/demos/common/python/model_zoo/__init__.py
@@ -1,0 +1,14 @@
+"""
+ Copyright (C) 2024 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Updated `__init__.py` for the demos/common/python/model_zoo package.