### PR TITLE
[PyOV] Limit numpy to major version

### DIFF
--- a/demos/common/python/requirements.txt
+++ b/demos/common/python/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.16.6
+numpy>=1.16.6,<2.0.0
 opencv-python
 scipy>=1.5.4

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -4,7 +4,7 @@ matplotlib>=3.3.4,<3.8
 pyparsing
 motmetrics>=1.2.0
 nibabel>=3.2.1
-numpy>=1.16.6
+numpy>=1.16.6,<2.0.0
 opencv-python
 pillow>=8.1.2
 pyyaml>=5.4.1

--- a/tools/accuracy_checker/requirements-core.in
+++ b/tools/accuracy_checker/requirements-core.in
@@ -1,6 +1,6 @@
 # core components
 defusedxml>=0.7.1
-numpy>=1.16.6
+numpy>=1.16.6,<2.0.0
 openvino-telemetry>=2023.2.1
 PyYAML>=5.4.1
 pillow>=8.1.2


### PR DESCRIPTION
Related story: https://github.com/openvinotoolkit/openvino/pull/24103

**Tickets:**
* [CVS-138838](https://jira.devtools.intel.com/browse/CVS-138838)