### PR TITLE
Fix plugin bug in object detection demo

### DIFF
--- a/demos/common/python/model_zoo/model_api/pipelines/async_pipeline.py
+++ b/demos/common/python/model_zoo/model_api/pipelines/async_pipeline.py
@@ -88,8 +88,12 @@ def get_user_config(flags_d: str, flags_nstreams: str, flags_nthreads: int)-> Di
                     config['MULTI']['GPU_PLUGIN_THROTTLE'] = '1'
 
     if 'MULTI' in flags_d:
+        if 'CPU' in devices:
+            config['MULTI'].update(config['CPU'])
+        print(config)
         return config['MULTI']
     else:
+        print(config)
         return config[flags_d]
 
 

--- a/demos/common/python/model_zoo/model_api/pipelines/async_pipeline.py
+++ b/demos/common/python/model_zoo/model_api/pipelines/async_pipeline.py
@@ -84,6 +84,7 @@ def get_user_config(flags_d: str, flags_nstreams: str, flags_nthreads: int)-> Di
                 # multi-device execution with the CPU + GPU performs best with GPU throttling hint,
                 # which releases another CPU thread (that is otherwise used by the GPU driver for active polling)
                 if 'CPU' in devices:
+                    config['MULTI'].update(config['CPU'])
                     config['MULTI']['GPU_PLUGIN_THROTTLE'] = '1'
 
     if 'MULTI' in flags_d:


### PR DESCRIPTION
In the Python demo, the argument -device can only take AUTO because of the previous bug inside of the async_pipeline.py script. Updated the script so it can handle the device configuration correctly. 