### PR TITLE
 face_recognition_demo: reject bare HETERO device with clear error message 

### DIFF
--- a/demos/face_recognition_demo/python/face_recognition_demo.py
+++ b/demos/face_recognition_demo/python/face_recognition_demo.py
@@ -207,6 +207,10 @@ def center_crop(frame, crop_size):
 def main():
     args = build_argparser().parse_args()
 
+    for arg_name, device in [('-d_fd', args.d_fd), ('-d_lm', args.d_lm), ('-d_reid', args.d_reid)]:
+        if device == 'HETERO':
+            raise ValueError('{} requires sub-devices, e.g. HETERO:GPU,CPU'.format(arg_name))
+
     cap = open_images_capture(args.input, args.loop)
     frame_processor = FrameProcessor(args)
 


### PR DESCRIPTION
 ## Summary

  - Passing `THROUGHPUT` performance hint to `compile_model` when the AUTO
    plugin is used (`ie_module.py`)
  - Adding early validation that rejects a bare `HETERO` device string and
    shows a clear error with the correct format to guide the user in the file mentioned. (`face_recognition_demo.py`)

  ## Root Cause

- **Bug 1 — No performance hint for AUTO plugin:**
When `AUTO` is selected as the device, OpenVINO's AUTO plugin defaults
to `LATENCY` mode. For a video streaming pipeline that runs inference
continuously, `THROUGHPUT` mode is the correct choice for this particular case and it lets OpenVINO
batch and pipeline requests internally for better hardware utilisation.
The demo never passed any config to `compile_model`, so users running
`-d_fd AUTO` were silently getting suboptimal performance.

- **Bug 2 — Bare HETERO fails at runtime with no useful message:**
The HETERO plugin always requires a sub-device list (e.g. `HETERO:GPU,CPU`).
Passing just `HETERO` is accepted by argparse but crashes deep inside
OpenVINO with an unhelpful error. The user had no indication of what was
wrong or how to fix it as it is vague.

 ## Solution

   In `ie_module.py`, `deploy()`  function now checks if the device string starts with

  `AUTO` and passes `{"PERFORMANCE_HINT": "THROUGHPUT"}` to `compile_model`.
  All other devices are unaffected.

  In `face_recognition_demo.py`, `main()` now validates all three device
  arguments immediately after parsing. If any equals exactly `HETERO`
  (no colon), it raises a `ValueError` with a clear message showing the
  correct format before any model loading begins.

 ## How to Test

  ```bash
  # Bug 1 — should compile with THROUGHPUT hint, no error
  python face_recognition_demo.py -d_fd AUTO ...

  # Bug 2 — should now print a clear error instead of crashing in OpenVINO
  python face_recognition_demo.py -d_fd HETERO ...
  # Expected: ValueError: -d_fd requires sub-devices, e.g. HETERO:GPU,CPU