### PR TITLE
Force pip to choose prebuilt wheel for Python 3.13 scikit-learn

### DIFF
--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -7,7 +7,8 @@ numpy>=1.16.6,<2.0.0
 opencv-python
 pillow>=8.1.2
 pyyaml>=5.4.1
-scikit-learn>=0.24.1
+scikit-learn>=0.24.1;python_version < "3.13"
+scikit-learn>=1.5.2;python_version >= "3.13"
 scipy>=1.5.4
 sympy>=1.8
 tensorboardX>=2.6;python_version < "3.13"


### PR DESCRIPTION
It currently discards prebuilt wheels and fails to build from source. This PR forces pip to use prebuilt version

```bash
[2025-09-17T09:05:51.571Z] [2025-09-17 11:05:51,471] [16452] helper.cmd_exec INFO: Collecting scikit-learn>=0.24.1 (from -r c:\jenkins\workspace\private-ci\ie\e2e-tests-windows-pip-conflicts\b\install\dldt_cpack\extras\open_model_zoo\demos\requirements.txt (line 10))
[2025-09-17T09:05:51.571Z] [2025-09-17 11:05:51,488] [16452] helper.cmd_exec INFO:   Using cached scikit_learn-1.7.1-cp313-cp313-win_amd64.whl.metadata (11 kB)
[2025-09-17T09:05:52.532Z] [2025-09-17 11:05:52,162] [16452] helper.cmd_exec INFO:   Downloading scikit_learn-1.7.0-cp313-cp313-win_amd64.whl.metadata (14 kB)
[2025-09-17T09:05:53.120Z] [2025-09-17 11:05:52,798] [16452] helper.cmd_exec INFO:   Downloading scikit_learn-1.6.1-cp313-cp313-win_amd64.whl.metadata (15 kB)
[2025-09-17T09:05:53.699Z] [2025-09-17 11:05:53,530] [16452] helper.cmd_exec INFO:   Downloading scikit_learn-1.6.0-cp313-cp313-win_amd64.whl.metadata (15 kB)
[2025-09-17T09:05:54.277Z] [2025-09-17 11:05:54,118] [16452] helper.cmd_exec INFO:   Downloading scikit_learn-1.5.2-cp313-cp313-win_amd64.whl.metadata (13 kB)
[2025-09-17T09:05:54.551Z] [2025-09-17 11:05:54,505] [16452] helper.cmd_exec INFO:   Downloading scikit_learn-1.5.1.tar.gz (7.0 MB)
[2025-09-17T09:05:54.864Z] [2025-09-17 11:05:54,685] [16452] helper.cmd_exec INFO:      ---------------------------------------- 7.0/7.0 MB 61.9 MB/s eta 0:00:00
[2025-09-17T09:05:55.816Z] [2025-09-17 11:05:55,554] [16452] helper.cmd_exec INFO:   Installing build dependencies: started
[2025-09-17T09:06:27.972Z] [2025-09-17 11:06:24,808] [16452] helper.cmd_exec INFO:   Installing build dependencies: finished with status 'done'
[2025-09-17T09:06:27.972Z] [2025-09-17 11:06:24,809] [16452] helper.cmd_exec INFO:   Getting requirements to build wheel: started
[2025-09-17T09:06:27.972Z] [2025-09-17 11:06:24,946] [16452] helper.cmd_exec INFO:   Getting requirements to build wheel: finished with status 'done'
[2025-09-17T09:06:27.972Z] [2025-09-17 11:06:24,948] [16452] helper.cmd_exec INFO:   Preparing metadata (pyproject.toml): started
[2025-09-17T09:06:33.624Z] [2025-09-17 11:06:33,214] [16452] helper.cmd_exec INFO:   Preparing metadata (pyproject.toml): finished with status 'error'
[2025-09-17T09:06:33.624Z] [2025-09-17 11:06:33,216] [16452] helper.cmd_exec INFO:   error: subprocess-exited-with-error
```