### PR TITLE
Exclude a specific tensorflow version which does not support Python 3.8 on MacOS

### DIFF
--- a/tools/model_tools/requirements-tensorflow.in
+++ b/tools/model_tools/requirements-tensorflow.in
@@ -1,1 +1,2 @@
-tensorflow>=2.5,<2.18.0
+tensorflow>=2.5,<2.18.0; platform_system != 'darwin' or python_version != '3.8'
+tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'darwin' and python_version == '3.8'  # Explanation: 151865


### PR DESCRIPTION
Details in CVS-151865

Related PR: https://github.com/openvinotoolkit/openvino/pull/26507