### PR TITLE
Bump `torchvision` to avoid an unsafe `torch` version

### DIFF
--- a/tools/model_tools/requirements-pytorch.in
+++ b/tools/model_tools/requirements-pytorch.in
@@ -3,5 +3,5 @@ scipy>=1.5.4
 mpmath<1.4
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=1.8.1
-torchvision>=0.9.1
+torchvision>=0.17
 yacs>=0.1.8


### PR DESCRIPTION
`torchvision 0.16`, for some reason preferred by pip on Python 3.8 CI pipelines, is coupled with `torch 2.1.2`, which has vulnerabilities CVE-2024-31580 and CVE-2024-31583.

The new lower bound is compatible with the lowest supported Python version.

Details in CVS-150809