### PR TITLE
fix(demos): background_subtraction_demo crashes with --raw_output_message (print_raw_results arity)

### DIFF
--- a/demos/background_subtraction_demo/python/background_subtraction_demo.py
+++ b/demos/background_subtraction_demo/python/background_subtraction_demo.py
@@ -321,7 +321,7 @@ def main():
         results = pipeline.get_result(next_frame_id_to_show)
         objects, frame_meta = results
         if args.raw_output_message:
-            print_raw_results(objects, next_frame_id_to_show, model.labels)
+            print_raw_results(objects, next_frame_id_to_show)
         frame = frame_meta['frame']
         start_time = frame_meta['start_time']
 


### PR DESCRIPTION
## Problem

`demos/background_subtraction_demo/python/background_subtraction_demo.py` defines

```python
def print_raw_results(outputs, frame_id):      # line 144
```

but calls it with a different arity in its two call sites:

| line | call | args |
|---|---|---|
| 295 (main loop) | `print_raw_results(objects, next_frame_id_to_show)` | 2 ✔ |
| 324 (drain loop, after `pipeline.await_all()`) | `print_raw_results(objects, next_frame_id_to_show, model.labels)` | 3 ✘ |

The three-argument call raises

```
TypeError: print_raw_results() takes 2 positional arguments but 3 were given
```

The demo's `print_raw_results` never takes a `labels` argument at all — it formats
raw class ids, so there is nothing for `model.labels` to do here.

## Reachability

`args.raw_output_message` is only forced off for matting-based models
(lines 138–141); for the instance-segmentation-based background subtraction models
it stays on. So running any of those models with `-r` / `--raw_output_message`
processes the whole stream fine and then crashes in the drain loop that flushes the
remaining in-flight requests — i.e. right at the end of the run, after the work is
already done.

## Why line 324 and not line 295 is the wrong one

Every other Python demo in `demos/` keeps its two `print_raw_results` call sites
identical to each other:

```
classification_demo.py         :203 / :264   print_raw_results(classifications, next_frame_id_to_show)
human_pose_estimation_demo.py  :217 / :264   print_raw_results(poses, scores, next_frame_id_to_show)
instance_segmentation_demo.py  :198 / :230   print_raw_results(boxes, classes, scores, next_frame_id_to_show)
object_detection_demo.py       :213 / :273   print_raw_results(objects, model.labels, next_frame_id_to_show)
segmentation_demo.py           :227 / :257   print_raw_results(objects, next_frame_id_to_show, model.labels)
```

`background_subtraction_demo.py` is the only one whose pair disagrees, and its
line 324 is character-for-character `segmentation_demo.py`'s call — whose
`print_raw_results(mask, frame_id, labels=None)` *does* take a third argument.

## Fix

Drop the extra argument so the drain-loop call matches the in-loop call and the
definition. One line, no behaviour change on the working path.

## Verification

No OpenVINO runtime here, so I extracted the definition straight out of the file
with `ast` and replayed both call sites against it with a shape-faithful
`(scores, classes, boxes, masks)` tuple:

```
--- line 295 (in-loop, 2 args) ---
  -------------------------- Frame # 7 --------------------------
  Class ID | Confidence |     XMIN |     YMIN |     XMAX |     YMAX
         1 |   0.910000 |     1.00 |     2.00 |     3.00 |     4.00
OK

--- line 324 (drain-loop, 3 args) ---
TypeError: print_raw_results() takes 2 positional arguments but 3 were given
```

The control group (line 295) formats correctly; only the patched line raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
