### PR TITLE
Make Accuracy Checker annotation conversion deterministic

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/adapters/classification.py
+++ b/tools/accuracy_checker/accuracy_checker/adapters/classification.py
@@ -72,7 +72,8 @@ class ClassificationAdapter(Adapter):
     def select_output_blob(self, outputs):
         self.output_verified = True
         if self.classification_out:
-            self.classification_out = self.check_output_name(self.classification_out, outputs)
+            self.output_blob = self.check_output_name(self.classification_out, outputs)
+            self.classification_out = self.output_blob
             return
         super().select_output_blob(outputs)
         self.classification_out = self.output_blob

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/camvid.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/camvid.py
@@ -157,7 +157,7 @@ class CamVid32DatasetConverter(BaseFormatConverter):
         self.dataset_meta = self.get_value_from_config('dataset_meta_file')
 
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
-        label_files = list(self.labels_dir.glob('*.png'))
+        label_files = sorted(self.labels_dir.glob('*.png'))
         annotations = []
         val_subset_size = int(len(label_files) * self.val_subset_ratio)
         val_labels = label_files[len(label_files)-val_subset_size:]

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/image_processing.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/image_processing.py
@@ -19,6 +19,7 @@ from ..representation import ImageProcessingAnnotation
 from ..representation.image_processing import GTLoader
 from ..utils import check_file_existence
 from ..data_readers import ParametricImageIdentifier
+from ..logging import warning
 from .format_converter import BaseFormatConverter, ConverterReturn
 
 LOADERS_MAPPING = {
@@ -72,9 +73,9 @@ class ImageProcessingConverter(BaseFormatConverter):
         content_errors = [] if check_content else None
         file_list_in = []
         if self.recursive:
-            data_dir_files = [file for file in self.data_dir.rglob('*') if file.is_file()]
+            data_dir_files = sorted(file for file in self.data_dir.rglob('*') if file.is_file())
         else:
-            data_dir_files = self.data_dir.iterdir()
+            data_dir_files = sorted(self.data_dir.iterdir())
         for file_in_dir in data_dir_files:
             if self.in_suffix in file_in_dir.parts[-1]:
                 file_list_in.append(file_in_dir)
@@ -126,6 +127,7 @@ class ParametricImageProcessing(BaseFormatConverter):
 
     def convert(self, check_content=False, progress_callback=None, progress_interval=100, **kwargs):
         image_pairs = self.get_image_pairs()
+        self.warn_missing_pairs(image_pairs)
         annotations = []
         for image, params, gt in image_pairs:
             identifier = ParametricImageIdentifier(image, params)
@@ -135,10 +137,24 @@ class ParametricImageProcessing(BaseFormatConverter):
 
     def get_image_pairs(self):
         data = []
-        for ref_img in self.reference_dir.glob('*.png'):
+        for ref_img in sorted(self.reference_dir.glob('*.png')):
             params = ref_img.stem.split('_')
             name = params[0]
             parameters = [float(param) * self.param_scale for param in params[1:]]
             source_img = name + '.png'
             data.append((source_img, parameters, ref_img.name))
         return data
+
+    def warn_missing_pairs(self, image_pairs):
+        # detects source images from input_dir that got zero variants in reference_dir (e.g. share got truncated)
+        source_images = {file.name for file in self.input_dir.glob('*.png')}
+        paired_images = {image for image, _, _ in image_pairs}
+        missing_images = sorted(source_images - paired_images)
+        if missing_images:
+            warning(
+                '{} of {} images from {} have no reference pairs in {}: {}'.format(
+                    len(missing_images), len(source_images), self.input_dir, self.reference_dir,
+                    ', '.join(missing_images)
+                ),
+                raise_warning=False
+            )

--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/librispeech.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/librispeech.py
@@ -60,7 +60,7 @@ class LibrispeechConverter(DirectoryBasedAnnotationConverter):
         pattern = re.compile(r'([0-9\-]+)\s+(.+)')
         annotations = []
         data_folder = Path(self.data_dir)
-        txts = list(data_folder.glob('**/*.txt'))
+        txts = sorted(data_folder.glob('**/*.txt'))
         for txt in txts:
             content = txt.open().readlines()
             for line in content:


### PR DESCRIPTION
## Description

This PR improves Accuracy Checker validation reliability in two areas:

- selects classification outputs explicitly when a model exposes multiple outputs;
- makes filesystem-derived annotation ordering deterministic before annotation or subset selection.

## Changes

### Classification adapter

- Prefer an explicitly configured output name when resolving classification model outputs.
- Preserve the existing fallback behavior for models without an explicit output selection.

### Deterministic annotation conversion

- Sort image inputs in `ImageProcessingConverter`, including recursive inputs.
- Sort generated reference images in `ParametricImageProcessing` before creating Denoise annotations.
- Sort LibriSpeech transcript files before creating annotations.
- Sort CamVid-32 label files before its `val_subset_ratio` logic selects the validation subset.
- Warn when a parametric image-processing input has no generated reference pair.

Sorting removes dependence on filesystem directory-entry order. Consequently, the same dataset contents produce the same annotation order and the same fixed-seed subset after a dataset restore or annotation-cache regeneration.

## Affected Validation Workloads

The deterministic ordering change covers the currently observed unstable validation subsets:

- Denoise
- Colorization
- QuartzNet 15x5 English
- Tiramisu FC-DenseNet-103 / CamVid-32

## Validation

- Ran `python3 -m compileall` for the modified annotation converter modules.
- Ran `git diff --check`.
- Verified all filesystem enumeration paths touched by the four affected converters are explicitly sorted.
- Checked editor diagnostics for modified converter modules: no errors.

## Follow-up

Regenerate validation references for the affected workloads using the deterministic annotation order. Additional annotation converters identified by the broader audit will be addressed separately.
