### PR TITLE
Relax `networkx` upper bound

### DIFF
--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -3,7 +3,7 @@ tqdm>=4.54.1
 
 # image reading and preprocessing
 # nncf's upperbound: https://github.com/openvinotoolkit/nncf/blob/1de67217adf60a29afa310edf4a5f4d36314446a/setup.py#L104
-networkx<=3.6
+networkx<3.6
 scikit-image>=0.19.2
 
 imagecodecs~=2022.2.22;python_version<="3.10"


### PR DESCRIPTION
Bump `networkx` to solve an issue for Python 3.13 pipelines

```shell
The user requested networkx<=2.8.2
torch 2.7.0 depends on networkx
scikit-image 0.25.2 depends on networkx>=3.0
```