### PR TITLE
Fix the NumPy 2 calling nonzero on 0d arrays is not allowed failure

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/annotation_converters/squad.py
+++ b/tools/accuracy_checker/accuracy_checker/annotation_converters/squad.py
@@ -346,7 +346,7 @@ class SQUADConverter(BaseFormatConverter):
         else:
             p_mask[-len(span["tokens"]): -(tr_q_len + sequence_added_tokens)] = 0
 
-        pad_token_indices = np.where(span["input_ids"] == self.tokenizer.pad_token_id)
+        pad_token_indices = np.where(np.asarray(span["input_ids"]) == self.tokenizer.pad_token_id)
         special_token_indices = np.asarray(
             self.tokenizer.get_special_tokens_mask(span["input_ids"], already_has_special_tokens=True)
         ).nonzero()


### PR DESCRIPTION
## Fix SQuAD annotation conversion with NumPy 2

`SQUADConverter.fill_p_mask` receives `span["input_ids"]` as a Python list. Comparing the list directly with `pad_token_id` produces a scalar Boolean rather than an elementwise mask, causing NumPy 2 to fail in `np.where` with:

```text
ValueError: Calling nonzero on 0d arrays is not allowed
```

Convert `input_ids` to a NumPy array before the comparison so `np.where` receives the intended elementwise Boolean array.

## Validation

Converted the SQuAD v1.1 evaluation data with BERT-Large settings:

- `max_seq_length=384`
- `max_query_length=64`
- `doc_stride=128`
- `lower_case=True`

The patched converter completed all 10,833 generated spans successfully. The generated `input_ids` and `p_mask` arrays have the expected `(384,)` shape.