### PR TITLE
Fix IndexError when label file has fewer entries than predicted classes

### DIFF
--- a/demos/action_recognition_demo/python/action_recognition_demo/result_renderer.py
+++ b/demos/action_recognition_demo/python/action_recognition_demo/result_renderer.py
@@ -152,6 +152,6 @@ def decode_output(probs, labels, top_k=None, label_postprocessing=None):
 
         top_ind = [postproc.get() for postproc in label_postprocessing]
 
-    decoded_labels = [labels[i] if labels else str(i) for i in top_ind]
+    decoded_labels = [labels[i] if labels and i < len(labels) else str(i) for i in top_ind]
     probs = [probs[i] for i in top_ind]
     return decoded_labels, probs


### PR DESCRIPTION
Reproduced issue #4003 where using action-recognition-0001 model with driver_actions.txt causes an IndexError in result_renderer.py.
This patch adds a bounds check as a minimal fix to prevent label indexing from exceeding the label list length.
Fixes #4003