### PR TITLE
Avoid accessing absent element of the empty container

### DIFF
--- a/demos/classification_benchmark_demo/cpp/main.cpp
+++ b/demos/classification_benchmark_demo/cpp/main.cpp
@@ -317,7 +317,7 @@ int main(int argc, char* argv[]) {
                     throw std::invalid_argument("Renderer: image provided in metadata is empty");
                 }
                 PredictionResult predictionResult = PredictionResult::Incorrect;
-                std::string label = classificationResult.topLabels.front().label;
+                std::string label = (classificationResult.topLabels.size() != 0) ? classificationResult.topLabels.front().label : "N/A";
                 if (!FLAGS_gt.empty()) {
                     for (size_t i = 0; i < FLAGS_nt; i++) {
                         unsigned predictedClass = classificationResult.topLabels[i].id;


### PR DESCRIPTION
Ticket: [144363]

### Description:
Classification Benchmark C++ might crash when classification results list is empty. Fix is to substitute default 'N/A' value in case of empty result.

### Affected demos:
 classification_benchmark_demo 

