### PR TITLE
fix(smartlab_demo): Detector.inference_async raises TypeError on every call

### DIFF
--- a/demos/smartlab_demo/python/object_detection/detector.py
+++ b/demos/smartlab_demo/python/object_detection/detector.py
@@ -216,5 +216,5 @@ class Detector:
                 [side_bboxes, side_cls_ids, side_labels, side_scores], \
                 frame_index
 
-    async def inference_async(self, img_top, img_side):
-        return await self.inference_multithread(img_top, img_side)
+    def inference_async(self, img_top, img_side, frame_index):
+        return self.inference_multithread(img_top, img_side, frame_index)


### PR DESCRIPTION
## Problem

`Detector.inference_async` in `demos/smartlab_demo/python/object_detection/detector.py`
cannot complete for **any** input — it fails twice over:

```python
def inference_multithread(self, img_top, img_side, frame_index):   # L186
    ...
    return [top_bboxes, top_cls_ids, top_labels, top_scores], \
           [side_bboxes, side_cls_ids, side_labels, side_scores], \
           frame_index

async def inference_async(self, img_top, img_side):                # L219
    return await self.inference_multithread(img_top, img_side)     # L220
```

1. **Missing required argument.** `inference_multithread` takes `frame_index`, but the
   call passes only `img_top, img_side` →
   `TypeError: missing a required argument: 'frame_index'`.
2. **Awaiting a non-awaitable.** `inference_multithread` is a plain `def` returning a
   3-tuple, so even with the argument supplied, `await` raises
   `TypeError: object tuple can't be used in 'await' expression`.

## Why this is the intended shape

The parallel class in the same demo already defines the contract — `Segmentor.inference_async`
in `demos/smartlab_demo/python/segmentor.py:109` is a **plain `def` taking `frame_index`**:

```python
def inference_async(self, frame_top, frame_side, frame_index):
```

And the demo's own working call site passes all three arguments, confirming the arity:

```python
# demos/smartlab_demo/python/smartlab_demo.py:112
detector.inference_multithread, frame_top, frame_side, frame_counter
```

`Detector.inference_async` has no call sites, which is why the breakage has gone unnoticed;
the live path goes through `inference_multithread` directly.

## Verification

Replaying the call against the real signature extracted from the file, with the working
demo call site as a control:

```
inference_multithread signature: (self, img_top, img_side, frame_index)

UNPATCHED  inference_async -> (self, img_top, img_side)
  TypeError: missing a required argument: 'frame_index'
CONTROL    smartlab_demo.py:112 -> (self, top, side, counter)
  bound OK
PATCHED    inference_async -> (self, img_top, img_side, frame_index)
  bound OK
```

The second defect reproduced independently:

```
TypeError: object tuple can't be used in 'await' expression
```

## Fix

Two lines — align `Detector.inference_async` with its `Segmentor` sibling:

```python
def inference_async(self, img_top, img_side, frame_index):
    return self.inference_multithread(img_top, img_side, frame_index)
```

Behaviour of the live `inference_multithread` path is unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
