### PR TITLE
fix(accuracy_checker): prepend to the dynamic-blob template instead of discarding it

### DIFF
--- a/tools/accuracy_checker/accuracy_checker/launcher/openvino_launcher.py
+++ b/tools/accuracy_checker/accuracy_checker/launcher/openvino_launcher.py
@@ -861,7 +861,7 @@ class OpenVINOLauncher(Launcher):
             data = np.expand_dims(data, 0)
             data_shape = np.shape(data)
             if template is not None:
-                template = [1].extend(template)
+                template = [1] + template
         if len(data_shape) - layer_rang == 1 and data_shape[0] == 1:
             if len(data_shape) == len(layout):
                 data = np.transpose(data, layout)


### PR DESCRIPTION
### Problem

In `OpenVINOLauncher._data_to_blob_dyn`, the branch that adds a leading batch
axis writes:

```python
if layer_rang - len(data_shape) == 1:
    data = np.expand_dims(data, 0)
    data_shape = np.shape(data)
    if template is not None:
        template = [1].extend(template)
```

`list.extend()` mutates in place and returns `None`, so this assigns `None` to
`template` — the prepend is lost and the local is cleared. Everything downstream
in the same function is then skipped:

* `if template is not None and len(template) == layer_rang:` — the transpose
  re-ordering,
* the `if template is not None:` padding/truncation block,
* the final `if template is not None:` layout re-ordering,

and in the caller (`openvino_launcher.py:839`)

```python
data, l_template = self._data_to_blob_dyn(layer_rang, data, layout, input_template)
layer_shape = data.shape
if l_template is not None:
    template[layer_name] = l_template
```

the layer's template is never recorded at all.

### The correct spelling is already in the same function

```python
tmp_template = [1, ] + template
...
template = [1] * (np.ndim(data) - len(template)) + template
```

Both prepend with `+`. This patch makes the third site match.

### Verification

The static method is cut out of the real file with `ast.get_source_segment`
(before: `git show HEAD:…`; after: the patched source — neither is re-typed) and
run against NumPy; no OpenVINO runtime needed.

| layer_rang | data.shape | template in | BEFORE | AFTER |
|---|---|---|---|---|
| 3 | (4, 5) | [4, 5] | `shape=(1,4,5) template=None` | `shape=(1,4,5) template=[1,4,5]` |
| 3 | (4, 5) | [1, 1] | `shape=(1,4,5) template=None` | `shape=(1,4,5) template=[1,1,1]` |
| 4 | (2, 3, 4) | [2, 3, 4] | `shape=(1,2,3,4) template=None` | `shape=(1,2,3,4) template=[1,2,3,4]` |
| 2 | (7,) | [7] | `shape=(1,7) template=None` | `shape=(1,7) template=[1,7]` |
| 2 | (1, 7) | [1, 7] | `shape=(1,7) template=[1,7]` | *(unchanged)* |
| 3 | (1, 2, 3) | [1, 2, 3] | `shape=(1,2,3) template=[1,2,3]` | *(unchanged)* |
| 2 | (4, 5) | [4, 5] | `shape=(4,5) template=[4,5]` | *(unchanged)* |
| 3 | (4, 5) | `None` | `shape=(1,4,5) template=None` | *(unchanged)* |

```
rows: 8   unchanged: 4   changed: 4

[1].extend([4, 5])  -> None
[1] + [4, 5]        -> [1, 4, 5]
```

The four changed rows are exactly the ones that enter the patched branch with a
template; the returned array is byte-identical in every row — only the returned
template differs, and it now matches the `np.expand_dims(data, 0)` that happens
alongside it. The control rows (branch not taken, or `template=None`) are
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
