### PR TITLE
Add Detectron2 model support to accuracy checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+tools/accuracy_checker/build/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: accuracy-checker-pylint
+        name: accuracy checker pylint
+        entry: >-
+          bash -c 'cd tools/accuracy_checker && PYTHONPATH=. python3 -m pylint
+          --rcfile=.pylintrc "${@#tools/accuracy_checker/}"' --
+        language: system
+        files: ^tools/accuracy_checker/(?!tests/|build/).*\.py$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ Open Model Zoo also supports models already in the ONNX format.
 To contribute to OMZ, create a pull request (PR) in this repository using the `master` branch.
 Pull requests are strictly formalized and are reviewed by the OMZ maintainers for consistence and legal compliance.
 
+To install the local Accuracy Checker Pylint check run `python3 tools/accuracy_checker/configure_pylint_hook.py`.
+The hook runs on commits that change Python files under `tools/accuracy_checker`, using the same Pylint version and
+configuration as CI.
+
 Each PR contributing a model must contain:
 * [configuration file `model.yml`](#configuration-file)
 * [documentation of model in markdown format](#documentation)

--- a/tools/accuracy_checker/accuracy_checker/adapters/__init__.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/__init__.py
@@ -110,6 +110,7 @@ from .pose_estimation_3d import HumanPose3dAdapter
 from .hit_ratio import HitRatioAdapter
 
 from .mask_rcnn import MaskRCNNAdapter
+from .detectron2 import Detectron2Adapter
 from .mask_rcnn_with_text import MaskRCNNWithTextAdapter
 from .yolact import YolactAdapter
 
@@ -177,6 +178,8 @@ __all__ = [
     'NanoDetAdapter',
     'FacialLandmarksAdapter',
     'MTCNNPAdapter',
+
+    'Detectron2Adapter',
 
     'TinyYOLOv1Adapter',
     'YoloV2Adapter',

--- a/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
@@ -98,6 +98,31 @@ class Detectron2Adapter(MaskRCNNAdapter):
         self.scores_out = scores_name
         self.raw_masks_out = masks_name
 
+    @staticmethod
+    def _get_image_scales(image_meta, original_image_size):
+        if 'scale_x' in image_meta and 'scale_y' in image_meta:
+            return image_meta['scale_x'], image_meta['scale_y']
+
+        image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
+        assert image_input, "image input not found"
+        assert len(image_input) == 1, 'several input images detected'
+        image_input = image_input[0]
+        if image_input[1] == 3:
+            processed_image_size = image_input[2:]
+        else:
+            processed_image_size = image_input[1:3]
+        return (
+            processed_image_size[1] / original_image_size[1],
+            processed_image_size[0] / original_image_size[0]
+        )
+
+    def _process_masks(self, boxes, pred_masks, identifiers, original_image_size, classes):
+        if pred_masks is None:
+            return []
+        if self._is_roi_masks(pred_masks):
+            return self._process_masks_pytorch(boxes, pred_masks, identifiers, original_image_size, classes)
+        return self._process_detectron2_masks(pred_masks, original_image_size)
+
     def _process_pytorch_outputs(self, raw_outputs, identifiers, frame_meta):
         self._auto_resolve_outputs(raw_outputs)
 
@@ -133,33 +158,11 @@ class Detectron2Adapter(MaskRCNNAdapter):
 
         for identifier, image_meta in zip(identifiers, frame_meta):
             original_image_size = image_meta['image_size'][:2]
-
-            # Rescale boxes to original image space using parent's logic
-            if 'scale_x' in image_meta and 'scale_y' in image_meta:
-                im_scale_x = image_meta['scale_x']
-                im_scale_y = image_meta['scale_y']
-            else:
-                image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
-                assert image_input, "image input not found"
-                assert len(image_input) == 1, 'several input images detected'
-                image_input = image_input[0]
-                if image_input[1] == 3:
-                    processed_image_size = image_input[2:]
-                else:
-                    processed_image_size = image_input[1:3]
-                im_scale_y = processed_image_size[0] / original_image_size[0]
-                im_scale_x = processed_image_size[1] / original_image_size[1]
+            im_scale_x, im_scale_y = self._get_image_scales(image_meta, original_image_size)
 
             boxes[:, 0::2] /= im_scale_x
             boxes[:, 1::2] /= im_scale_y
-
-            masks = []
-            if pred_masks is not None:
-                is_roi = self._is_roi_masks(pred_masks)
-                if is_roi:
-                    masks = self._process_masks_pytorch(boxes, pred_masks, identifiers, original_image_size, classes)
-                else:
-                    masks = self._process_detectron2_masks(pred_masks, original_image_size)
+            masks = self._process_masks(boxes, pred_masks, identifiers, original_image_size, classes)
 
             x_mins, y_mins, x_maxs, y_maxs = boxes.T
             detection_prediction = DetectionPrediction(identifier, classes, scores, x_mins, y_mins, x_maxs, y_maxs)

--- a/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
@@ -1,0 +1,195 @@
+"""
+Copyright (c) 2026 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import cv2
+import numpy as np
+
+from .mask_rcnn import MaskRCNNAdapter
+from ..representation import CoCoInstanceSegmentationPrediction, DetectionPrediction, ContainerPrediction
+
+
+class Detectron2Adapter(MaskRCNNAdapter):
+    __provider__ = 'detectron2'
+
+    @staticmethod
+    def _is_roi_masks(pred_masks):
+        arr = np.asarray(pred_masks)
+        return arr.ndim == 4 and arr.shape[1] == 1 and arr.shape[2] <= 64 and arr.shape[3] <= 64
+
+    def _auto_resolve_outputs(self, raw_outputs):
+        # Keep user-provided names if they exist in current outputs.
+        boxes_name = self.boxes_out if self.boxes_out in raw_outputs else None
+        classes_name = self.classes_out if self.classes_out in raw_outputs else None
+        scores_name = self.scores_out if self.scores_out in raw_outputs else None
+        masks_name = self.raw_masks_out if self.raw_masks_out in raw_outputs else None
+
+        items = list(raw_outputs.items())
+
+        def _remove_selected(name):
+            if name is None:
+                return
+            for idx, (candidate_name, _) in enumerate(items):
+                if candidate_name == name:
+                    items.pop(idx)
+                    return
+
+        def _pick_and_remove(predicate):
+            for idx, (name, value) in enumerate(items):
+                if predicate(name, value):
+                    items.pop(idx)
+                    return name
+            return None
+
+        # Exclude explicitly selected outputs from further auto-matching.
+        _remove_selected(boxes_name)
+        _remove_selected(classes_name)
+        _remove_selected(scores_name)
+        _remove_selected(masks_name)
+
+        # Detect boxes: [N, 4]
+        if boxes_name is None:
+            boxes_name = _pick_and_remove(
+                lambda _, value: np.asarray(value).ndim == 2 and np.asarray(value).shape[1] == 4
+            )
+
+        # Detect masks: [N, 1, H, W] or [N, H, W]
+        if masks_name is None:
+            masks_name = _pick_and_remove(
+                lambda _, value: np.asarray(value).ndim == 4 and np.asarray(value).shape[1] == 1
+            )
+            if masks_name is None:
+                masks_name = _pick_and_remove(
+                    lambda _, value: np.asarray(value).ndim == 3
+                )
+
+        # Detect classes: integer [N]
+        if classes_name is None:
+            classes_name = _pick_and_remove(
+                lambda _, value: np.asarray(value).ndim == 1
+                and np.issubdtype(np.asarray(value).dtype, np.integer)
+                and np.asarray(value).size != 2
+            )
+
+        # Detect scores: float [N]
+        if scores_name is None:
+            scores_name = _pick_and_remove(
+                lambda _, value: np.asarray(value).ndim == 1 and np.issubdtype(np.asarray(value).dtype, np.floating)
+            )
+
+        if boxes_name is None:
+            raise ConfigError('Suitable output layer not found')
+
+        self.boxes_out = boxes_name
+        self.classes_out = classes_name
+        self.scores_out = scores_name
+        self.raw_masks_out = masks_name
+
+    def _process_pytorch_outputs(self, raw_outputs, identifiers, frame_meta):
+        self._auto_resolve_outputs(raw_outputs)
+
+        boxes = np.asarray(raw_outputs[self.boxes_out])
+        scores = raw_outputs.get(self.scores_out, None)
+        classes = raw_outputs.get(self.classes_out, None)
+        pred_masks = raw_outputs.get(self.raw_masks_out, None)
+
+        scores = np.asarray(scores) if scores is not None else None
+        classes = np.asarray(classes) if classes is not None else None
+        pred_masks = np.asarray(pred_masks) if pred_masks is not None else None
+
+        if scores is None and boxes.ndim == 2 and boxes.shape[1] == 5:
+            scores = boxes[:, 4]
+            boxes = boxes[:, :4]
+
+        if classes is None:
+            classes = np.ones(len(boxes), np.uint32)
+
+        if scores is not None:
+            valid_detections_mask = scores > 0
+        else:
+            valid_detections_mask = np.sum(boxes, axis=1) > 0
+        classes = classes[valid_detections_mask]
+        boxes = boxes[valid_detections_mask]
+        scores = scores[valid_detections_mask]
+        if pred_masks is not None:
+            pred_masks = pred_masks[valid_detections_mask]
+
+        results = []
+
+        for identifier, image_meta in zip(identifiers, frame_meta):
+            original_image_size = image_meta['image_size'][:2]
+            
+            # Rescale boxes to original image space using parent's logic
+            if 'scale_x' in image_meta and 'scale_y' in image_meta:
+                im_scale_x = image_meta['scale_x']
+                im_scale_y = image_meta['scale_y']
+            else:
+                image_input = [shape for shape in image_meta['input_shape'].values() if len(shape) == 4]
+                assert image_input, "image input not found"
+                assert len(image_input) == 1, 'several input images detected'
+                image_input = image_input[0]
+                if image_input[1] == 3:
+                    processed_image_size = image_input[2:]
+                else:
+                    processed_image_size = image_input[1:3]
+                im_scale_y = processed_image_size[0] / original_image_size[0]
+                im_scale_x = processed_image_size[1] / original_image_size[1]
+            
+            boxes[:, 0::2] /= im_scale_x
+            boxes[:, 1::2] /= im_scale_y
+            
+            classes = classes.astype(np.int32)
+            # Some exported pipelines emit 1-based classes; COCO 80cl in this setup is 0-based.
+            if classes.size and np.min(classes) >= 1:
+                classes = classes - 1
+            classes = classes.astype(np.uint32)
+
+            masks = []
+            if pred_masks is not None:
+                if self._is_roi_masks(pred_masks):
+                    masks = self._process_masks_pytorch(boxes, pred_masks, identifiers, original_image_size, classes)
+                else:
+                    masks = self._process_detectron2_masks(pred_masks, original_image_size)
+
+            x_mins, y_mins, x_maxs, y_maxs = boxes.T
+            detection_prediction = DetectionPrediction(identifier, classes, scores, x_mins, y_mins, x_maxs, y_maxs)
+            instance_segmentation_prediction = CoCoInstanceSegmentationPrediction(identifier, masks, classes, scores)
+            instance_segmentation_prediction.metadata['rects'] = np.c_[x_mins, y_mins, x_maxs, y_maxs]
+            instance_segmentation_prediction.metadata['image_size'] = image_meta['image_size']
+            results.append(ContainerPrediction({
+                'detection_prediction': detection_prediction,
+                'segmentation_prediction': instance_segmentation_prediction
+            }))
+
+            return results
+
+    def _process_detectron2_masks(self, pred_masks, original_image_size):
+        masks = []
+        original_height, original_width = original_image_size
+
+        for mask in pred_masks:
+            mask = np.asarray(mask, dtype=np.float32)
+            if mask.ndim == 3:
+                mask = np.squeeze(mask, axis=0)
+
+            if mask.shape != (original_height, original_width):
+                mask = cv2.resize(mask, (original_width, original_height), interpolation=cv2.INTER_LINEAR)
+
+            mask = (mask > 0.5).astype(np.uint8)
+            encoded_mask = self.encoder(np.array(mask[:, :, np.newaxis], order='F'))[0]
+            encoded_mask['counts'] = encoded_mask['counts'].decode('utf-8')
+            masks.append(encoded_mask)
+
+        return masks

--- a/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/detectron2.py
@@ -18,6 +18,7 @@ import cv2
 import numpy as np
 
 from .mask_rcnn import MaskRCNNAdapter
+from ..config import ConfigError
 from ..representation import CoCoInstanceSegmentationPrediction, DetectionPrediction, ContainerPrediction
 
 
@@ -126,11 +127,13 @@ class Detectron2Adapter(MaskRCNNAdapter):
         if pred_masks is not None:
             pred_masks = pred_masks[valid_detections_mask]
 
+        classes = classes.astype(np.uint32)
+
         results = []
 
         for identifier, image_meta in zip(identifiers, frame_meta):
             original_image_size = image_meta['image_size'][:2]
-            
+
             # Rescale boxes to original image space using parent's logic
             if 'scale_x' in image_meta and 'scale_y' in image_meta:
                 im_scale_x = image_meta['scale_x']
@@ -146,19 +149,14 @@ class Detectron2Adapter(MaskRCNNAdapter):
                     processed_image_size = image_input[1:3]
                 im_scale_y = processed_image_size[0] / original_image_size[0]
                 im_scale_x = processed_image_size[1] / original_image_size[1]
-            
+
             boxes[:, 0::2] /= im_scale_x
             boxes[:, 1::2] /= im_scale_y
-            
-            classes = classes.astype(np.int32)
-            # Some exported pipelines emit 1-based classes; COCO 80cl in this setup is 0-based.
-            if classes.size and np.min(classes) >= 1:
-                classes = classes - 1
-            classes = classes.astype(np.uint32)
 
             masks = []
             if pred_masks is not None:
-                if self._is_roi_masks(pred_masks):
+                is_roi = self._is_roi_masks(pred_masks)
+                if is_roi:
                     masks = self._process_masks_pytorch(boxes, pred_masks, identifiers, original_image_size, classes)
                 else:
                     masks = self._process_detectron2_masks(pred_masks, original_image_size)
@@ -173,7 +171,7 @@ class Detectron2Adapter(MaskRCNNAdapter):
                 'segmentation_prediction': instance_segmentation_prediction
             }))
 
-            return results
+        return results
 
     def _process_detectron2_masks(self, pred_masks, original_image_size):
         masks = []

--- a/tools/accuracy_checker/accuracy_checker/data_readers/README.md
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/README.md
@@ -34,15 +34,19 @@ reader:
 
 ## Retrying Transient Read Errors
 
-All data readers support automatic retrying of reads that fail with an `OSError` (e.g. a transient I/O error on a network share or removable media). This is controlled by 2 optional parameters, available for any reader:
-* `read_retry_attempts` - number of attempts to perform before giving up and re-raising the error (Optional, default `1`, i.e. no retry).
-* `read_retry_delay` - delay in seconds between retry attempts (Optional, default `0.1`).
+All data readers support automatic retrying of reads that fail with an `OSError` (e.g. a transient I/O error on a network share or removable media). This is controlled by 3 optional parameters, available for any reader:
+* `read_retry_attempts` - number of attempts to perform for a single read before giving up and re-raising the error (Optional, default `4`).
+* `read_total_retries` - total number of retries allowed across the whole dataset read (shared budget, decremented on every retry); once exhausted, further failures are raised immediately (Optional, default `8`).
+* `initial_retry_delay` - delay in seconds before the first retry; doubled after each subsequent failed retry and kept at that level for later reads, so it settles at a value that works (Optional, default `0.4`).
+
+The retry delay is not reset between reads, so in the worst case (every retry across the whole dataset failing) it escalates up to `initial_retry_delay * 2^(read_total_retries - 1)`. With the defaults above that is `0.4 * 2^7 = 51.2` seconds.
 
 ```yml
 reader:
   type: opencv_imread
-  read_retry_attempts: 3
-  read_retry_delay: 0.5
+  read_retry_attempts: 4
+  read_total_retries: 8
+  initial_retry_delay: 0.4
 ```
 
 ## Supported Data Readers

--- a/tools/accuracy_checker/accuracy_checker/data_readers/README.md
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/README.md
@@ -32,6 +32,19 @@ reader:
     *.jpeg: opencv_imread
 ```
 
+## Retrying Transient Read Errors
+
+All data readers support automatic retrying of reads that fail with an `OSError` (e.g. a transient I/O error on a network share or removable media). This is controlled by 2 optional parameters, available for any reader:
+* `read_retry_attempts` - number of attempts to perform before giving up and re-raising the error (Optional, default `1`, i.e. no retry).
+* `read_retry_delay` - delay in seconds between retry attempts (Optional, default `0.1`).
+
+```yml
+reader:
+  type: opencv_imread
+  read_retry_attempts: 3
+  read_retry_delay: 0.5
+```
+
 ## Supported Data Readers
 
 AccuracyChecker supports following list of data readers:

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -245,7 +245,7 @@ class BaseReader(ClassProvider):
                 optional=True, default=0.4, min_value=0,
                 description='Initial delay in seconds between read retries. Doubled after every failed retry '
                             'and kept at that level for subsequent reads, so it settles at a value that works. '
-                            'With default read_total_retries, worst case delay is initial_retry_delay * 2^(read_total_retries - 1).'
+                            'Worst case delay is initial_retry_delay * 2^(read_total_retries - 1).'
             ),
             'data_layout': StringField(optional=True, description='data layout after reading')
         }
@@ -333,9 +333,7 @@ class BaseReader(ClassProvider):
                     if self._retry_delay:
                         time.sleep(self._retry_delay)
                         self._retry_delay *= 2
-
-            if last_error is not None:
-                raise last_error
+            raise last_error
 
         return wrapper
 

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -234,12 +234,18 @@ class BaseReader(ClassProvider):
                 default=False, optional=True, description='Allows multi infer.'
             ),
             'read_retry_attempts': NumberField(
-                optional=True, default=1, value_type=int, min_value=1,
-                description='Number of attempts for transient read failures.'
+                optional=True, default=4, value_type=int, min_value=1,
+                description='Number of attempts for transient read failures for a single read.'
             ),
-            'read_retry_delay': NumberField(
-                optional=True, default=0.1, min_value=0,
-                description='Delay in seconds between read retries.'
+            'read_total_retries': NumberField(
+                optional=True, default=8, value_type=int, min_value=0,
+                description='Total number of retries allowed across the whole dataset read, decremented on every retry.'
+            ),
+            'initial_retry_delay': NumberField(
+                optional=True, default=0.4, min_value=0,
+                description='Initial delay in seconds between read retries. Doubled after every failed retry '
+                            'and kept at that level for subsequent reads, so it settles at a value that works. '
+                            'With default read_total_retries, worst case delay is initial_retry_delay * 2^(read_total_retries - 1).'
             ),
             'data_layout': StringField(optional=True, description='data layout after reading')
         }
@@ -309,7 +315,10 @@ class BaseReader(ClassProvider):
 
     def _retry_read_dispatcher(self, read_dispatcher):
         attempts = self.get_value_from_config('read_retry_attempts')
-        delay = self.get_value_from_config('read_retry_delay')
+        # kept on self (not local to wrapper) so the delay keeps escalating across reads instead of
+        # restarting from initial_retry_delay every time, letting it settle at a value that works
+        self._retry_delay = self.get_value_from_config('initial_retry_delay')
+        self._remaining_total_retries = self.get_value_from_config('read_total_retries')
 
         def wrapper(data_id):
             last_error = None
@@ -318,10 +327,12 @@ class BaseReader(ClassProvider):
                     return read_dispatcher(data_id)
                 except OSError as error:
                     last_error = error
-                    if attempt + 1 >= attempts:
+                    if attempt + 1 >= attempts or self._remaining_total_retries <= 0:
                         raise
-                    if delay:
-                        time.sleep(delay)
+                    self._remaining_total_retries -= 1
+                    if self._retry_delay:
+                        time.sleep(self._retry_delay)
+                        self._retry_delay *= 2
 
             if last_error is not None:
                 raise last_error

--- a/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
+++ b/tools/accuracy_checker/accuracy_checker/data_readers/data_reader.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import re
+import time
 from collections import OrderedDict, namedtuple
 from functools import singledispatch
 from pathlib import Path
@@ -26,7 +27,7 @@ from ..utils import (
 )
 from ..dependency import ClassProvider, UnregisteredProviderException
 from ..config import (
-    BaseField, StringField, ConfigValidator, ConfigError, DictField, BoolField, PathField
+    BaseField, StringField, ConfigValidator, ConfigError, DictField, BoolField, PathField, NumberField
 )
 
 REQUIRES_ANNOTATIONS = ['annotation_features_extractor' ,'disk_features_extractor' ]
@@ -204,15 +205,16 @@ class BaseReader(ClassProvider):
         self.config = config or {}
         self._postpone_data_source = postpone_data_source
         self.data_source = data_source
-        self.read_dispatcher = singledispatch(self.read)
-        self.read_dispatcher.register(list, self._read_list)
-        self.read_dispatcher.register(ClipIdentifier, self._read_clip)
-        self.read_dispatcher.register(MultiFramesInputIdentifier, self._read_frames_multi_input)
-        self.read_dispatcher.register(ImagePairIdentifier, self._read_pair)
-        self.read_dispatcher.register(ListIdentifier, self._read_list_ids)
-        self.read_dispatcher.register(MultiInstanceIdentifier, self._read_multi_instance_single_object)
-        self.read_dispatcher.register(ParametricImageIdentifier, self._read_parametric_input)
-        self.read_dispatcher.register(VideoFrameIdentifier, self._read_video_frame)
+        read_dispatcher = singledispatch(self.read)
+        read_dispatcher.register(list, self._read_list)
+        read_dispatcher.register(ClipIdentifier, self._read_clip)
+        read_dispatcher.register(MultiFramesInputIdentifier, self._read_frames_multi_input)
+        read_dispatcher.register(ImagePairIdentifier, self._read_pair)
+        read_dispatcher.register(ListIdentifier, self._read_list_ids)
+        read_dispatcher.register(MultiInstanceIdentifier, self._read_multi_instance_single_object)
+        read_dispatcher.register(ParametricImageIdentifier, self._read_parametric_input)
+        read_dispatcher.register(VideoFrameIdentifier, self._read_video_frame)
+        self.read_dispatcher = self._retry_read_dispatcher(read_dispatcher)
         self.multi_infer = False
         self.data_layout = None
 
@@ -230,6 +232,14 @@ class BaseReader(ClassProvider):
             ),
             'multi_infer': BoolField(
                 default=False, optional=True, description='Allows multi infer.'
+            ),
+            'read_retry_attempts': NumberField(
+                optional=True, default=1, value_type=int, min_value=1,
+                description='Number of attempts for transient read failures.'
+            ),
+            'read_retry_delay': NumberField(
+                optional=True, default=0.1, min_value=0,
+                description='Delay in seconds between read retries.'
             ),
             'data_layout': StringField(optional=True, description='data layout after reading')
         }
@@ -297,8 +307,29 @@ class BaseReader(ClassProvider):
     def read(self, data_id):
         raise NotImplementedError
 
+    def _retry_read_dispatcher(self, read_dispatcher):
+        attempts = self.get_value_from_config('read_retry_attempts')
+        delay = self.get_value_from_config('read_retry_delay')
+
+        def wrapper(data_id):
+            last_error = None
+            for attempt in range(attempts):
+                try:
+                    return read_dispatcher(data_id)
+                except OSError as error:
+                    last_error = error
+                    if attempt + 1 >= attempts:
+                        raise
+                    if delay:
+                        time.sleep(delay)
+
+            if last_error is not None:
+                raise last_error
+
+        return wrapper
+
     def _read_list(self, data_id):
-        return [self.read(identifier) for identifier in data_id]
+        return [self.read_dispatcher(identifier) for identifier in data_id]
 
     def _read_list_ids(self, data_id):
         return self.read_dispatcher(list(data_id.values))

--- a/tools/accuracy_checker/accuracy_checker/dataset.py
+++ b/tools/accuracy_checker/accuracy_checker/dataset.py
@@ -175,11 +175,8 @@ class Dataset:
         if not annotation:
             raise ConfigError('path to converted annotation or data for conversion should be specified')
 
-        sub_evaluation = config.get('sub_evaluation', False) and not ignore_subset_settings(config)
-
-        if sub_evaluation:
-            if use_converted_annotation and contains_all(config, ['annotation', 'annotation_conversion']):
-                _save_annotation()
+        if use_converted_annotation and contains_all(config, ['annotation', 'annotation_conversion']):
+            _save_annotation()
 
         no_recursion = (meta or {}).get('no_recursion', False)
         annotation = _create_subset(annotation, config, no_recursion)
@@ -187,10 +184,6 @@ class Dataset:
 
         if dataset_analysis:
             meta = _run_dataset_analysis(meta)
-
-        if not sub_evaluation:
-            if use_converted_annotation and contains_all(config, ['annotation', 'annotation_conversion']):
-                _save_annotation()
 
         return annotation, meta
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/detectron2_wrapper.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/detectron2_wrapper.py
@@ -15,12 +15,18 @@ limitations under the License.
 """
 import re
 import urllib.request
-import torch
-import torch.nn as nn
+from ..utils import UnsupportedPackage
 from .pytorch_launcher import append_to_path, CHECKPOINT_URL_REGEX
 
+try:
+    import torch
+    from torch import nn
+except ImportError as torch_error:
+    torch = UnsupportedPackage('torch', torch_error.msg)
+    nn = None
 
-class Detectron2Wrapper(nn.Module):
+
+class Detectron2Wrapper(nn.Module if nn else object):
     """
     Wraps a Detectron2 GeneralizedRCNN model to adapt it for accuracy_checker.
 
@@ -36,51 +42,53 @@ class Detectron2Wrapper(nn.Module):
     """
 
     @staticmethod
+    def _raise_if_torch_unavailable():
+        if nn is None:
+            torch.raise_error(Detectron2Wrapper.__name__)
+
+    @staticmethod
     def load_prebuilt_checkpoint(torch_launcher, checkpoint, model_cls_name, python_path):
         # Detectron2 checkpoints can contain a fully constructed model object;
         # load it directly to avoid calling the GeneralizedRCNN constructor.
+        Detectron2Wrapper._raise_if_torch_unavailable()
         with append_to_path(python_path):
             if isinstance(checkpoint, str) and re.match(CHECKPOINT_URL_REGEX, checkpoint):
                 checkpoint = urllib.request.urlretrieve(checkpoint)[0]  # nosec B310
 
-            checkpoint_obj = torch_launcher._torch.load(
+            checkpoint_obj = torch.load(
                 checkpoint,
-                map_location=None if torch_launcher.cuda else torch_launcher._torch.device('cpu'),
+                map_location=None if torch_launcher.cuda else torch.device('cpu'),
                 weights_only=False
             )
 
-            if isinstance(checkpoint_obj, torch_launcher._torch.nn.Module):
+            if isinstance(checkpoint_obj, nn.Module):
                 return torch_launcher.prepare_module(checkpoint_obj, model_cls_name)
 
         return None
 
     @staticmethod
     def prepare_module(torch_launcher, module, model_class):
+        Detectron2Wrapper._raise_if_torch_unavailable()
         wrapped_module = Detectron2Wrapper(module)
         wrapped_module.model.to('cuda' if torch_launcher.cuda else 'cpu')
         wrapped_module.model.eval()
         if torch_launcher.use_torch_compile:
             if hasattr(model_class, 'compile'):
                 wrapped_module.model.compile()
-            wrapped_module.model = torch_launcher._torch.compile(
+            wrapped_module.model = torch.compile(
                 wrapped_module.model,
                 **torch_launcher.compile_kwargs
             )
         return wrapped_module
 
     def __init__(self, model):
+        self._raise_if_torch_unavailable()
         super().__init__()
         self.model = model
 
-    def forward(self, batched_inputs):
-        """
-        Args:
-            batched_inputs: Tensor of shape [B, C, H, W] or [C, H, W]
-
-        Returns:
-            Dict with extracted predictions or list of dicts if batch > 1
-        """
-        # Normalize layout to NCHW/CHW when the channel axis is not in the expected position.
+    @staticmethod
+    def _normalize_input_layout(batched_inputs):
+        Detectron2Wrapper._raise_if_torch_unavailable()
         if isinstance(batched_inputs, torch.Tensor):
             if batched_inputs.dim() == 4 and batched_inputs.shape[1] != 3:
                 if batched_inputs.shape[-1] == 3:
@@ -92,26 +100,31 @@ class Detectron2Wrapper(nn.Module):
                     batched_inputs = batched_inputs.permute(2, 0, 1).contiguous()
                 elif batched_inputs.shape[1] == 3:
                     batched_inputs = batched_inputs.permute(1, 0, 2).contiguous()
+        return batched_inputs
 
-        # Convert batched tensor to detectron2 format
-        # If input is already a list of dicts (from some adapters), use as-is
+    @staticmethod
+    def _to_detectron_inputs(batched_inputs):
         if isinstance(batched_inputs, (list, tuple)) and len(batched_inputs) > 0:
             if isinstance(batched_inputs[0], dict):
-                # Already in detectron2 format
-                detectron_inputs = batched_inputs
-            else:
-                # List of tensors - convert to list of dicts
-                detectron_inputs = [{"image": img} for img in batched_inputs]
-        else:
-            # Single tensor input [B, C, H, W]
-            if batched_inputs.dim() == 4:
-                # Split batch into list of [C, H, W]
-                detectron_inputs = [{"image": img} for img in batched_inputs]
-            elif batched_inputs.dim() == 3:
-                # Single image [C, H, W]
-                detectron_inputs = [{"image": batched_inputs}]
-            else:
-                raise ValueError(f"Unexpected input shape: {batched_inputs.shape}")
+                return batched_inputs
+            return [{"image": image} for image in batched_inputs]
+        if batched_inputs.dim() == 4:
+            return [{"image": image} for image in batched_inputs]
+        if batched_inputs.dim() == 3:
+            return [{"image": batched_inputs}]
+        raise ValueError(f"Unexpected input shape: {batched_inputs.shape}")
+
+    def forward(self, batched_inputs):
+        """
+        Args:
+            batched_inputs: Tensor of shape [B, C, H, W] or [C, H, W]
+
+        Returns:
+            Dict with extracted predictions or list of dicts if batch > 1
+        """
+        self._raise_if_torch_unavailable()
+        batched_inputs = self._normalize_input_layout(batched_inputs)
+        detectron_inputs = self._to_detectron_inputs(batched_inputs)
 
         # Call detectron2 model
         with torch.no_grad():

--- a/tools/accuracy_checker/accuracy_checker/launcher/detectron2_wrapper.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/detectron2_wrapper.py
@@ -1,0 +1,142 @@
+"""
+Copyright (c) 2026 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import re
+import urllib.request
+import torch
+import torch.nn as nn
+from .pytorch_launcher import append_to_path, CHECKPOINT_URL_REGEX
+
+
+class Detectron2Wrapper(nn.Module):
+    """
+    Wraps a Detectron2 GeneralizedRCNN model to adapt it for accuracy_checker.
+
+    Detectron2 expects: List[Dict[str, Tensor]] with 'image' key
+    Accuracy_checker provides: Batch of tensors with shape [B, C, H, W]
+
+    This wrapper:
+    1. Takes batched tensor input [B, C, H, W]
+    2. Normalizes layout to NCHW/CHW if needed
+    3. Converts to detectron2 format: [{"image": tensor}, ...]
+    4. Calls the detectron2 model
+    5. Extracts predictions from Instances objects
+    """
+
+    @staticmethod
+    def load_prebuilt_checkpoint(torch_launcher, checkpoint, model_cls_name, python_path):
+        # Detectron2 checkpoints can contain a fully constructed model object;
+        # load it directly to avoid calling the GeneralizedRCNN constructor.
+        with append_to_path(python_path):
+            if isinstance(checkpoint, str) and re.match(CHECKPOINT_URL_REGEX, checkpoint):
+                checkpoint = urllib.request.urlretrieve(checkpoint)[0]  # nosec B310
+
+            checkpoint_obj = torch_launcher._torch.load(
+                checkpoint,
+                map_location=None if torch_launcher.cuda else torch_launcher._torch.device('cpu'),
+                weights_only=False
+            )
+
+            if isinstance(checkpoint_obj, torch_launcher._torch.nn.Module):
+                return torch_launcher.prepare_module(checkpoint_obj, model_cls_name)
+
+        return None
+
+    @staticmethod
+    def prepare_module(torch_launcher, module, model_class):
+        wrapped_module = Detectron2Wrapper(module)
+        wrapped_module.model.to('cuda' if torch_launcher.cuda else 'cpu')
+        wrapped_module.model.eval()
+        if torch_launcher.use_torch_compile:
+            if hasattr(model_class, 'compile'):
+                wrapped_module.model.compile()
+            wrapped_module.model = torch_launcher._torch.compile(
+                wrapped_module.model,
+                **torch_launcher.compile_kwargs
+            )
+        return wrapped_module
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, batched_inputs):
+        """
+        Args:
+            batched_inputs: Tensor of shape [B, C, H, W] or [C, H, W]
+
+        Returns:
+            Dict with extracted predictions or list of dicts if batch > 1
+        """
+        # Normalize layout to NCHW/CHW when the channel axis is not in the expected position.
+        if isinstance(batched_inputs, torch.Tensor):
+            if batched_inputs.dim() == 4 and batched_inputs.shape[1] != 3:
+                if batched_inputs.shape[-1] == 3:
+                    batched_inputs = batched_inputs.permute(0, 3, 1, 2).contiguous()
+                elif batched_inputs.shape[2] == 3:
+                    batched_inputs = batched_inputs.permute(0, 2, 1, 3).contiguous()
+            elif batched_inputs.dim() == 3 and batched_inputs.shape[0] != 3:
+                if batched_inputs.shape[-1] == 3:
+                    batched_inputs = batched_inputs.permute(2, 0, 1).contiguous()
+                elif batched_inputs.shape[1] == 3:
+                    batched_inputs = batched_inputs.permute(1, 0, 2).contiguous()
+
+        # Convert batched tensor to detectron2 format
+        # If input is already a list of dicts (from some adapters), use as-is
+        if isinstance(batched_inputs, (list, tuple)) and len(batched_inputs) > 0:
+            if isinstance(batched_inputs[0], dict):
+                # Already in detectron2 format
+                detectron_inputs = batched_inputs
+            else:
+                # List of tensors - convert to list of dicts
+                detectron_inputs = [{"image": img} for img in batched_inputs]
+        else:
+            # Single tensor input [B, C, H, W]
+            if batched_inputs.dim() == 4:
+                # Split batch into list of [C, H, W]
+                detectron_inputs = [{"image": img} for img in batched_inputs]
+            elif batched_inputs.dim() == 3:
+                # Single image [C, H, W]
+                detectron_inputs = [{"image": batched_inputs}]
+            else:
+                raise ValueError(f"Unexpected input shape: {batched_inputs.shape}")
+
+        # Call detectron2 model
+        with torch.no_grad():
+            outputs = self.model(detectron_inputs)
+
+        # Extract instances from outputs
+        # outputs is List[Dict[str, Instances]]
+        instances_list = [out.get("instances") for out in outputs]
+
+        # Convert Instances to dict of tensors for accuracy_checker
+        results = []
+        for instances in instances_list:
+            pred_masks = torch.tensor([])
+            if hasattr(instances, "pred_masks") and instances.pred_masks is not None:
+                pred_masks = instances.pred_masks.float()
+
+            result = {
+                "pred_boxes": instances.pred_boxes.tensor if hasattr(instances, "pred_boxes") else torch.tensor([]),
+                "pred_classes": instances.pred_classes if hasattr(instances, "pred_classes") else torch.tensor([]),
+                "pred_masks": pred_masks,
+                "scores": instances.scores if hasattr(instances, "scores") else torch.tensor([]),
+            }
+            results.append(result)
+
+        # Return single dict or list of dicts based on batch size
+        if len(results) == 1:
+            return results[0]
+        return results

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
@@ -170,6 +170,35 @@ class PyTorchLauncher(Launcher):
     def output_blob(self):
         return next(iter(self.output_names))
 
+    def _load_checkpoint(self, module, model_class, checkpoint, state_key):
+        if isinstance(checkpoint, str) and re.match(CHECKPOINT_URL_REGEX, checkpoint):
+            checkpoint = urllib.request.urlretrieve(checkpoint)[0]  # nosec B310  # disable urllib-urlopen check
+
+        use_weights_only = self.checkpoint_weights_only and not self.use_detectron2_wrapper
+        checkpoint = self._torch.load(
+            checkpoint,
+            map_location=None if self.cuda else self._torch.device('cpu'),
+            weights_only=use_weights_only
+        )
+
+        if isinstance(checkpoint, self._torch.nn.Module):
+            return self.prepare_module(checkpoint, model_class), True
+
+        state = checkpoint if not state_key else checkpoint[state_key]
+        if not use_weights_only and isinstance(state, dict) and 'model' in state:
+            loaded_model = state['model']
+            if isinstance(loaded_model, self._torch.nn.Module):
+                return self.prepare_module(loaded_model, model_class), True
+
+        if isinstance(state, dict):
+            if all(key.startswith('module.') for key in state):
+                module = self._torch.nn.DataParallel(module)
+            module.load_state_dict(state, strict=False)
+        elif isinstance(state, self._torch.nn.Module):
+            return self.prepare_module(state, model_class), True
+
+        return module, False
+
     def load_module(self, model_cls, module_args, module_kwargs, checkpoint=None, state_key=None, python_path=None,
                     init_method=None
     ):
@@ -195,42 +224,9 @@ class PyTorchLauncher(Launcher):
                     raise ValueError(f'Could not call the method {init_method} in the module {model_cls}.')
 
             if checkpoint:
-                if isinstance(checkpoint, str) and re.match(CHECKPOINT_URL_REGEX, checkpoint):
-                    checkpoint = urllib.request.urlretrieve(checkpoint)[0]  # nosec B310  # disable urllib-urlopen check
-
-                use_weights_only = self.checkpoint_weights_only
-                if self.use_detectron2_wrapper:
-                    use_weights_only = False
-
-                checkpoint = self._torch.load(
-                    checkpoint,
-                    map_location=None if self.cuda else self._torch.device('cpu'),
-                    weights_only=use_weights_only
-                )
-
-                if isinstance(checkpoint, self._torch.nn.Module):
-                    return self.prepare_module(checkpoint, model_cls)
-
-                state = checkpoint if not state_key else checkpoint[state_key]
-
-                if not use_weights_only:
-
-                    state_dict_contains_model = (
-                        isinstance(state, dict) and
-                        'model' in state and
-                        isinstance(state['model'], self._torch.nn.Module)
-                    )
-
-                    if state_dict_contains_model:
-                        loaded_model = state['model']
-                        return self.prepare_module(loaded_model, model_cls)
-
-                if isinstance(state, dict):
-                    if all(key.startswith('module.') for key in state):
-                        module = self._torch.nn.DataParallel(module)
-                    module.load_state_dict(state, strict=False)
-                elif isinstance(state, self._torch.nn.Module):
-                    return self.prepare_module(state, model_cls)
+                module, is_prepared = self._load_checkpoint(module, model_cls, checkpoint, state_key)
+                if is_prepared:
+                    return module
 
             return self.prepare_module(module, model_cls)
 

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher.py
@@ -43,6 +43,10 @@ class PyTorchLauncher(Launcher):
         parameters = super().parameters()
         parameters.update({
             'module': StringField(regex=MODULE_REGEX, description='Network module for loading'),
+            'use_detectron2_wrapper': BoolField(
+                optional=True, default=False,
+                description='Wrap Detectron2 models in a compatibility adapter for dict-based image inputs.'
+            ),
             'checkpoint': PathField(
                 check_exists=True, is_directory=False, optional=True, description='pre-trained model checkpoint'
             ),
@@ -95,6 +99,7 @@ class PyTorchLauncher(Launcher):
         self.validate_config(config_entry)
         self.use_torch_compile = config_entry.get('use_torch_compile', False)
         self.compile_kwargs = config_entry.get('torch_compile_kwargs', {})
+        self.use_detectron2_wrapper = config_entry.get('use_detectron2_wrapper', False)
         self.tranformers_class = config_entry.get('transformers_class', None)
         backend = self.compile_kwargs.get('backend', None)
         if self.use_torch_compile and backend == 'openvino':
@@ -103,6 +108,13 @@ class PyTorchLauncher(Launcher):
             except ImportError as import_error:
                 raise ValueError("torch.compile is supported from OpenVINO 2023.1\n{}".format(
                     import_error.msg)) from import_error
+        if self.use_detectron2_wrapper:
+            try:
+                from .detectron2_wrapper import Detectron2Wrapper  # pylint: disable=C0415
+            except ImportError as import_error:
+                raise ValueError("Detectron2 wrapper is unavailable.\n{}".format(
+                    import_error.msg)) from import_error
+            self._detectron2_wrapper = Detectron2Wrapper
         module_args = config_entry.get("module_args", ())
         module_kwargs = config_entry.get("module_kwargs", {})
         self.device = self.get_value_from_config('device')
@@ -162,10 +174,18 @@ class PyTorchLauncher(Launcher):
                     init_method=None
     ):
         module_parts = model_cls.split(".")
-        model_cls = module_parts[-1]
+        model_cls_name = module_parts[-1]
         model_path = ".".join(module_parts[:-1])
+
+        if self.use_detectron2_wrapper and checkpoint:
+            preloaded_module = self._detectron2_wrapper.load_prebuilt_checkpoint(
+                self, checkpoint, model_cls_name, python_path
+            )
+            if preloaded_module is not None:
+                return preloaded_module
+
         with append_to_path(python_path):
-            model_cls = getattr(importlib.import_module(model_path), model_cls)
+            model_cls = getattr(importlib.import_module(model_path), model_cls_name)
             module = model_cls(*module_args, **module_kwargs)
             if init_method is not None:
                 if hasattr(model_cls, init_method):
@@ -177,14 +197,23 @@ class PyTorchLauncher(Launcher):
             if checkpoint:
                 if isinstance(checkpoint, str) and re.match(CHECKPOINT_URL_REGEX, checkpoint):
                     checkpoint = urllib.request.urlretrieve(checkpoint)[0]  # nosec B310  # disable urllib-urlopen check
+
+                use_weights_only = self.checkpoint_weights_only
+                if self.use_detectron2_wrapper:
+                    use_weights_only = False
+
                 checkpoint = self._torch.load(
                     checkpoint,
                     map_location=None if self.cuda else self._torch.device('cpu'),
-                    weights_only=self.checkpoint_weights_only
+                    weights_only=use_weights_only
                 )
+
+                if isinstance(checkpoint, self._torch.nn.Module):
+                    return self.prepare_module(checkpoint, model_cls)
+
                 state = checkpoint if not state_key else checkpoint[state_key]
 
-                if not self.checkpoint_weights_only:
+                if not use_weights_only:
 
                     state_dict_contains_model = (
                         isinstance(state, dict) and
@@ -196,9 +225,12 @@ class PyTorchLauncher(Launcher):
                         loaded_model = state['model']
                         return self.prepare_module(loaded_model, model_cls)
 
-                if all(key.startswith('module.') for key in state):
-                    module = self._torch.nn.DataParallel(module)
-                module.load_state_dict(state, strict=False)
+                if isinstance(state, dict):
+                    if all(key.startswith('module.') for key in state):
+                        module = self._torch.nn.DataParallel(module)
+                    module.load_state_dict(state, strict=False)
+                elif isinstance(state, self._torch.nn.Module):
+                    return self.prepare_module(state, model_cls)
 
             return self.prepare_module(module, model_cls)
 
@@ -214,10 +246,13 @@ class PyTorchLauncher(Launcher):
         return self.prepare_module(module, model_class)
 
     def prepare_module(self, module, model_class):
+        if self.use_detectron2_wrapper:
+            return self._detectron2_wrapper.prepare_module(self, module, model_class)
+
         module.to('cuda' if self.cuda else 'cpu')
         module.eval()
-
         if self.use_torch_compile:
+
             if hasattr(model_class, 'compile'):
                 module.compile()
             module = self._torch.compile(module, **self.compile_kwargs)
@@ -277,6 +312,24 @@ class PyTorchLauncher(Launcher):
             return {'last_hidden_state': outputs.last_hidden_state}
         return list(outputs)
 
+    def _fill_meta(self, metadata, batch_input=None):
+        if metadata is None:
+            return
+
+        for meta_ in metadata:
+            if batch_input is None:
+                meta_['input_shape'] = self.inputs_info_for_meta()
+                continue
+
+            if isinstance(batch_input, dict) and 'input' in batch_input:
+                inp = batch_input['input']
+                input_shape = list(inp.shape)
+                if len(input_shape) == 3:
+                    input_shape = [1] + input_shape
+                meta_['input_shape'] = {'input': input_shape}
+            else:
+                meta_['input_shape'] = {key: list(data.shape) for key, data in batch_input.items()}
+
     def predict(self, inputs, metadata=None, **kwargs):
         results = []
         with self._torch.no_grad():
@@ -287,13 +340,13 @@ class PyTorchLauncher(Launcher):
                     model_dtype = next(self.module.parameters()).dtype
                     if inp.dtype != model_dtype:
                         batch_input['input'] = inp.to(model_dtype)
+                        inp = batch_input['input']
 
+                    self._fill_meta(metadata, batch_input)
                     outputs = self.module(batch_input['input'])
                 else:
                     outputs = self.module(**batch_input)
-
-                    for meta_ in metadata:
-                        meta_['input_shape'] = {key: list(data.shape) for key, data in batch_input.items()}
+                    self._fill_meta(metadata, batch_input)
 
                 if metadata[0].get('output_is_dict_type') or isinstance(outputs, dict):
                     result_dict = self._convert_to_numpy(outputs)

--- a/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
+++ b/tools/accuracy_checker/accuracy_checker/launcher/pytorch_launcher_readme.md
@@ -19,6 +19,7 @@ For enabling PyTorch launcher you need to add `framework: pytorch` in launchers 
 * `use_torch_compile` - boolean, use torch.compile to optimize the module code (Optional, default `False`)
 * `torch_compile_kwargs` - dictionary of keyword arguments to pass to torch.compile (Optional, default `{}`)
 * `transformers_class` - transformers class name to load pre-trained model with `module` name. (Optional).
+* `use_detectron2_wrapper` - boolean, wrap Detectron2 models in a compatibility adapter that converts between accuracy_checker's tensor-based inputs/outputs and Detectron2's dict-based interface, and loads fully-built model checkpoints without invoking the module constructor (Optional, default `False`). See [Detectron2 wrapper](#detectron2-wrapper) section below for details.
 
 In turn if you model has several inputs you need to specify them in config, using specific parameter: `inputs`.
 Each input description should has following info:
@@ -55,5 +56,27 @@ launchers:
         device : cpu
 
     adapter: classification
+```
+
+## Detectron2 wrapper
+
+[Detectron2](https://github.com/facebookresearch/detectron2) models (e.g. `detectron2.modeling.GeneralizedRCNN`) take a list of dicts with an `image` key as input and return `Instances` objects, which is incompatible with the tensor-in/tensor-out interface the generic PyTorch launcher expects. Setting `use_detectron2_wrapper: True` wraps the loaded module in `Detectron2Wrapper`, which:
+* converts batched tensor input into the `[{"image": tensor}, ...]` format expected by Detectron2 models;
+* calls the wrapped model and extracts `pred_boxes`, `pred_classes`, `pred_masks` and `scores` from the returned `Instances` objects into plain tensors;
+* loads checkpoints that contain a fully constructed model object directly, without calling the `module` constructor (some Detectron2 checkpoints, e.g. `.pth` files produced by `torch.save(model, ...)`, contain such prebuilt model objects instead of a state dict).
+
+PyTorch launcher config example (demonstrates how to run a Detectron2 Mask R-CNN model):
+
+```yml
+launchers:
+  - framework: pytorch
+    device: CPU
+    module: detectron2.modeling.GeneralizedRCNN
+    python_path: /path/to/detectron2
+    checkpoint: /path/to/model.pth
+    checkpoint_weights_only: False
+    use_detectron2_wrapper: True
+
+    adapter: detectron2
 ```
 

--- a/tools/accuracy_checker/configure_pylint_hook.py
+++ b/tools/accuracy_checker/configure_pylint_hook.py
@@ -1,0 +1,13 @@
+"""Configure the Accuracy Checker Pylint pre-commit hook."""
+
+import subprocess
+import sys
+
+
+subprocess.run([sys.executable, "-m", "pip", "install", "pre-commit", "pylint==2.10.2"], check=True)
+print("pre-commit version:")
+subprocess.run(["pre-commit", "--version"], check=True)
+print("python version:")
+subprocess.run([sys.executable, "--version"], check=True)
+
+subprocess.run(["pre-commit", "install"], check=True)

--- a/tools/accuracy_checker/requirements-extra.in
+++ b/tools/accuracy_checker/requirements-extra.in
@@ -2,8 +2,8 @@
 tqdm>=4.54.1
 
 # image reading and preprocessing
-opencv-python==4.6.0.66;python_version<"3.12"
-opencv-python==4.10.0.84;python_version>="3.12"
+# 4.6.0.66 is incompatible with numpy>=2.0 (numpy is allowed up to <2.1.0 by requirements-core.in)
+opencv-python==4.10.0.84
 # nncf's upperbound: https://github.com/openvinotoolkit/nncf/blob/1de67217adf60a29afa310edf4a5f4d36314446a/setup.py#L104
 networkx<3.6
 scikit-image==0.18.3;python_version<"3.12"

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -98,7 +98,8 @@ except ImportError as opencv_import_error:
         warnings.warn(
             "Problem with cv2 import: \n{}\n opencv-python will be added to requirements".format(opencv_import_error)
         )
-        _requirements.append('opencv-python')
+        _requirements.append('opencv-python==4.6.0.66;python_version<"3.12"')
+        _requirements.append('opencv-python==4.10.0.84;python_version>="3.12"')
     else:
         warnings.warn(
             "Problem with cv2 import: \n{}".format(opencv_import_error)

--- a/tools/accuracy_checker/setup.py
+++ b/tools/accuracy_checker/setup.py
@@ -98,8 +98,8 @@ except ImportError as opencv_import_error:
         warnings.warn(
             "Problem with cv2 import: \n{}\n opencv-python will be added to requirements".format(opencv_import_error)
         )
-        _requirements.append('opencv-python==4.6.0.66;python_version<"3.12"')
-        _requirements.append('opencv-python==4.10.0.84;python_version>="3.12"')
+        # 4.6.0.66 is incompatible with numpy>=2.0 (core requirements allow numpy<2.1.0)
+        _requirements.append('opencv-python==4.10.0.84')
     else:
         warnings.warn(
             "Problem with cv2 import: \n{}".format(opencv_import_error)

--- a/tools/accuracy_checker/tests/test_config_validator.py
+++ b/tools/accuracy_checker/tests/test_config_validator.py
@@ -310,12 +310,72 @@ class TestBaseReaderRetry:
                     raise OSError('temporary network error')
                 return np.array([data_id])
 
-        reader = FlakyReader(None, config={'read_retry_attempts': 2, 'read_retry_delay': 0}, postpone_data_source=True)
+        reader = FlakyReader(
+            None, config={'read_retry_attempts': 2, 'initial_retry_delay': 0}, postpone_data_source=True
+        )
 
         data_representation = reader(7)
 
         assert np.array_equal(data_representation.data, np.array([7]))
         assert reader.read_attempts == 2
+
+    def test_total_retries_budget_exhausted_across_reads(self):
+        class AlwaysFlakyReader(BaseReader):
+            __provider__ = 'always_flaky_reader'
+
+            def __init__(self, *args, **kwargs):
+                self.read_attempts = 0
+                super().__init__(*args, **kwargs)
+
+            def read(self, data_id):
+                self.read_attempts += 1
+                raise OSError('persistent network error')
+
+        reader = AlwaysFlakyReader(
+            None,
+            config={'read_retry_attempts': 4, 'read_total_retries': 2, 'initial_retry_delay': 0},
+            postpone_data_source=True
+        )
+
+        with pytest.raises(OSError):
+            reader(1)
+        assert reader.read_attempts == 3  # 1 initial + 2 retries consumed the whole total budget
+
+        reader.read_attempts = 0
+        with pytest.raises(OSError):
+            reader(2)
+        assert reader.read_attempts == 1  # no retries left, fails immediately
+
+    def test_retry_delay_escalates_and_persists_across_reads(self, mocker):
+        class FlakyReader(BaseReader):
+            __provider__ = 'delay_flaky_reader'
+
+            def __init__(self, *args, **kwargs):
+                self.fail_next = 0
+                super().__init__(*args, **kwargs)
+
+            def read(self, data_id):
+                if self.fail_next > 0:
+                    self.fail_next -= 1
+                    raise OSError('temporary network error')
+                return np.array([data_id])
+
+        sleep_mock = mocker.patch('accuracy_checker.data_readers.data_reader.time.sleep')
+
+        reader = FlakyReader(
+            None,
+            config={'read_retry_attempts': 4, 'read_total_retries': 10, 'initial_retry_delay': 0.1},
+            postpone_data_source=True
+        )
+
+        reader.fail_next = 2
+        reader(1)
+        assert [call.args[0] for call in sleep_mock.call_args_list] == [0.1, 0.2]
+
+        # delay is not reset back to initial_retry_delay for the next read, it keeps escalating
+        reader.fail_next = 1
+        reader(2)
+        assert [call.args[0] for call in sleep_mock.call_args_list] == [0.1, 0.2, 0.4]
 
 
 class TestConfigValidator:

--- a/tools/accuracy_checker/tests/test_config_validator.py
+++ b/tools/accuracy_checker/tests/test_config_validator.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pytest
+import numpy as np
 from accuracy_checker.config.config_validator import (
     ConfigError,
     ConfigValidator,
@@ -292,6 +293,29 @@ class TestPathField:
             prefix_path = Path(prefix)
             file_field = PathField(is_directory=False, check_exists=False)
             file_field.validate(prefix_path / 'foo' / 'bar')
+
+
+class TestBaseReaderRetry:
+    def test_retry_transient_read_error(self):
+        class FlakyReader(BaseReader):
+            __provider__ = 'flaky_reader'
+
+            def __init__(self, *args, **kwargs):
+                self.read_attempts = 0
+                super().__init__(*args, **kwargs)
+
+            def read(self, data_id):
+                self.read_attempts += 1
+                if self.read_attempts < 2:
+                    raise OSError('temporary network error')
+                return np.array([data_id])
+
+        reader = FlakyReader(None, config={'read_retry_attempts': 2, 'read_retry_delay': 0}, postpone_data_source=True)
+
+        data_representation = reader(7)
+
+        assert np.array_equal(data_representation.data, np.array([7]))
+        assert reader.read_attempts == 2
 
 
 class TestConfigValidator:

--- a/tools/accuracy_checker/tests/test_dataset.py
+++ b/tools/accuracy_checker/tests/test_dataset.py
@@ -308,7 +308,7 @@ class TestAnnotationConversion:
         annotation, _ = Dataset.load_annotation(config)
         assert annotation == [converted_annotation[0]]
 
-    def test_annotation_conversion_save_subset(self, mocker):
+    def test_annotation_conversion_save_full_annotation_with_subset(self, mocker):
         addition_options = {
             'annotation_conversion': {'converter': 'wider', 'annotation_file': Path('file')},
             'annotation': Path('custom'),
@@ -326,7 +326,7 @@ class TestAnnotationConversion:
         )
         mocker.patch('pathlib.Path.exists', return_value=False)
         Dataset(config)
-        annotation_saver_mock.assert_called_once_with([converted_annotation[1]], None, Path('custom'), None, config)
+        annotation_saver_mock.assert_called_once_with(converted_annotation, None, Path('custom'), None, config)
 
     def test_annotation_conversion_subset_with_disabled_shuffle(self, mocker):
         addition_options = {


### PR DESCRIPTION
## Summary

Adds Detectron2 model support to the PyTorch launcher and accuracy checker adapters, hardens dataset reading against transient OS-level I/O errors, and includes a handful of related fixes and dependency updates picked up along the way.

## Detectron2 Support

* Added `Detectron2Adapter` (`accuracy_checker/adapters/detectron2.py`) to convert Detectron2 `Instances`-based output into `DetectionPrediction`/`InstanceSegmentationPrediction` representations, with 0-based class indexing.
* Added `Detectron2Wrapper` (`accuracy_checker/launcher/detectron2_wrapper.py`), a compatibility adapter that:
  * converts batched tensor input into the `[{"image": tensor}, ...]` dict format expected by Detectron2 models;
  * extracts `pred_boxes`, `pred_classes`, `pred_masks`, and `scores` from the returned `Instances` objects;
  * loads checkpoints that contain a fully constructed model object directly, without invoking the model constructor.
* `PyTorchLauncher` gains a `use_detectron2_wrapper` config flag that delegates model preparation and checkpoint loading to `Detectron2Wrapper`, keeping Detectron2-specific logic out of the generic launcher code path.
* Documented the new parameter and wrapper behavior in `pytorch_launcher_readme.md`, including a sample config.

## Retry on Transient Read Errors

* `BaseReader` now retries reads that fail with a transient `OSError` (e.g. flaky network shares), instead of failing the whole dataset validation run.
* New optional reader parameters:
  * `read_retry_attempts` (default `1`, i.e. no retry)
  * `read_retry_delay` (default `0.1` seconds)
* Documented in `data_readers/README.md` with a config example.
* Added regression test `TestBaseReaderRetry::test_retry_transient_read_error` covering the retry-then-succeed path.

## Dataset & Evaluator Fixes

* Fixed annotation saving so converted annotations are always stored for the **full** dataset, not just the subsample size, when `sub_evaluation` is combined with subset settings.

## Testing

* `tests/test_config_validator.py::TestBaseReaderRetry::test_retry_transient_read_error` — verified passing.