### PR TITLE
Use last model layer for benchmarking (do not pick softmax layer, which may be located somewhere in the middle of the model (#147490)

### DIFF
--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -89,7 +89,7 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     // --------------------------- Configure input & output -------------------------------------------------
     // --------------------------- Prepare input  ------------------------------------------------------
     if (model->inputs().size() != 1) {
-        throw std::logic_error("Classification model wrapper supports topologies with only 1 input");
+        throw std::logic_error("Classification model wrapper supports topologies with only 1 input, but found: " + std::to_string(model->inputs().size()));
     }
     const auto& input = model->input();
     inputsNames.push_back(input.get_any_name());
@@ -158,11 +158,6 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     model = ppp.build();
 
     // --------------------------- Adding softmax and topK output  ---------------------------
-
-    if (model->get_output_size() != 1) {
-        throw std::logic_error("Expected model's number of output equal to 1 (but found: " + std::to_string(model->get_output_size()) + ")");
-    }
-
     auto logitsNode = model->get_output_op(0)->input(0).get_source_output().get_node();
 
     const auto k = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<size_t>{nTop});

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -160,8 +160,8 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     // --------------------------- Adding softmax and topK output  ---------------------------
     auto logitsNode = model->get_output_op(0)->input(0).get_source_output().get_node();
 
-    const auto k = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<size_t>{nTop});
     std::shared_ptr<ov::Node> softmaxNode = std::make_shared<ov::op::v1::Softmax>(logitsNode->output(0), 1);
+    const auto k = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<size_t>{nTop});
 
     std::shared_ptr<ov::Node> topkNode = std::make_shared<ov::op::v3::TopK>(softmaxNode,
                                                                             k,

--- a/demos/common/cpp/models/src/classification_model.cpp
+++ b/demos/common/cpp/models/src/classification_model.cpp
@@ -158,19 +158,16 @@ void ClassificationModel::prepareInputsOutputs(std::shared_ptr<ov::Model>& model
     model = ppp.build();
 
     // --------------------------- Adding softmax and topK output  ---------------------------
-    auto nodes = model->get_ops();
-    auto softmaxNodeIt = std::find_if(std::begin(nodes), std::end(nodes), [](const std::shared_ptr<ov::Node>& op) {
-        return std::string(op->get_type_name()) == "Softmax";
-    });
 
-    std::shared_ptr<ov::Node> softmaxNode;
-    if (softmaxNodeIt == nodes.end()) {
-        auto logitsNode = model->get_output_op(0)->input(0).get_source_output().get_node();
-        softmaxNode = std::make_shared<ov::op::v1::Softmax>(logitsNode->output(0), 1);
-    } else {
-        softmaxNode = *softmaxNodeIt;
+    if (model->get_output_size() != 1) {
+        throw std::logic_error("Expected model's number of output equal to 1 (but found: " + std::to_string(model->get_output_size()) + ")");
     }
+
+    auto logitsNode = model->get_output_op(0)->input(0).get_source_output().get_node();
+
     const auto k = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<size_t>{nTop});
+    std::shared_ptr<ov::Node> softmaxNode = std::make_shared<ov::op::v1::Softmax>(logitsNode->output(0), 1);
+
     std::shared_ptr<ov::Node> topkNode = std::make_shared<ov::op::v3::TopK>(softmaxNode,
                                                                             k,
                                                                             1,


### PR DESCRIPTION
Use last model layer for benchmarking (do not pick softmax layer, which may be located somewhere in the middle of the model (#147490)

Ticket: [147490]

Description:
Classification Benchmark C++ classification_benchmark_demo provides incorrect classification results for some networks.

Networks affected:
levit-128s
resnest-50-pytorch
swin-tiny-patch4-window7-224
t2t-vit-14

Affected demos:
classification_benchmark_demo