### PR TITLE
demos: fix speech_recognition_deepspeech

### DIFF
--- a/demos/speech_recognition_deepspeech_demo/python/asr_utils/profiles.py
+++ b/demos/speech_recognition_deepspeech_demo/python/asr_utils/profiles.py
@@ -26,10 +26,10 @@ PROFILES = {
         # in_state_c, in_state_h, out_state_c, out_state_h, in_data, out_data (str), IR node names
         'in_state_c': 'previous_state_c:0',
         'in_state_h': 'previous_state_h:0',
-        'out_state_c': 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd',
-        'out_state_h': 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1',
+        'out_state_c': 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd:0',
+        'out_state_h': 'cudnn_lstm/rnn/multi_rnn_cell/cell_0/cudnn_compatible_lstm_cell/GatherNd_1:0',
         'in_data': 'input_node',
-        'out_data': 'logits',  # Despite being named logits, output is probabilities after softmax
+        'out_data': 'logits:0',  # Despite being named logits, output is probabilities after softmax
 
         # === CTC decoder and LM parameters ===
         # log_probs (bool), True is input data contains base e log(probabilities), False if simply probabilities.


### PR DESCRIPTION
It seems MO added :0 to the names for mozilla-deepspeech-0.6.1 and mozilla-deepspeech-0.8.2 despite the fact that the config doesn't have :0: https://github.com/openvinotoolkit/open_model_zoo/blob/828890a839480240467bffc0c4165e37b38719a8/models/public/mozilla-deepspeech-0.6.1/model.yml#L47