### PR TITLE
remove pyparsing upperbound for 2022.3 LTS

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,7 +1,7 @@
 inflect>=5.3.0
 librosa>=0.8.0
 matplotlib>=3.3.4,<3.6
-pyparsing<3.0
+pyparsing
 motmetrics>=1.2.0
 nibabel>=3.2.1
 numpy>=1.16.6


### PR DESCRIPTION
To resolve conflict between nncf and omz requirements.

There already was such a [PR](https://github.com/openvinotoolkit/open_model_zoo/pull/3890).