### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+properties([
+    parameters([
+        booleanParam(defaultValue: false,
+                     description: 'Cancel the rest of parallel stages if one of them fails and return status immediately',
+                     name: 'failFast'),
+        booleanParam(defaultValue: true,
+                     description: 'Whether to propagate commit status to GitHub',
+                     name: 'propagateStatus'),
+        string(defaultValue: '',
+               description: 'Pipeline shared library version (branch/tag/commit). Determined automatically if empty',
+               name: 'library_version'),
+        string(defaultValue: '',
+               description: 'Docker tag to take images with. Determined automatically if empty',
+               name: 'docker_tag')
+    ])
+])
+
+loadOpenVinoLibrary {
+    entrypoint(this)
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
         booleanParam(defaultValue: true,
                      description: 'Whether to propagate commit status to GitHub',
                      name: 'propagateStatus'),
-        string(defaultValue: '',
+        string(defaultValue: 'pull/1101/head',
                description: 'Pipeline shared library version (branch/tag/commit). Determined automatically if empty',
                name: 'library_version'),
         string(defaultValue: '',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ properties([
         booleanParam(defaultValue: true,
                      description: 'Whether to propagate commit status to GitHub',
                      name: 'propagateStatus'),
-        string(defaultValue: 'pull/1101/head',
+        string(defaultValue: '',
                description: 'Pipeline shared library version (branch/tag/commit). Determined automatically if empty',
                name: 'library_version'),
         string(defaultValue: '',


### PR DESCRIPTION
OMZ is no longer a submodule in OV, but we still need to run a (reduced) validation scope for OMZ changes to ensure no regressions introduced to OV CI.